### PR TITLE
ci: try cache build dir

### DIFF
--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -37,9 +37,9 @@ jobs:
         uses: actions/cache/restore@v4
         with:
           path: |
-            build/debug
-            !build/debug/cargo
-            !build/debug/cargo/**
+            build/release
+            !build/release/cargo
+            !build/release/cargo/**
           key: build-release-${{ runner.os }}-${{ steps.duckdb-sha.outputs.sha }}-${{ hashFiles('extension_config.cmake', 'CMakeLists.txt', 'vcpkg.json') }}-${{ github.sha }}
           restore-keys: |
             build-release-${{ runner.os }}-${{ steps.duckdb-sha.outputs.sha }}-${{ hashFiles('extension_config.cmake', 'CMakeLists.txt', 'vcpkg.json') }}-


### PR DESCRIPTION
Try cache build dir instead.

---

**Parts of this PR were drafted with assistance from Codex (with `gpt-5.2`) and fully reviewed and edited by me. I take full responsibility for all changes.**