### PR TITLE
chore: add lance dependency bump automation

### DIFF
--- a/.github/workflows/codex-update-lance-dependency.yml
+++ b/.github/workflows/codex-update-lance-dependency.yml
@@ -1,0 +1,122 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Codex Update Lance Dependency
+
+on:
+  workflow_call:
+    inputs:
+      tag:
+        description: "Tag name from Lance (e.g., v2.0.0)"
+        required: true
+        type: string
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Tag name from Lance (e.g., v2.0.0)"
+        required: true
+        type: string
+
+permissions:
+  contents: write
+  pull-requests: write
+  actions: read
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Show inputs
+        run: |
+          echo "tag = ${{ inputs.tag }}"
+
+      - name: Checkout Repo
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+          persist-credentials: true
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Install Codex CLI
+        run: npm install -g @openai/codex
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Set up Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt, clippy
+
+      - name: Configure git user
+        run: |
+          git config user.name "lance-community"
+          git config user.email "community@lance.org"
+
+      - name: Run Codex to update Lance dependency
+        env:
+          TAG: ${{ inputs.tag }}
+          GITHUB_TOKEN: ${{ secrets.LANCE_RELEASE_TOKEN }}
+          GH_TOKEN: ${{ secrets.LANCE_RELEASE_TOKEN }}
+          OPENAI_API_KEY: ${{ secrets.CODEX_TOKEN }}
+        run: |
+          set -euo pipefail
+          VERSION="${TAG#refs/tags/}"
+          VERSION="${VERSION#v}"
+          BRANCH_NAME="codex/update-lance-${VERSION//[^a-zA-Z0-9]/-}"
+
+          cat <<EOF >/tmp/codex-prompt.txt
+          You are running inside the lance-duckdb repository on a GitHub Actions runner.
+          Update the Lance Rust dependencies to version ${VERSION} (semver format) and prepare a pull request for maintainers to review.
+
+          Follow these steps exactly:
+          1. Update versions in Cargo.toml:
+             - In the [dependencies] section, update the versions for these crates to "${VERSION}":
+               lance, lance-arrow, lance-core, lance-index, lance-linalg, lance-namespace, lance-namespace-impls, lance-table.
+             - Keep existing features/flags unchanged.
+          2. Update Cargo.lock to match the new versions.
+             - Prefer precise updates like:
+               cargo update -p lance --precise ${VERSION}
+               cargo update -p lance-arrow --precise ${VERSION}
+               ... (repeat for each of the crates above)
+             - If Cargo complains about incompatible Arrow/DataFusion versions, update the pinned Arrow/DataFusion versions in Cargo.toml to match the Lance ${VERSION} dependency requirements, then update Cargo.lock again.
+          3. Run these checks:
+             - cargo fmt --all
+             - cargo check --manifest-path Cargo.toml
+             - cargo clippy --manifest-path Cargo.toml --all-targets
+          4. Inspect "git status --short" and "git diff" to confirm the dependency update and any required fixes.
+          5. Create and switch to a new branch named "${BRANCH_NAME}" (replace any duplicated hyphens if necessary).
+          6. Stage all relevant files with "git add -A". Commit using the message "chore: update lance dependency to v${VERSION}".
+          7. Push the branch to origin. If the branch already exists, force-push your changes.
+          8. env "GH_TOKEN" is available; use "gh" tools for GitHub operations like creating pull requests.
+          9. Create a pull request targeting "main" with title "chore: update lance dependency to v${VERSION}".
+             - First, write the PR body to /tmp/pr-body.md using a heredoc (cat <<'EOF' > /tmp/pr-body.md).
+             - The body should summarize the dependency bump, key resolver changes (if any), the commands run in step 3, and link the triggering tag (${TAG}).
+             - Then run "gh pr create --body-file /tmp/pr-body.md".
+          10. Display the PR URL, "git status --short", and a concise summary of the commands run and their results.
+
+          Constraints:
+          - Use bash commands.
+          - Do not merge the PR.
+          - If any command fails, diagnose and fix the issue instead of aborting.
+          - For compatibility issues, consult lance-format/lance at tag v${VERSION} for the expected Rust dependency versions.
+          EOF
+
+          printenv OPENAI_API_KEY | codex login --with-api-key
+          codex --config shell_environment_policy.ignore_default_excludes=true exec --dangerously-bypass-approvals-and-sandbox "$(cat /tmp/codex-prompt.txt)"
+

