### PR TITLE
fix: Fix UPDATE with DEFAULT support

### DIFF
--- a/docs/sql.md
+++ b/docs/sql.md
@@ -131,10 +131,6 @@ UPDATE ns.main.my_table SET s = 'bb' WHERE id = 2;
 DETACH ns;
 ```
 
-Notes:
-- `UPDATE` requires a `WHERE` predicate (full-table `UPDATE` is not supported).
-- `SET column = DEFAULT` is not supported.
-
 ### `DELETE`
 
 ```sql

--- a/rust/ffi/update.rs
+++ b/rust/ffi/update.rs
@@ -290,8 +290,17 @@ fn rewrite_rows_update_transaction_inner(
                 .field(column.as_str())
                 .ok_or_else(|| format!("column does not exist: {}", column))?;
 
+            let value_sql = if value_sql.trim().eq_ignore_ascii_case("DEFAULT") {
+                field.metadata
+                    .get("duckdb_default_expr")
+                    .map(|s| s.as_str())
+                    .unwrap_or("NULL")
+            } else {
+                value_sql.as_str()
+            };
+
             let mut value_expr = planner
-                .parse_expr(value_sql.as_str())
+                .parse_expr(value_sql)
                 .map_err(|e| e.to_string())?;
 
             let dest_type = field.data_type();

--- a/src/lance_scan.cpp
+++ b/src/lance_scan.cpp
@@ -2257,7 +2257,25 @@ unique_ptr<CatalogEntry> LanceTableEntry::AlterEntry(ClientContext &context,
         throw IOException("Failed to add column to Lance dataset: " +
                           dataset_uri + LanceFormatErrorSuffix());
       }
+
+      // Best-effort persistence of DuckDB column defaults in Lance field
+      // metadata. Re-open the dataset after schema evolution so the new field
+      // is visible to the metadata updater.
       lance_close_dataset(dataset);
+      dataset = nullptr;
+      if (add.new_column.HasDefaultValue()) {
+        dataset = LanceOpenDataset(context, dataset_uri);
+        if (dataset) {
+          auto default_expr = add.new_column.DefaultValue().ToString();
+          (void)lance_dataset_update_field_metadata(
+              dataset, add.new_column.Name().c_str(), "duckdb_default_expr",
+              default_expr.c_str());
+          lance_close_dataset(dataset);
+          dataset = nullptr;
+        }
+      } else {
+        // The dataset was already closed above, keep going.
+      }
       return BuildUpdatedLanceTableEntryFromDataset(context, ParentCatalog(),
                                                     ParentSchema(), name,
                                                     dataset_uri, internal);

--- a/src/lance_storage.cpp
+++ b/src/lance_storage.cpp
@@ -582,6 +582,33 @@ public:
                         LanceFormatErrorSuffix());
     }
 
+    // Best-effort persistence of DuckDB column defaults in Lance field
+    // metadata. Lance itself does not currently expose defaults through
+    // DuckDB's catalog, but we can still use the metadata during UPDATE
+    // execution to resolve SET col = DEFAULT.
+    if (create_info.columns.LogicalColumnCount() > 0) {
+      void *dataset = nullptr;
+      if (option_keys.empty()) {
+        dataset = lance_open_dataset(dataset_path.c_str());
+      } else {
+        dataset = lance_open_dataset_with_storage_options(
+            dataset_path.c_str(), key_ptrs.data(), value_ptrs.data(),
+            option_keys.size());
+      }
+      if (dataset) {
+        for (auto &col : create_info.columns.Logical()) {
+          if (!col.HasDefaultValue()) {
+            continue;
+          }
+          auto default_expr = col.DefaultValue().ToString();
+          (void)lance_dataset_update_field_metadata(dataset, col.Name().c_str(),
+                                                    "duckdb_default_expr",
+                                                    default_expr.c_str());
+        }
+        lance_close_dataset(dataset);
+      }
+    }
+
     return nullptr;
   }
 

--- a/src/lance_update.cpp
+++ b/src/lance_update.cpp
@@ -506,8 +506,9 @@ PhysicalOperator &PlanLanceUpdateOverwrite(ClientContext &context,
 
     if (op.expressions[i]->GetExpressionType() ==
         ExpressionType::VALUE_DEFAULT) {
-      throw NotImplementedException(
-          "Lance UPDATE does not support SET column = DEFAULT");
+      // Keep DEFAULT as a marker and let the Lance execution layer resolve it.
+      set_expressions.push_back("DEFAULT");
+      continue;
     }
 
     unique_ptr<Expression> set_expr;

--- a/test/sql/dml_update.test
+++ b/test/sql/dml_update.test
@@ -99,10 +99,45 @@ UPDATE ns.main.lance_update_basic SET s = 'x';
 ----
 Not implemented Error: Lance UPDATE requires a WHERE predicate (full-table UPDATE is not supported)
 
-statement error
+statement ok
+BEGIN TRANSACTION;
+
+statement ok
 UPDATE ns.main.lance_update_basic SET s = DEFAULT WHERE id = 2;
+
+statement ok
+COMMIT;
+
+query I
+SELECT s IS NULL FROM ns.main.lance_update_basic WHERE id = 2;
 ----
-Not implemented Error: Lance UPDATE does not support SET column = DEFAULT
+1
+
+statement ok
+CREATE OR REPLACE TABLE ns.main.lance_update_default (id BIGINT, v INTEGER DEFAULT 42);
+
+statement ok
+BEGIN TRANSACTION;
+
+statement ok
+INSERT INTO ns.main.lance_update_default VALUES (1, 0);
+
+statement ok
+COMMIT;
+
+statement ok
+BEGIN TRANSACTION;
+
+statement ok
+UPDATE ns.main.lance_update_default SET v = DEFAULT WHERE id = 1;
+
+statement ok
+COMMIT;
+
+query I
+SELECT v FROM ns.main.lance_update_default WHERE id = 1;
+----
+42
 
 statement ok
 DETACH ns;


### PR DESCRIPTION
This PR will fix UPDATE with DEFAULT support

Close https://github.com/lance-format/lance-duckdb/issues/101

---

**Parts of this PR were drafted with assistance from Codex (with `gpt-5.2`) and fully reviewed and edited by me. I take full responsibility for all changes.**