### PR TITLE
feat: Implement pushdown for regexp_matches

### DIFF
--- a/rust/filter_ir.rs
+++ b/rust/filter_ir.rs
@@ -18,6 +18,10 @@ const TAG_IS_NULL: u8 = 7;
 const TAG_IS_NOT_NULL: u8 = 8;
 const TAG_IN_LIST: u8 = 9;
 const TAG_LIKE: u8 = 10;
+const TAG_REGEXP: u8 = 11;
+
+const REGEXP_MODE_PARTIAL_MATCH: u8 = 0;
+const REGEXP_MODE_FULL_MATCH: u8 = 1;
 
 const LIT_NULL: u8 = 0;
 const LIT_BOOL: u8 = 1;
@@ -43,10 +47,17 @@ const OP_GT: u8 = 4;
 const OP_GT_EQ: u8 = 5;
 
 static GETFIELD_UDF: OnceLock<Arc<ScalarUDF>> = OnceLock::new();
+static REGEXP_LIKE_UDF: OnceLock<Arc<ScalarUDF>> = OnceLock::new();
 
 fn getfield_udf() -> Arc<ScalarUDF> {
     GETFIELD_UDF
         .get_or_init(|| Arc::new(ScalarUDF::new_from_impl(GetFieldFunc::default())))
+        .clone()
+}
+
+fn regexp_like_udf() -> Arc<ScalarUDF> {
+    REGEXP_LIKE_UDF
+        .get_or_init(datafusion_functions::regex::regexp_like)
         .clone()
 }
 
@@ -177,6 +188,7 @@ fn parse_node(cursor: &mut Cursor<'_>) -> Result<Expr> {
         }
         TAG_IN_LIST => parse_in_list(cursor),
         TAG_LIKE => parse_like(cursor),
+        TAG_REGEXP => parse_regexp(cursor),
         other => Err(anyhow!("unknown node tag: {other}")),
     }
 }
@@ -313,4 +325,76 @@ fn parse_like(cursor: &mut Cursor<'_>) -> Result<Expr> {
         escape_char,
         case_insensitive,
     )))
+}
+
+fn parse_regexp(cursor: &mut Cursor<'_>) -> Result<Expr> {
+    let mode = cursor.read_u8()?;
+    let has_flags = cursor.read_u8()? != 0;
+
+    let value = parse_len_prefixed_node(cursor)?;
+    let mut pattern = parse_len_prefixed_node(cursor)?;
+    let normalized_flags = if has_flags {
+        let flags_expr = parse_len_prefixed_node(cursor)?;
+        let flags_str = match flags_expr {
+            Expr::Literal(ScalarValue::Utf8(Some(v)), _) => v,
+            other => {
+                return Err(anyhow!(
+                    "regexp_matches expects a non-null string literal options, got: {other:?}"
+                ))
+            }
+        };
+
+        let mut has_i = false;
+        let mut has_s = false;
+        for c in flags_str.chars() {
+            match c {
+                'i' => has_i = true,
+                's' => has_s = true,
+                ' ' | '\t' | '\n' => {}
+                other => bail!("unsupported regexp option: {other}"),
+            }
+        }
+
+        let mut normalized = String::new();
+        if has_i {
+            normalized.push('i');
+        }
+        if has_s {
+            normalized.push('s');
+        }
+        if normalized.is_empty() { None } else { Some(normalized) }
+    } else {
+        None
+    };
+
+    if mode == REGEXP_MODE_FULL_MATCH {
+        let pattern_str = match &pattern {
+            Expr::Literal(ScalarValue::Utf8(Some(v)), _) => v,
+            other => {
+                return Err(anyhow!(
+                    "regexp_full_match expects a non-null string literal pattern, got: {other:?}"
+                ))
+            }
+        };
+        pattern = Expr::Literal(ScalarValue::Utf8(Some(format!("^(?:{pattern_str})$"))), None);
+    } else if mode != REGEXP_MODE_PARTIAL_MATCH {
+        bail!("unknown regexp mode: {mode}");
+    }
+
+    let pattern_str = match &pattern {
+        Expr::Literal(ScalarValue::Utf8(Some(v)), _) => v,
+        other => {
+            return Err(anyhow!(
+                "regexp_matches expects a non-null string literal pattern, got: {other:?}"
+            ))
+        }
+    };
+    datafusion_functions::regex::compile_regex(pattern_str, normalized_flags.as_deref())
+        .map_err(|e| anyhow!("regexp compile failed: {e}"))?;
+
+    let mut args = vec![value, pattern];
+    if let Some(flags) = normalized_flags {
+        args.push(Expr::Literal(ScalarValue::Utf8(Some(flags)), None));
+    }
+    Ok(regexp_like_udf().call(args))
 }

