### PR TITLE
ci: Include build config in to cache key

### DIFF
--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -35,6 +35,11 @@ jobs:
         run: |
           echo "sha=$(git -C duckdb rev-parse HEAD)" >> "$GITHUB_OUTPUT"
 
+      - name: Compute Build SHA
+        id: build-sha
+        run: |
+          echo "sha=${{ hashFiles('CMakeLists.txt', 'extension_config.cmake', 'Makefile') }}" >> "$GITHUB_OUTPUT"
+
       - name: Prepare cache directories
         run: |
           mkdir -p .ccache
@@ -45,9 +50,9 @@ jobs:
         with:
           path: |
             .ccache
-          key: ccache-${{ runner.os }}-${{ steps.duckdb-sha.outputs.sha }}-${{ github.sha }}
+          key: ccache-${{ runner.os }}-${{ steps.duckdb-sha.outputs.sha }}-${{ steps.build-sha.outputs.sha }}-${{ github.sha }}
           restore-keys: |
-            ccache-${{ runner.os }}-${{ steps.duckdb-sha.outputs.sha }}-
+            ccache-${{ runner.os }}-${{ steps.duckdb-sha.outputs.sha }}-${{ steps.build-sha.outputs.sha }}-
 
       - name: Install dependencies
         run: |
@@ -67,4 +72,4 @@ jobs:
         with:
           path: |
             .ccache
-          key: ccache-${{ runner.os }}-${{ steps.duckdb-sha.outputs.sha }}-${{ github.sha }}
+          key: ccache-${{ runner.os }}-${{ steps.duckdb-sha.outputs.sha }}-${{ steps.build-sha.outputs.sha }}-${{ github.sha }}


### PR DESCRIPTION
This PR will include build config in to cache key

---

**Parts of this PR were drafted with assistance from Codex (with `gpt-5.2`) and fully reviewed and edited by me. I take full responsibility for all changes.**