--- a/.github/workflows/lance-release-timer.yml
+++ b/.github/workflows/lance-release-timer.yml
@@ -1,0 +1,80 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Lance Release Timer
+
+on:
+  schedule:
+    - cron: "*/10 * * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  actions: write
+
+concurrency:
+  group: lance-release-timer
+  cancel-in-progress: false
+
+jobs:
+  trigger-update:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Check for new Lance tag
+        id: check
+        env:
+          GH_TOKEN: ${{ secrets.LANCE_RELEASE_TOKEN }}
+        run: |
+          python3 ci/check_lance_release.py --github-output "$GITHUB_OUTPUT"
+
+      - name: Look for existing PR
+        if: steps.check.outputs.needs_update == 'true'
+        id: pr
+        env:
+          GH_TOKEN: ${{ secrets.LANCE_RELEASE_TOKEN }}
+        run: |
+          set -euo pipefail
+          TITLE="chore: update lance dependency to v${{ steps.check.outputs.latest_version }}"
+          COUNT=$(gh pr list --search "\"$TITLE\" in:title" --state open --limit 1 --json number --jq 'length')
+          if [ "$COUNT" -gt 0 ]; then
+            echo "Open PR already exists for $TITLE"
+            echo "pr_exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "No existing PR for $TITLE"
+            echo "pr_exists=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Trigger codex update workflow
+        if: steps.check.outputs.needs_update == 'true' && steps.pr.outputs.pr_exists != 'true'
+        env:
+          GH_TOKEN: ${{ secrets.LANCE_RELEASE_TOKEN }}
+        run: |
+          set -euo pipefail
+          TAG=${{ steps.check.outputs.latest_tag }}
+          gh workflow run codex-update-lance-dependency.yml -f tag=refs/tags/$TAG
+
+      - name: Show latest codex workflow run
+        if: steps.check.outputs.needs_update == 'true' && steps.pr.outputs.pr_exists != 'true'
+        env:
+          GH_TOKEN: ${{ secrets.LANCE_RELEASE_TOKEN }}
+        run: |
+          set -euo pipefail
+          gh run list --workflow codex-update-lance-dependency.yml --limit 1 --json databaseId,url,displayTitle
+

