### PR TITLE
chore: Set dev panic=abort to avoid FFI unwind

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,9 @@ lto = "thin"
 strip = true
 panic = "abort"
 
+[profile.dev]
+panic = "abort"
+
 [dependencies]
 
 # Lance and Arrow dependencies - using compatible versions


### PR DESCRIPTION
Ensure non-release builds abort on panic so unwinding never crosses the Rust<->C++ FFI boundary.

---

**Parts of this PR were drafted with assistance from Codex (with `gpt-5.2`) and fully reviewed and edited by me. I take full responsibility for all changes.**