### PR TITLE
docs: add DuckDB write examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Lance is a modern columnar data format optimized for ML/AI workloads, with nativ
 
 ## Usage
 
-### Query a `*.lance` path
+### Query a Lance dataset
 
 ```sql
 -- local file
@@ -20,9 +20,7 @@ SELECT *
   LIMIT 10;
 ```
 
-### S3 authentication via DuckDB Secrets
-
-For `s3://` paths, the extension can use DuckDB's native Secrets mechanism to obtain credentials:
+To read `s3://` paths, the extension can use DuckDB's native Secrets mechanism to obtain credentials:
 
 ```sql
 CREATE SECRET (TYPE S3, provider credential_chain);


### PR DESCRIPTION
Document Lance dataset writes via DuckDB COPY TO (FORMAT lance). Includes overwrite/append, schema-only output, and an S3 example (httpfs + secret). Matches the existing sqllogictests for write paths.

---

**Parts of this PR were drafted with assistance from Codex (with `gpt-5.2`) and fully reviewed and edited by me. I take full responsibility for all changes.**