--- a/README.md
+++ b/README.md
@@ -174,6 +174,18 @@ See the SQL reference for full parameter documentation: [docs/sql.md#search](doc
 
 Issues and PRs are welcome. High-impact areas include pushdown, parallelism/performance, type coverage, and better diagnostics.
 
+### Automation: Lance dependency bumps
+
+This repository includes a GitHub Actions workflow pair that opens a PR when a newer tag is detected in `lance-format/lance`:
+
+- `.github/workflows/lance-release-timer.yml`: polls for a newer Lance tag and triggers the Codex workflow.
+- `.github/workflows/codex-update-lance-dependency.yml`: uses Codex CLI to update `Cargo.toml` / `Cargo.lock`, run basic Rust checks, and open a PR.
+
+Required repository secrets:
+
+- `LANCE_RELEASE_TOKEN`: a GitHub token that can read tags and create PRs in this repository.
+- `CODEX_TOKEN`: an OpenAI API key used by Codex CLI.
+
 ## License
 
 Apache License 2.0.

--- a/ci/check_lance_release.py
+++ b/ci/check_lance_release.py
@@ -1,0 +1,207 @@
+#!/usr/bin/env python3
+
+"""Determine whether a newer Lance tag exists and expose results for CI."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+from collections.abc import Iterable, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+
+import tomllib
+
+LANCE_REPO = "lance-format/lance"
+
+SEMVER_RE = re.compile(
+    r"^\s*(?P<major>0|[1-9]\d*)\.(?P<minor>0|[1-9]\d*)\.(?P<patch>0|[1-9]\d*)"
+    r"(?:-(?P<prerelease>[0-9A-Za-z.-]+))?"
+    r"(?:\+[0-9A-Za-z.-]+)?\s*$"
+)
+
+
+@dataclass(frozen=True)
+class SemVer:
+    major: int
+    minor: int
+    patch: int
+    prerelease: tuple[int | str, ...]
+
+    def __lt__(self, other: "SemVer") -> bool:
+        if (self.major, self.minor, self.patch) != (other.major, other.minor, other.patch):
+            return (self.major, self.minor, self.patch) < (
+                other.major,
+                other.minor,
+                other.patch,
+            )
+        if self.prerelease == other.prerelease:
+            return False
+        if not self.prerelease:
+            return False  # release > prerelease
+        if not other.prerelease:
+            return True
+        for left, right in zip(self.prerelease, other.prerelease, strict=False):
+            if left == right:
+                continue
+            if isinstance(left, int) and isinstance(right, int):
+                return left < right
+            if isinstance(left, int):
+                return True
+            if isinstance(right, int):
+                return False
+            return str(left) < str(right)
+        return len(self.prerelease) < len(other.prerelease)
+
+
+def parse_semver(raw: str) -> SemVer:
+    match = SEMVER_RE.match(raw)
+    if not match:
+        raise ValueError(f"Unsupported version format: {raw}")
+    prerelease = match.group("prerelease")
+    parts: tuple[int | str, ...] = ()
+    if prerelease:
+        parsed: list[int | str] = []
+        for piece in prerelease.split("."):
+            parsed.append(int(piece) if piece.isdigit() else piece)
+        parts = tuple(parsed)
+    return SemVer(
+        major=int(match.group("major")),
+        minor=int(match.group("minor")),
+        patch=int(match.group("patch")),
+        prerelease=parts,
+    )
+
+
+@dataclass(frozen=True)
+class TagInfo:
+    tag: str  # e.g. v1.0.0-beta.2
+    version: str  # e.g. 1.0.0-beta.2
+    semver: SemVer
+
+
+def run_command(cmd: Sequence[str]) -> str:
+    result = subprocess.run(cmd, capture_output=True, text=True, check=False)
+    if result.returncode != 0:
+        raise RuntimeError(
+            f"Command {' '.join(cmd)} failed with {result.returncode}: {result.stderr.strip()}"
+        )
+    return result.stdout.strip()
+
+
+def fetch_remote_tags() -> list[TagInfo]:
+    output = run_command(
+        [
+            "gh",
+            "api",
+            "-X",
+            "GET",
+            f"repos/{LANCE_REPO}/git/refs/tags",
+            "--paginate",
+            "--jq",
+            ".[].ref",
+        ]
+    )
+    tags: list[TagInfo] = []
+    for line in output.splitlines():
+        ref = line.strip()
+        if not ref.startswith("refs/tags/v"):
+            continue
+        tag = ref.split("refs/tags/")[-1]
+        version = tag.removeprefix("v")
+        try:
+            tags.append(TagInfo(tag=tag, version=version, semver=parse_semver(version)))
+        except ValueError:
+            continue
+    if not tags:
+        raise RuntimeError("No Lance tags could be parsed from GitHub API output")
+    return tags
+
+
+def normalize_cargo_version(raw: str) -> str:
+    trimmed = raw.strip()
+    for prefix in ("^", "~", "="):
+        if trimmed.startswith(prefix):
+            trimmed = trimmed[len(prefix) :].strip()
+    if " " in trimmed or "," in trimmed or "|" in trimmed:
+        raise ValueError(f"Unsupported Cargo version requirement: {raw}")
+    return trimmed
+
+
+def read_current_version(repo_root: Path) -> str:
+    """Read dependencies.lance.version from Cargo.toml."""
+    cargo_toml_path = repo_root / "Cargo.toml"
+    with cargo_toml_path.open("rb") as handle:
+        cargo_toml = tomllib.load(handle)
+
+    deps = cargo_toml.get("dependencies", {})
+    spec = deps.get("lance")
+    if spec is None:
+        raise RuntimeError("Failed to locate [dependencies].lance in Cargo.toml")
+
+    if isinstance(spec, str):
+        return normalize_cargo_version(spec)
+    if isinstance(spec, dict):
+        version = spec.get("version")
+        if not version or not isinstance(version, str):
+            raise RuntimeError("Failed to locate [dependencies].lance.version in Cargo.toml")
+        return normalize_cargo_version(version)
+
+    raise RuntimeError(f"Unsupported [dependencies].lance format: {type(spec)!r}")
+
+
+def determine_latest_tag(tags: Iterable[TagInfo]) -> TagInfo:
+    return max(tags, key=lambda tag: tag.semver)
+
+
+def write_outputs(args: argparse.Namespace, payload: dict) -> None:
+    target = getattr(args, "github_output", None)
+    if not target:
+        return
+    with open(target, "a", encoding="utf-8") as handle:
+        for key, value in payload.items():
+            handle.write(f"{key}={value}\n")
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--repo-root",
+        default=Path(__file__).resolve().parents[1],
+        type=Path,
+        help="Path to the lance-duckdb repository root",
+    )
+    parser.add_argument(
+        "--github-output",
+        default=os.environ.get("GITHUB_OUTPUT"),
+        help="Optional file path for writing GitHub Action outputs",
+    )
+    args = parser.parse_args(argv)
+
+    repo_root = Path(args.repo_root)
+    current_version = read_current_version(repo_root)
+    current_semver = parse_semver(current_version)
+
+    tags = fetch_remote_tags()
+    latest = determine_latest_tag(tags)
+    needs_update = latest.semver > current_semver
+
+    payload = {
+        "current_version": current_version,
+        "current_tag": f"v{current_version}",
+        "latest_version": latest.version,
+        "latest_tag": latest.tag,
+        "needs_update": "true" if needs_update else "false",
+    }
+
+    print(json.dumps(payload))
+    write_outputs(args, payload)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+


### PR DESCRIPTION
This adds an automated workflow (modeled after lance-spark) to keep the Rust `lance*` dependencies in sync with upstream `lance-format/lance` tags.

What is included
- `lance-release-timer.yml`: polls upstream tags every 10 minutes, de-duplicates by PR title, and triggers the Codex workflow.
- `codex-update-lance-dependency.yml`: runs Codex CLI to bump `Cargo.toml`/`Cargo.lock`, runs `cargo fmt/check/clippy`, and opens a PR.
- `ci/check_lance_release.py`: compares the latest upstream tag against `Cargo.toml`'s `dependencies.lance` version.
- `README.md`: documents the automation and required secrets.

Required repository secrets
- `LANCE_RELEASE_TOKEN`: GitHub token to query tags and create PRs.
- `CODEX_TOKEN`: OpenAI API key for Codex CLI.

Local checks
- `uv run make format`
- `python3 -m py_compile ci/check_lance_release.py`
