### PR TITLE
refactor: Cleanup duplicated logic in DELETE

### DIFF
--- a/src/include/lance_common.hpp
+++ b/src/include/lance_common.hpp
@@ -19,12 +19,29 @@ void LanceFillS3StorageOptionsFromSecrets(ClientContext &context,
                                           const string &path,
                                           vector<string> &out_keys,
                                           vector<string> &out_values);
+void ResolveLanceStorageOptions(ClientContext &context, const string &path,
+                                string &out_open_path,
+                                vector<string> &out_option_keys,
+                                vector<string> &out_option_values);
+void BuildStorageOptionPointerArrays(const vector<string> &option_keys,
+                                     const vector<string> &option_values,
+                                     vector<const char *> &out_key_ptrs,
+                                     vector<const char *> &out_value_ptrs);
+
+static constexpr uint64_t LANCE_DEFAULT_MAX_ROWS_PER_FILE = 1024ULL * 1024ULL;
+static constexpr uint64_t LANCE_DEFAULT_MAX_ROWS_PER_GROUP = 1024ULL;
+static constexpr uint64_t LANCE_DEFAULT_MAX_BYTES_PER_FILE =
+    90ULL * 1024ULL * 1024ULL * 1024ULL;
+
 void ResolveLanceNamespaceAuth(ClientContext &context, const string &endpoint,
                                const unordered_map<string, Value> &options,
                                string &out_bearer_token, string &out_api_key);
 void ResolveLanceNamespaceAuth(ClientContext &context, const string &endpoint,
                                const named_parameter_map_t &options,
                                string &out_bearer_token, string &out_api_key);
+void ResolveLanceNamespaceAuthOverrides(
+    const unordered_map<string, Value> &options, string &out_bearer_token,
+    string &out_api_key);
 
 bool TryLanceNamespaceListTables(ClientContext &context, const string &endpoint,
                                  const string &namespace_id,

--- a/test/sql/lance_delete.test
+++ b/test/sql/lance_delete.test
@@ -112,5 +112,20 @@ SELECT count(*) FROM del_ns.main.lance_delete_basic;
 ----
 2
 
+query I
+DELETE FROM del_ns.main.lance_delete_basic;
+----
+2
+
+query I
+SELECT count(*) FROM del_ns.main.lance_delete_basic;
+----
+0
+
+query T
+SELECT ((SELECT c FROM v_basic) + 2) = (SELECT count(*)::BIGINT FROM glob('test/.tmp/lance_delete_basic.lance/_versions/*'));
+----
+true
+
 statement ok
 DETACH del_ns;


### PR DESCRIPTION
This PR will cleanup duplicated logic in DELETE

---

**Parts of this PR were drafted with assistance from Codex (with `gpt-5.2`) and fully reviewed and edited by me. I take full responsibility for all changes.**
