### PR TITLE
Bump to verson 0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,24 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 
 ## [Unreleased]
 
+## [0.4.0] - 2025-12-29
+
+### Added
+
+- Transactional `DELETE` support (honors `BEGIN`/`COMMIT`/`ROLLBACK`).
+- Support `UPDATE` without a `WHERE` clause to update all rows.
+- Predicate pushdown for string functions: `starts_with`, `ends_with`, `contains`.
+- Support `CREATE INDEX ... ON ns.main.tbl(col) USING BTREE` on attached namespaces.
+
+### Changed
+
+- **Breaking:** Object store credential/configuration now uses `CREATE SECRET (TYPE LANCE, ...)` (instead of `TYPE S3`).
+- Aligned directory and REST namespace behavior.
+
+### Fixed
+
+- `UPDATE ... SET col = DEFAULT` now works correctly.
+
 ## [0.3.0] - 2025-12-28
 
 ### Added

--- a/docs/sql.md
+++ b/docs/sql.md
@@ -127,6 +127,8 @@ DETACH ns;
 ATTACH 'path/to/dir' AS ns (TYPE LANCE);
 
 UPDATE ns.main.my_table SET s = 'bb' WHERE id = 2;
+UPDATE ns.main.my_table SET s = 'x'; -- update all rows
+UPDATE ns.main.my_table SET s = DEFAULT WHERE id = 2;
 
 DETACH ns;
 ```
@@ -141,9 +143,6 @@ DELETE FROM ns.main.my_table; -- delete all rows
 
 DETACH ns;
 ```
-
-Notes:
-- Explicit transactions for `DELETE` are currently not supported.
 
 ### `TRUNCATE TABLE`
 


### PR DESCRIPTION
This PR will bump lance-duckdb to v0.4.0

---

**Parts of this PR were drafted with assistance from Codex (with `gpt-5.2`) and fully reviewed and edited by me. I take full responsibility for all changes.**