--- a/src/lance_filter_ir.cpp
+++ b/src/lance_filter_ir.cpp
@@ -71,6 +71,7 @@ enum class LanceFilterIRTag : uint8_t {
   IS_NOT_NULL = 8,
   IN_LIST = 9,
   LIKE = 10,
+  REGEXP = 11,
 };
 
 enum class LanceFilterIRLiteralTag : uint8_t {
@@ -104,6 +105,9 @@ enum class LanceFilterIRComparisonOp : uint8_t {
 
 static constexpr uint8_t LANCE_FILTER_IR_LIKE_FLAG_CASE_INSENSITIVE = 1;
 static constexpr uint8_t LANCE_FILTER_IR_LIKE_FLAG_HAS_ESCAPE = 2;
+
+static constexpr uint8_t LANCE_FILTER_IR_REGEXP_MODE_PARTIAL_MATCH = 0;
+static constexpr uint8_t LANCE_FILTER_IR_REGEXP_MODE_FULL_MATCH = 1;
 
 static void LanceFilterIRAppendU8(string &out, uint8_t v) {
   out.push_back(static_cast<char>(v));
@@ -492,6 +496,29 @@ static bool TryEncodeLanceFilterIRLike(bool case_insensitive, bool has_escape,
   }
   if (has_escape) {
     LanceFilterIRAppendU8(out_ir, escape_char);
+  }
+  return true;
+}
+
+static bool TryEncodeLanceFilterIRRegexp(uint8_t mode, bool has_flags,
+                                         const string &expr,
+                                         const string &pattern,
+                                         const string &flags, string &out_ir) {
+  if (mode != LANCE_FILTER_IR_REGEXP_MODE_PARTIAL_MATCH &&
+      mode != LANCE_FILTER_IR_REGEXP_MODE_FULL_MATCH) {
+    return false;
+  }
+
+  out_ir.clear();
+  LanceFilterIRAppendU8(out_ir, static_cast<uint8_t>(LanceFilterIRTag::REGEXP));
+  LanceFilterIRAppendU8(out_ir, mode);
+  LanceFilterIRAppendU8(out_ir, has_flags ? 1 : 0);
+  if (!LanceFilterIRAppendLenPrefixed(out_ir, expr) ||
+      !LanceFilterIRAppendLenPrefixed(out_ir, pattern)) {
+    return false;
+  }
+  if (has_flags) {
+    return LanceFilterIRAppendLenPrefixed(out_ir, flags);
   }
   return true;
 }
@@ -910,6 +937,52 @@ bool TryBuildLanceExprFilterIR(const LogicalGet &get,
         func.function.name == "struct_extract_at") {
       return TryBuildLanceExprColumnRefIR(
           get, names, types, exclude_computed_columns, expr, out_ir);
+    }
+
+    if (func.function.name == "regexp_matches" ||
+        func.function.name == "regexp_full_match") {
+      if (func.children.size() != 2 && func.children.size() != 3) {
+        return false;
+      }
+      for (auto &child : func.children) {
+        if (!child) {
+          return false;
+        }
+      }
+
+      string input_ir;
+      if (!TryBuildLanceExprFilterIR(get, names, types,
+                                     exclude_computed_columns,
+                                     *func.children[0], input_ir)) {
+        return false;
+      }
+
+      string pattern_value;
+      if (!TryGetNonNullVarcharConstant(*func.children[1], pattern_value)) {
+        return false;
+      }
+      string pattern_ir;
+      if (!TryEncodeLanceFilterIRLiteral(Value(pattern_value), pattern_ir)) {
+        return false;
+      }
+
+      bool has_flags = func.children.size() == 3;
+      string flags_ir;
+      if (has_flags) {
+        string flags_value;
+        if (!TryGetNonNullVarcharConstant(*func.children[2], flags_value)) {
+          return false;
+        }
+        if (!TryEncodeLanceFilterIRLiteral(Value(flags_value), flags_ir)) {
+          return false;
+        }
+      }
+
+      uint8_t mode = func.function.name == "regexp_full_match"
+                         ? LANCE_FILTER_IR_REGEXP_MODE_FULL_MATCH
+                         : LANCE_FILTER_IR_REGEXP_MODE_PARTIAL_MATCH;
+      return TryEncodeLanceFilterIRRegexp(mode, has_flags, input_ir, pattern_ir,
+                                          flags_ir, out_ir);
     }
 
     bool case_insensitive = false;

--- a/src/lance_scan.cpp
+++ b/src/lance_scan.cpp
@@ -271,8 +271,7 @@ LancePushdownComplexFilter(ClientContext &context, LogicalGet &get,
   }
 
   for (auto &expr : filters) {
-    if (!expr || expr->HasParameter() || expr->IsVolatile() ||
-        expr->CanThrow()) {
+    if (!expr || expr->HasParameter() || expr->IsVolatile()) {
       continue;
     }
     string filter_ir;

--- a/src/lance_search.cpp
+++ b/src/lance_search.cpp
@@ -213,8 +213,7 @@ LancePushdownComplexFilter(ClientContext &, LogicalGet &get,
   auto &scan_bind = bind_data->Cast<LanceKnnBindData>();
 
   for (auto &expr : filters) {
-    if (!expr || expr->HasParameter() || expr->IsVolatile() ||
-        expr->CanThrow()) {
+    if (!expr || expr->HasParameter() || expr->IsVolatile()) {
       continue;
     }
     string filter_ir;

--- a/test/sql/regex_pushdown.test
+++ b/test/sql/regex_pushdown.test
@@ -1,0 +1,52 @@
+# name: test/sql/regex_pushdown.test
+# description: regexp_matches/SIMILAR TO filter pushdown
+# group: [sql]
+
+require lance
+
+statement ok
+COPY (
+  SELECT * FROM (VALUES
+    ('Alice'),
+    ('ALICE'),
+    ('a.c'),
+    ('abc'),
+    ('aXc'),
+    ('zzz')
+  ) t(s)
+) TO 'test/.tmp/regex_pushdown.lance' (FORMAT lance, mode 'overwrite');
+
+# Basic regexp_matches
+query I
+SELECT count(*) FROM 'test/.tmp/regex_pushdown.lance' WHERE regexp_matches(s, 'a.c');
+----
+3
+
+# regexp_matches with options
+query I
+SELECT count(*) FROM 'test/.tmp/regex_pushdown.lance' WHERE regexp_matches(s, '^ali', 'i');
+----
+2
+
+# SIMILAR TO is rewritten to regexp_full_match
+query I
+SELECT count(*) FROM 'test/.tmp/regex_pushdown.lance' WHERE s SIMILAR TO 'A.*';
+----
+2
+
+# Explain diagnostics indicate regexp filters are attempted for pushdown
+query II
+EXPLAIN (FORMAT JSON) SELECT count(*) FROM 'test/.tmp/regex_pushdown.lance' WHERE regexp_matches(s, '^ali', 'i');
+----
+physical_plan	<REGEX>:[\s\S]*"Lance Filter IR Bytes \(Bind\)": "[1-9][0-9]*"[\s\S]*
+
+# Unsupported options should fall back to DuckDB-side filtering (and not fail the query)
+query I
+SELECT count(*) FROM 'test/.tmp/regex_pushdown.lance' WHERE regexp_matches(s, 'a.c', 'p');
+----
+3
+
+query II
+EXPLAIN (ANALYZE, FORMAT JSON) SELECT count(*) FROM 'test/.tmp/regex_pushdown.lance' WHERE regexp_matches(s, 'a.c', 'p');
+----
+analyzed_plan	<REGEX>:[\s\S]*"Lance Filter Pushdown Fallbacks": "[1-9][0-9]*"[\s\S]*


### PR DESCRIPTION
This PR will implement pushdown for regexp_matches

```sql
SELECT count(*) FROM 'test/.tmp/regex_pushdown.lance' WHERE regexp_matches(s, '^ali', 'i');
```

Close https://github.com/lance-format/lance-duckdb/issues/90

---

**Parts of this PR were drafted with assistance from Codex (with `gpt-5.2`) and fully reviewed and edited by me. I take full responsibility for all changes.**