### PR TITLE
ci: Don't build parquet extension

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,5 +4,11 @@ PROJ_DIR := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
 EXT_NAME=lance
 EXT_CONFIG=${PROJ_DIR}extension_config.cmake
 
+# Default build: skip DuckDB's parquet extension.
+# Override by providing EXT_FLAGS that already contains -DSKIP_EXTENSIONS=...
+ifeq (,$(findstring -DSKIP_EXTENSIONS=,$(EXT_FLAGS)))
+	EXT_FLAGS += -DSKIP_EXTENSIONS=parquet
+endif
+
 # Include the Makefile from extension-ci-tools
 include extension-ci-tools/makefiles/duckdb_extension.Makefile


### PR DESCRIPTION
This PR will skip the parquet extension since lance doesn't need it.

---

**Parts of this PR were drafted with assistance from Codex (with `gpt-5.2`) and fully reviewed and edited by me. I take full responsibility for all changes.**