### PR TITLE
feat: Add starts_with/ends_with/contains pushdown

### DIFF
--- a/rust/filter_ir.rs
+++ b/rust/filter_ir.rs
@@ -19,6 +19,7 @@ const TAG_IS_NOT_NULL: u8 = 8;
 const TAG_IN_LIST: u8 = 9;
 const TAG_LIKE: u8 = 10;
 const TAG_REGEXP: u8 = 11;
+const TAG_SCALAR_FUNCTION: u8 = 12;
 
 const REGEXP_MODE_PARTIAL_MATCH: u8 = 0;
 const REGEXP_MODE_FULL_MATCH: u8 = 1;
@@ -50,6 +51,11 @@ const OP_NOT_DISTINCT_FROM: u8 = 7;
 
 static GETFIELD_UDF: OnceLock<Arc<ScalarUDF>> = OnceLock::new();
 static REGEXP_LIKE_UDF: OnceLock<Arc<ScalarUDF>> = OnceLock::new();
+static STARTS_WITH_UDF: OnceLock<Arc<ScalarUDF>> = OnceLock::new();
+static ENDS_WITH_UDF: OnceLock<Arc<ScalarUDF>> = OnceLock::new();
+static CONTAINS_UDF: OnceLock<Arc<ScalarUDF>> = OnceLock::new();
+static LOWER_UDF: OnceLock<Arc<ScalarUDF>> = OnceLock::new();
+static UPPER_UDF: OnceLock<Arc<ScalarUDF>> = OnceLock::new();
 
 fn getfield_udf() -> Arc<ScalarUDF> {
     GETFIELD_UDF
@@ -61,6 +67,32 @@ fn regexp_like_udf() -> Arc<ScalarUDF> {
     REGEXP_LIKE_UDF
         .get_or_init(datafusion_functions::regex::regexp_like)
         .clone()
+}
+
+fn starts_with_udf() -> Arc<ScalarUDF> {
+    STARTS_WITH_UDF
+        .get_or_init(datafusion_functions::string::starts_with)
+        .clone()
+}
+
+fn ends_with_udf() -> Arc<ScalarUDF> {
+    ENDS_WITH_UDF
+        .get_or_init(datafusion_functions::string::ends_with)
+        .clone()
+}
+
+fn contains_udf() -> Arc<ScalarUDF> {
+    CONTAINS_UDF
+        .get_or_init(datafusion_functions::string::contains)
+        .clone()
+}
+
+fn lower_udf() -> Arc<ScalarUDF> {
+    LOWER_UDF.get_or_init(datafusion_functions::string::lower).clone()
+}
+
+fn upper_udf() -> Arc<ScalarUDF> {
+    UPPER_UDF.get_or_init(datafusion_functions::string::upper).clone()
 }
 
 pub fn parse_filter_ir(filter_ir: &[u8]) -> Result<Expr> {
@@ -191,6 +223,7 @@ fn parse_node(cursor: &mut Cursor<'_>) -> Result<Expr> {
         TAG_IN_LIST => parse_in_list(cursor),
         TAG_LIKE => parse_like(cursor),
         TAG_REGEXP => parse_regexp(cursor),
+        TAG_SCALAR_FUNCTION => parse_scalar_function(cursor),
         other => Err(anyhow!("unknown node tag: {other}")),
     }
 }
@@ -409,4 +442,49 @@ fn parse_regexp(cursor: &mut Cursor<'_>) -> Result<Expr> {
         args.push(Expr::Literal(ScalarValue::Utf8(Some(flags)), None));
     }
     Ok(regexp_like_udf().call(args))
+}
+
+fn parse_scalar_function(cursor: &mut Cursor<'_>) -> Result<Expr> {
+    let name = cursor.read_len_prefixed_string()?;
+    let args_len = usize::try_from(cursor.read_u32_le()?)?;
+    let mut args = Vec::with_capacity(args_len);
+    for _ in 0..args_len {
+        args.push(parse_len_prefixed_node(cursor)?);
+    }
+
+    let func = match name.as_str() {
+        "starts_with" => {
+            if args.len() != 2 {
+                bail!("starts_with expects 2 args, got {}", args.len());
+            }
+            starts_with_udf()
+        }
+        "ends_with" => {
+            if args.len() != 2 {
+                bail!("ends_with expects 2 args, got {}", args.len());
+            }
+            ends_with_udf()
+        }
+        "contains" => {
+            if args.len() != 2 {
+                bail!("contains expects 2 args, got {}", args.len());
+            }
+            contains_udf()
+        }
+        "lower" => {
+            if args.len() != 1 {
+                bail!("lower expects 1 arg, got {}", args.len());
+            }
+            lower_udf()
+        }
+        "upper" => {
+            if args.len() != 1 {
+                bail!("upper expects 1 arg, got {}", args.len());
+            }
+            upper_udf()
+        }
+        other => bail!("unsupported scalar function: {other}"),
+    };
+
+    Ok(Expr::ScalarFunction(ScalarFunction { func, args }))
 }

