### PR TITLE
refactor: Never expose unneed table functions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,6 +18,21 @@ This project is delivered as a fully self-contained DuckDB extension artifact (s
 - There are no external downstream users that depend on them.
 - When planning/implementing/refactoring, prioritize first principles and the most direct correct design; do not optimize for migrations or compatibility unless explicitly requested.
 
+## SQL Export Policy (Release Requirement)
+
+For releases, keep the exported function surface minimal. Only the search table functions and the `COPY ... (FORMAT lance)` writer should be user-visible:
+
+- Exported (user-facing):
+  - `lance_vector_search`
+  - `lance_fts`
+  - `lance_hybrid_search`
+  - `COPY ... TO ... (FORMAT lance, ...)` (registered as the `lance` copy format)
+- Not exported (must be internal-only), including but not limited to:
+  - `lance_scan` (and any scan/namespace helper table functions)
+  - all metadata/maintenance table functions (e.g. `lance_*metadata`, `lance_*config`, `lance_*indices`, compaction/cleanup)
+
+Prefer exposing capabilities via DuckDB standard SQL mechanisms (replacement scan, `ATTACH ... (TYPE LANCE)`, standard DDL/DML) rather than new user-facing functions.
+
 ## Essential Commands
 
 ### Building

--- a/src/lance_extension.cpp
+++ b/src/lance_extension.cpp
@@ -15,18 +15,16 @@ void RegisterLanceScan(ExtensionLoader &loader);
 void RegisterLanceSearch(ExtensionLoader &loader);
 void RegisterLanceReplacement(DBConfig &config);
 void RegisterLanceWrite(ExtensionLoader &loader);
-void RegisterLanceMetadata(ExtensionLoader &loader);
 void RegisterLanceStorage(DBConfig &config);
 void RegisterLanceTruncate(DBConfig &config);
 void RegisterLanceIndex(DBConfig &config, ExtensionLoader &loader);
 void RegisterLanceScanOptimizer(DBConfig &config);
 
 static void LoadInternal(ExtensionLoader &loader) {
-  // Register the lance_scan table function
+  // Register internal scan table functions.
   RegisterLanceScan(loader);
   RegisterLanceSearch(loader);
   RegisterLanceWrite(loader);
-  RegisterLanceMetadata(loader);
 }
 
 void LanceExtension::Load(ExtensionLoader &loader) {

--- a/src/lance_replacement.cpp
+++ b/src/lance_replacement.cpp
@@ -18,7 +18,7 @@ LanceReplacementScan(ClientContext &, ReplacementScanInput &input,
 
   auto table_function = make_uniq<TableFunctionRef>();
   auto function_expr = make_uniq<FunctionExpression>(
-      "lance_scan", vector<unique_ptr<ParsedExpression>>());
+      "__lance_scan", vector<unique_ptr<ParsedExpression>>());
   function_expr->children.push_back(
       make_uniq<ConstantExpression>(Value(table_name)));
   table_function->function = std::move(function_expr);

--- a/src/lance_scan.cpp
+++ b/src/lance_scan.cpp
@@ -668,7 +668,7 @@ static unique_ptr<FunctionData> LanceScanBind(ClientContext &context,
                                               vector<LogicalType> &return_types,
                                               vector<string> &names) {
   if (input.inputs.empty() || input.inputs[0].IsNull()) {
-    throw InvalidInputException("lance_scan requires a dataset root path");
+    throw InvalidInputException("Lance scan requires a dataset root path");
   }
 
   auto result = make_uniq<LanceScanBindData>();
@@ -1528,7 +1528,7 @@ static bool TryParseConstantLimitOffset(const LogicalLimit &limit_op,
 }
 
 static bool IsLanceScanTableFunction(const TableFunction &fn) {
-  return fn.name == "lance_scan" || fn.name == "__lance_table_scan" ||
+  return fn.name == "__lance_scan" || fn.name == "__lance_table_scan" ||
          fn.name == "__lance_namespace_scan";
 }
 
@@ -1953,7 +1953,7 @@ LanceCardinalityFixup(ClientContext &context, unique_ptr<LogicalOperator> op) {
 
   auto &get = op->Cast<LogicalGet>();
   if (!IsLanceScanTableFunction(get.function) || !get.bind_data) {
-    if (get.function.name != "lance_scan" || get.parameters.size() != 1 ||
+    if (get.function.name != "__lance_scan" || get.parameters.size() != 1 ||
         get.parameters[0].IsNull() ||
         get.parameters[0].type() != LogicalType::VARCHAR) {
       return op;
@@ -2471,25 +2471,28 @@ LanceTableEntry::GetScanFunction(ClientContext &context,
 }
 
 void RegisterLanceScan(ExtensionLoader &loader) {
-  TableFunction lance_scan("lance_scan", {LogicalType::VARCHAR}, LanceScanFunc,
-                           LanceScanBind, LanceScanInitGlobal,
-                           LanceScanLocalInit);
-  lance_scan.named_parameters["explain_verbose"] = LogicalType::BOOLEAN;
-  lance_scan.projection_pushdown = true;
-  lance_scan.filter_pushdown = true;
-  lance_scan.filter_prune = true;
-  lance_scan.sampling_pushdown = true;
-  lance_scan.statistics = LanceScanStatistics;
-  lance_scan.cardinality = LanceScanCardinality;
-  lance_scan.get_partition_stats = LanceScanGetPartitionStats;
-  lance_scan.supports_pushdown_type = LanceSupportsPushdownType;
-  lance_scan.pushdown_expression = LancePushdownExpression;
-  lance_scan.pushdown_complex_filter = LancePushdownComplexFilter;
-  lance_scan.pushdown_expression = LancePushdownExpression;
-  lance_scan.get_virtual_columns = LanceGetVirtualColumns;
-  lance_scan.to_string = LanceScanToString;
-  lance_scan.dynamic_to_string = LanceScanDynamicToString;
-  loader.RegisterFunction(lance_scan);
+  TableFunction internal_scan("__lance_scan", {LogicalType::VARCHAR},
+                              LanceScanFunc, LanceScanBind, LanceScanInitGlobal,
+                              LanceScanLocalInit);
+  internal_scan.named_parameters["explain_verbose"] = LogicalType::BOOLEAN;
+  internal_scan.projection_pushdown = true;
+  internal_scan.filter_pushdown = true;
+  internal_scan.filter_prune = true;
+  internal_scan.sampling_pushdown = true;
+  internal_scan.statistics = LanceScanStatistics;
+  internal_scan.cardinality = LanceScanCardinality;
+  internal_scan.get_partition_stats = LanceScanGetPartitionStats;
+  internal_scan.supports_pushdown_type = LanceSupportsPushdownType;
+  internal_scan.pushdown_expression = LancePushdownExpression;
+  internal_scan.pushdown_complex_filter = LancePushdownComplexFilter;
+  internal_scan.pushdown_expression = LancePushdownExpression;
+  internal_scan.get_virtual_columns = LanceGetVirtualColumns;
+  internal_scan.to_string = LanceScanToString;
+  internal_scan.dynamic_to_string = LanceScanDynamicToString;
+
+  CreateTableFunctionInfo scan_info(std::move(internal_scan));
+  scan_info.internal = true;
+  loader.RegisterFunction(std::move(scan_info));
 
   TableFunction internal_namespace_scan(
       "__lance_namespace_scan",

--- a/src/lance_storage.cpp
+++ b/src/lance_storage.cpp
@@ -842,7 +842,7 @@ LanceStorageAttach(optional_ptr<StorageExtensionInfo>, ClientContext &context,
   }
 
   // Back the attached catalog by an in-memory DuckCatalog that lazily
-  // materializes per-table entries mapping to `lance_scan` / internal namespace
+  // materializes per-table entries mapping to internal scan / namespace scan,
   // scan, and supports CREATE TABLE for directory namespaces.
   info.path = ":memory:";
   auto catalog =

--- a/test/sql/alter_table_schema_evolution.test
+++ b/test/sql/alter_table_schema_evolution.test
@@ -25,7 +25,10 @@ statement ok
 COMMENT ON TABLE ns.main.alter_table_schema_evolution IS 'table comment';
 
 query T
-SELECT Value FROM lance_table_metadata('ns.main.alter_table_schema_evolution') WHERE Key='comment'
+SELECT comment FROM duckdb_tables()
+WHERE database_name = 'ns'
+  AND schema_name = 'main'
+  AND table_name = 'alter_table_schema_evolution';
 ----
 table comment
 
@@ -38,11 +41,6 @@ SELECT sum(age_plus_one) FROM ns.main.alter_table_schema_evolution
 ----
 63
 
-query I
-SELECT Count FROM lance_set_config('ns.main.alter_table_schema_evolution', 'lance.add_columns.batch_size', '1')
-----
-1
-
 statement ok
 ALTER TABLE ns.main.alter_table_schema_evolution ADD COLUMN const_col INTEGER DEFAULT 42;
 
@@ -51,66 +49,33 @@ SELECT sum(const_col) FROM ns.main.alter_table_schema_evolution
 ----
 126
 
-query T
-SELECT Value FROM lance_config('ns.main.alter_table_schema_evolution') WHERE Key='lance.add_columns.batch_size'
-----
-1
-
-query I
-SELECT Count FROM lance_unset_config('ns.main.alter_table_schema_evolution', 'lance.add_columns.batch_size')
-----
-1
-
-query I
-SELECT count(*) FROM lance_config('ns.main.alter_table_schema_evolution') WHERE Key='lance.add_columns.batch_size'
-----
-0
-
-query I
-SELECT Count FROM lance_set_schema_metadata('ns.main.alter_table_schema_evolution', 'schema_key', 'schema_value')
-----
-1
-
-query T
-SELECT Value FROM lance_schema_metadata('ns.main.alter_table_schema_evolution') WHERE Key='schema_key'
-----
-schema_value
-
-query I
-SELECT Count FROM lance_unset_schema_metadata('ns.main.alter_table_schema_evolution', 'schema_key')
-----
-1
-
-query I
-SELECT count(*) FROM lance_schema_metadata('ns.main.alter_table_schema_evolution') WHERE Key='schema_key'
-----
-0
-
 statement ok
 COMMENT ON COLUMN ns.main.alter_table_schema_evolution.age_plus_one IS 'col comment';
 
 query T
-SELECT Value FROM lance_column_metadata('ns.main.alter_table_schema_evolution', 'age_plus_one') WHERE Key='comment'
+SELECT comment FROM duckdb_columns()
+WHERE database_name = 'ns'
+  AND schema_name = 'main'
+  AND table_name = 'alter_table_schema_evolution'
+  AND column_name = 'age_plus_one';
 ----
 col comment
 
-query I
-SELECT Count FROM lance_create_scalar_index('ns.main.alter_table_schema_evolution', 'age', 'age_idx')
-----
-1
+statement ok
+CREATE INDEX age_idx ON 'test/.tmp/alter_table_schema_evolution.lance' (age) USING BTREE;
 
-query I
-SELECT count(*) FROM lance_indices('ns.main.alter_table_schema_evolution')
+query TTTIT
+SHOW INDEXES ON 'test/.tmp/alter_table_schema_evolution.lance';
 ----
-1
+age_idx	<REGEX>:.*	age	<REGEX>:[0-9]+	<REGEX>:.*
 
 statement ok
 ALTER TABLE ns.main.alter_table_schema_evolution RENAME COLUMN score TO score2;
 
-query I
-SELECT count(*) FROM lance_indices('ns.main.alter_table_schema_evolution')
+query TTTIT
+SHOW INDEXES ON 'test/.tmp/alter_table_schema_evolution.lance';
 ----
-1
+age_idx	<REGEX>:.*	age	<REGEX>:[0-9]+	<REGEX>:.*
 
 statement error
 ALTER TABLE ns.main.alter_table_schema_evolution ALTER COLUMN const_col SET NOT NULL;
@@ -123,10 +88,9 @@ ALTER TABLE ns.main.alter_table_schema_evolution ALTER COLUMN const_col DROP NOT
 statement ok
 ALTER TABLE ns.main.alter_table_schema_evolution ALTER COLUMN age TYPE BIGINT;
 
-query I
-SELECT count(*) FROM lance_indices('ns.main.alter_table_schema_evolution')
+query TTTIT
+SHOW INDEXES ON 'test/.tmp/alter_table_schema_evolution.lance';
 ----
-0
 
 query I
 SELECT sum(age) FROM ns.main.alter_table_schema_evolution
@@ -140,16 +104,6 @@ statement error
 SELECT score2 FROM ns.main.alter_table_schema_evolution LIMIT 1;
 ----
 Binder Error:
-
-query I
-SELECT Count FROM lance_compact_files('ns.main.alter_table_schema_evolution')
-----
-1
-
-query I
-SELECT Count FROM lance_cleanup_old_versions('ns.main.alter_table_schema_evolution', 0, false)
-----
-1
 
 statement error
 SELECT score2 FROM ns.main.alter_table_schema_evolution LIMIT 1;

--- a/test/sql/lance.test
+++ b/test/sql/lance.test
@@ -10,9 +10,9 @@ SELECT 1
 ----
 1
 
-# Test that lance_scan can read a local dataset root
+# Test that replacement scan can read a local dataset root
 statement ok
-SELECT * FROM lance_scan('test/data/test_data.lance') LIMIT 1
+SELECT * FROM 'test/data/test_data.lance' LIMIT 1
 
 # LIMIT/OFFSET pushdown correctness
 query I

--- a/test/sql/tpch.test
+++ b/test/sql/tpch.test
@@ -1,5 +1,5 @@
 # name: test/sql/tpch.test
-# description: TPC-H correctness suite for lance_scan
+# description: TPC-H correctness suite for Lance replacement scan
 # group: [sql]
 
 require lance


### PR DESCRIPTION
Never expose unneed table functions. We expect users to always use DuckDB SQL.

---

**Parts of this PR were drafted with assistance from Codex (with `gpt-5.2`) and fully reviewed and edited by me. I take full responsibility for all changes.**