--- a/src/lance_filter_ir.cpp
+++ b/src/lance_filter_ir.cpp
@@ -73,6 +73,7 @@ enum class LanceFilterIRTag : uint8_t {
   IN_LIST = 9,
   LIKE = 10,
   REGEXP = 11,
+  SCALAR_FUNCTION = 12,
 };
 
 enum class LanceFilterIRLiteralTag : uint8_t {
@@ -526,6 +527,28 @@ static bool TryEncodeLanceFilterIRRegexp(uint8_t mode, bool has_flags,
   return true;
 }
 
+static bool TryEncodeLanceFilterIRScalarFunction(const string &name,
+                                                 const vector<string> &args,
+                                                 string &out_ir) {
+  if (args.size() > std::numeric_limits<uint32_t>::max()) {
+    return false;
+  }
+
+  out_ir.clear();
+  LanceFilterIRAppendU8(
+      out_ir, static_cast<uint8_t>(LanceFilterIRTag::SCALAR_FUNCTION));
+  if (!LanceFilterIRAppendLenPrefixedString(out_ir, name)) {
+    return false;
+  }
+  LanceFilterIRAppendU32(out_ir, static_cast<uint32_t>(args.size()));
+  for (auto &arg : args) {
+    if (!LanceFilterIRAppendLenPrefixed(out_ir, arg)) {
+      return false;
+    }
+  }
+  return true;
+}
+
 static bool TryGetNonNullVarcharConstant(const Expression &expr,
                                          string &out_value) {
   if (expr.expression_class == ExpressionClass::BOUND_CONSTANT) {
@@ -575,6 +598,58 @@ static bool TryBuildLanceTableFilterIRExpr(const string &col_ref_ir,
     case ExpressionClass::BOUND_REF: {
       out_expr_ir = col_ref_ir;
       return true;
+    }
+    case ExpressionClass::BOUND_FUNCTION: {
+      auto &func = expr.Cast<BoundFunctionExpression>();
+      for (auto &child : func.children) {
+        if (!child) {
+          return false;
+        }
+      }
+
+      if (func.function.name == "lower" || func.function.name == "upper") {
+        if (func.children.size() != 1) {
+          return false;
+        }
+        string input_ir;
+        if (!build_from_expr(*func.children[0], input_ir)) {
+          return false;
+        }
+        vector<string> args;
+        args.push_back(std::move(input_ir));
+        return TryEncodeLanceFilterIRScalarFunction(func.function.name, args,
+                                                    out_expr_ir);
+      }
+
+      if (func.function.name == "starts_with" ||
+          func.function.name == "ends_with" ||
+          func.function.name == "contains") {
+        if (func.children.size() != 2) {
+          return false;
+        }
+
+        string input_ir;
+        if (!build_from_expr(*func.children[0], input_ir)) {
+          return false;
+        }
+
+        string needle_value;
+        if (!TryGetNonNullVarcharConstant(*func.children[1], needle_value)) {
+          return false;
+        }
+        string needle_ir;
+        if (!TryEncodeLanceFilterIRLiteral(Value(needle_value), needle_ir)) {
+          return false;
+        }
+
+        vector<string> args;
+        args.push_back(std::move(input_ir));
+        args.push_back(std::move(needle_ir));
+        return TryEncodeLanceFilterIRScalarFunction(func.function.name, args,
+                                                    out_expr_ir);
+      }
+
+      return false;
     }
     case ExpressionClass::BOUND_CONSTANT: {
       auto &c = expr.Cast<BoundConstantExpression>();
@@ -1078,6 +1153,50 @@ bool TryBuildLanceExprFilterIR(const LogicalGet &get,
         func.function.name == "struct_extract_at") {
       return TryBuildLanceExprColumnRefIR(
           get, names, types, exclude_computed_columns, expr, out_ir);
+    }
+
+    if (func.function.name == "lower" || func.function.name == "upper") {
+      if (func.children.size() != 1 || !func.children[0]) {
+        return false;
+      }
+      string input_ir;
+      if (!TryBuildLanceExprFilterIR(get, names, types,
+                                     exclude_computed_columns,
+                                     *func.children[0], input_ir)) {
+        return false;
+      }
+      vector<string> args;
+      args.push_back(std::move(input_ir));
+      return TryEncodeLanceFilterIRScalarFunction(func.function.name, args,
+                                                  out_ir);
+    }
+
+    if (func.function.name == "starts_with" ||
+        func.function.name == "ends_with" || func.function.name == "contains") {
+      if (func.children.size() != 2 || !func.children[0] || !func.children[1]) {
+        return false;
+      }
+      string input_ir;
+      if (!TryBuildLanceExprFilterIR(get, names, types,
+                                     exclude_computed_columns,
+                                     *func.children[0], input_ir)) {
+        return false;
+      }
+
+      string needle_value;
+      if (!TryGetNonNullVarcharConstant(*func.children[1], needle_value)) {
+        return false;
+      }
+      string needle_ir;
+      if (!TryEncodeLanceFilterIRLiteral(Value(needle_value), needle_ir)) {
+        return false;
+      }
+
+      vector<string> args;
+      args.push_back(std::move(input_ir));
+      args.push_back(std::move(needle_ir));
+      return TryEncodeLanceFilterIRScalarFunction(func.function.name, args,
+                                                  out_ir);
     }
 
     if (func.function.name == "regexp_matches" ||

--- a/test/sql/pushdown_string_functions.test
+++ b/test/sql/pushdown_string_functions.test
@@ -1,0 +1,54 @@
+# name: test/sql/pushdown_string_functions.test
+# description: String scalar function predicate pushdown
+# group: [sql]
+
+require lance
+
+statement ok
+COPY (
+  SELECT * FROM (VALUES
+    ('Alice'),
+    ('ALICE'),
+    ('prefix_suffix'),
+    ('xxsuffix'),
+    ('middle'),
+    (NULL)
+  ) t(s)
+) TO 'test/.tmp/string_functions_pushdown.lance' (FORMAT lance, mode 'overwrite');
+
+query I
+SELECT count(*) FROM 'test/.tmp/string_functions_pushdown.lance' WHERE starts_with(s, 'Al');
+----
+1
+
+query I
+SELECT count(*) FROM 'test/.tmp/string_functions_pushdown.lance' WHERE ends_with(s, 'suffix');
+----
+2
+
+query I
+SELECT count(*) FROM 'test/.tmp/string_functions_pushdown.lance' WHERE contains(s, 'fix');
+----
+2
+
+query I
+SELECT count(*) FROM 'test/.tmp/string_functions_pushdown.lance' WHERE lower(s) = 'alice';
+----
+2
+
+query I
+SELECT count(*) FROM 'test/.tmp/string_functions_pushdown.lance' WHERE upper(s) = 'ALICE';
+----
+2
+
+# Explain diagnostics indicate these predicates are pushed to Lance
+query II
+EXPLAIN (FORMAT JSON) SELECT count(*) FROM 'test/.tmp/string_functions_pushdown.lance' WHERE starts_with(s, 'Al');
+----
+physical_plan	<REGEX>:[\s\S]*"Lance Filter IR Bytes \(Bind\)": "[1-9][0-9]*"[\s\S]*starts_with[\s\S]*
+
+query II
+EXPLAIN (ANALYZE, FORMAT JSON) SELECT count(*) FROM 'test/.tmp/string_functions_pushdown.lance' WHERE starts_with(s, 'Al');
+----
+analyzed_plan	<REGEX>:[\s\S]*"Lance Filter Pushdown Fallbacks": "0"[\s\S]*
+


### PR DESCRIPTION
This PR will add starts_with/ends_with/contains pushdown, close https://github.com/lance-format/lance-duckdb/issues/109


---

**Parts of this PR were drafted with assistance from Codex (with `gpt-5.2`) and fully reviewed and edited by me. I take full responsibility for all changes.**