### PR TITLE
chore: update lance dependency to v2.0.0-rc.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -107,9 +107,9 @@ checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
 name = "arrow"
-version = "56.2.0"
+version = "57.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e833808ff2d94ed40d9379848a950d995043c7fb3e81a30b383f4c6033821cc"
+checksum = "2a2b10dcb159faf30d3f81f6d56c1211a5bea2ca424eabe477648a44b993320e"
 dependencies = [
  "arrow-arith",
  "arrow-array",
@@ -128,23 +128,23 @@ dependencies = [
 
 [[package]]
 name = "arrow-arith"
-version = "56.2.0"
+version = "57.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad08897b81588f60ba983e3ca39bda2b179bdd84dced378e7df81a5313802ef8"
+checksum = "288015089e7931843c80ed4032c5274f02b37bcb720c4a42096d50b390e70372"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
  "arrow-data",
  "arrow-schema",
  "chrono",
- "num",
+ "num-traits",
 ]
 
 [[package]]
 name = "arrow-array"
-version = "56.2.0"
+version = "57.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8548ca7c070d8db9ce7aa43f37393e4bfcf3f2d3681df278490772fd1673d08d"
+checksum = "65ca404ea6191e06bf30956394173337fa9c35f445bd447fe6c21ab944e1a23c"
 dependencies = [
  "ahash",
  "arrow-buffer",
@@ -154,29 +154,33 @@ dependencies = [
  "chrono-tz",
  "half",
  "hashbrown 0.16.1",
- "num",
+ "num-complex",
+ "num-integer",
+ "num-traits",
 ]
 
 [[package]]
 name = "arrow-buffer"
-version = "56.2.0"
+version = "57.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e003216336f70446457e280807a73899dd822feaf02087d31febca1363e2fccc"
+checksum = "36356383099be0151dacc4245309895f16ba7917d79bdb71a7148659c9206c56"
 dependencies = [
  "bytes",
  "half",
- "num",
+ "num-bigint",
+ "num-traits",
 ]
 
 [[package]]
 name = "arrow-cast"
-version = "56.2.0"
+version = "57.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "919418a0681298d3a77d1a315f625916cb5678ad0d74b9c60108eb15fd083023"
+checksum = "9c8e372ed52bd4ee88cc1e6c3859aa7ecea204158ac640b10e187936e7e87074"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
  "arrow-data",
+ "arrow-ord",
  "arrow-schema",
  "arrow-select",
  "atoi",
@@ -185,15 +189,15 @@ dependencies = [
  "comfy-table",
  "half",
  "lexical-core",
- "num",
+ "num-traits",
  "ryu",
 ]
 
 [[package]]
 name = "arrow-csv"
-version = "56.2.0"
+version = "57.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfa9bf02705b5cf762b6f764c65f04ae9082c7cfc4e96e0c33548ee3f67012eb"
+checksum = "8e4100b729fe656f2e4fb32bc5884f14acf9118d4ad532b7b33c1132e4dce896"
 dependencies = [
  "arrow-array",
  "arrow-cast",
@@ -206,21 +210,22 @@ dependencies = [
 
 [[package]]
 name = "arrow-data"
-version = "56.2.0"
+version = "57.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5c64fff1d142f833d78897a772f2e5b55b36cb3e6320376f0961ab0db7bd6d0"
+checksum = "bf87f4ff5fc13290aa47e499a8b669a82c5977c6a1fedce22c7f542c1fd5a597"
 dependencies = [
  "arrow-buffer",
  "arrow-schema",
  "half",
- "num",
+ "num-integer",
+ "num-traits",
 ]
 
 [[package]]
 name = "arrow-ipc"
-version = "56.2.0"
+version = "57.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d3594dcddccc7f20fd069bc8e9828ce37220372680ff638c5e00dea427d88f5"
+checksum = "eb3ca63edd2073fcb42ba112f8ae165df1de935627ead6e203d07c99445f2081"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -228,15 +233,15 @@ dependencies = [
  "arrow-schema",
  "arrow-select",
  "flatbuffers",
- "lz4_flex",
+ "lz4_flex 0.12.0",
  "zstd",
 ]
 
 [[package]]
 name = "arrow-json"
-version = "56.2.0"
+version = "57.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88cf36502b64a127dc659e3b305f1d993a544eab0d48cce704424e62074dc04b"
+checksum = "a36b2332559d3310ebe3e173f75b29989b4412df4029a26a30cc3f7da0869297"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -246,19 +251,21 @@ dependencies = [
  "chrono",
  "half",
  "indexmap",
+ "itoa",
  "lexical-core",
  "memchr",
- "num",
- "serde",
+ "num-traits",
+ "ryu",
+ "serde_core",
  "serde_json",
  "simdutf8",
 ]
 
 [[package]]
 name = "arrow-ord"
-version = "56.2.0"
+version = "57.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c8f82583eb4f8d84d4ee55fd1cb306720cddead7596edce95b50ee418edf66f"
+checksum = "13c4e0530272ca755d6814218dffd04425c5b7854b87fa741d5ff848bf50aa39"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -269,9 +276,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-row"
-version = "56.2.0"
+version = "57.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d07ba24522229d9085031df6b94605e0f4b26e099fb7cdeec37abd941a73753"
+checksum = "b07f52788744cc71c4628567ad834cadbaeb9f09026ff1d7a4120f69edf7abd3"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -282,34 +289,34 @@ dependencies = [
 
 [[package]]
 name = "arrow-schema"
-version = "56.2.0"
+version = "57.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3aa9e59c611ebc291c28582077ef25c97f1975383f1479b12f3b9ffee2ffabe"
+checksum = "6bb63203e8e0e54b288d0d8043ca8fa1013820822a27692ef1b78a977d879f2c"
 dependencies = [
  "bitflags",
- "serde",
+ "serde_core",
  "serde_json",
 ]
 
 [[package]]
 name = "arrow-select"
-version = "56.2.0"
+version = "57.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c41dbbd1e97bfcaee4fcb30e29105fb2c75e4d82ae4de70b792a5d3f66b2e7a"
+checksum = "c96d8a1c180b44ecf2e66c9a2f2bbcb8b1b6f14e165ce46ac8bde211a363411b"
 dependencies = [
  "ahash",
  "arrow-array",
  "arrow-buffer",
  "arrow-data",
  "arrow-schema",
- "num",
+ "num-traits",
 ]
 
 [[package]]
 name = "arrow-string"
-version = "56.2.0"
+version = "57.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53f5183c150fbc619eede22b861ea7c0eebed8eaac0333eaa7f6da5205fd504d"
+checksum = "a8ad6a81add9d3ea30bf8374ee8329992c7fd246ffd8b7e2f48a3cea5aa0cc9a"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -317,7 +324,7 @@ dependencies = [
  "arrow-schema",
  "arrow-select",
  "memchr",
- "num",
+ "num-traits",
  "regex",
  "regex-syntax 0.8.8",
 ]
@@ -816,7 +823,7 @@ dependencies = [
  "bitflags",
  "cexpr",
  "clang-sys",
- "itertools 0.12.1",
+ "itertools 0.11.0",
  "lazy_static",
  "lazycell",
  "log",
@@ -1353,12 +1360,11 @@ dependencies = [
 
 [[package]]
 name = "datafusion"
-version = "50.3.0"
+version = "51.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2af15bb3c6ffa33011ef579f6b0bcbe7c26584688bd6c994f548e44df67f011a"
+checksum = "8ba7cb113e9c0bedf9e9765926031e132fa05a1b09ba6e93a6d1a4d7044457b8"
 dependencies = [
  "arrow",
- "arrow-ipc",
  "arrow-schema",
  "async-trait",
  "bytes",
@@ -1369,6 +1375,7 @@ dependencies = [
  "datafusion-common",
  "datafusion-common-runtime",
  "datafusion-datasource",
+ "datafusion-datasource-arrow",
  "datafusion-datasource-csv",
  "datafusion-datasource-json",
  "datafusion-datasource-parquet",
@@ -1397,6 +1404,7 @@ dependencies = [
  "parquet",
  "rand 0.9.2",
  "regex",
+ "rstest",
  "sqlparser",
  "tempfile",
  "tokio",
@@ -1408,9 +1416,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-catalog"
-version = "50.3.0"
+version = "51.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "187622262ad8f7d16d3be9202b4c1e0116f1c9aa387e5074245538b755261621"
+checksum = "66a3a799f914a59b1ea343906a0486f17061f39509af74e874a866428951130d"
 dependencies = [
  "arrow",
  "async-trait",
@@ -1423,7 +1431,6 @@ dependencies = [
  "datafusion-physical-expr",
  "datafusion-physical-plan",
  "datafusion-session",
- "datafusion-sql",
  "futures",
  "itertools 0.14.0",
  "log",
@@ -1434,9 +1441,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-catalog-listing"
-version = "50.3.0"
+version = "51.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9657314f0a32efd0382b9a46fdeb2d233273ece64baa68a7c45f5a192daf0f83"
+checksum = "6db1b113c80d7a0febcd901476a57aef378e717c54517a163ed51417d87621b0"
 dependencies = [
  "arrow",
  "async-trait",
@@ -1446,10 +1453,11 @@ dependencies = [
  "datafusion-execution",
  "datafusion-expr",
  "datafusion-physical-expr",
+ "datafusion-physical-expr-adapter",
  "datafusion-physical-expr-common",
  "datafusion-physical-plan",
- "datafusion-session",
  "futures",
+ "itertools 0.14.0",
  "log",
  "object_store",
  "tokio",
@@ -1457,14 +1465,13 @@ dependencies = [
 
 [[package]]
 name = "datafusion-common"
-version = "50.3.0"
+version = "51.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a83760d9a13122d025fbdb1d5d5aaf93dd9ada5e90ea229add92aa30898b2d1"
+checksum = "7c10f7659e96127d25e8366be7c8be4109595d6a2c3eac70421f380a7006a1b0"
 dependencies = [
  "ahash",
  "arrow",
  "arrow-ipc",
- "base64",
  "chrono",
  "half",
  "hashbrown 0.14.5",
@@ -1482,9 +1489,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-common-runtime"
-version = "50.3.0"
+version = "51.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b6234a6c7173fe5db1c6c35c01a12b2aa0f803a3007feee53483218817f8b1e"
+checksum = "b92065bbc6532c6651e2f7dd30b55cba0c7a14f860c7e1d15f165c41a1868d95"
 dependencies = [
  "futures",
  "log",
@@ -1493,9 +1500,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-datasource"
-version = "50.3.0"
+version = "51.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7256c9cb27a78709dd42d0c80f0178494637209cac6e29d5c93edd09b6721b86"
+checksum = "fde13794244bc7581cd82f6fff217068ed79cdc344cafe4ab2c3a1c3510b38d6"
 dependencies = [
  "arrow",
  "async-compression",
@@ -1518,9 +1525,7 @@ dependencies = [
  "itertools 0.14.0",
  "log",
  "object_store",
- "parquet",
  "rand 0.9.2",
- "tempfile",
  "tokio",
  "tokio-util",
  "url",
@@ -1529,21 +1534,43 @@ dependencies = [
 ]
 
 [[package]]
-name = "datafusion-datasource-csv"
-version = "50.3.0"
+name = "datafusion-datasource-arrow"
+version = "51.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64533a90f78e1684bfb113d200b540f18f268134622d7c96bbebc91354d04825"
+checksum = "804fa9b4ecf3157982021770617200ef7c1b2979d57bec9044748314775a9aea"
 dependencies = [
  "arrow",
+ "arrow-ipc",
  "async-trait",
  "bytes",
- "datafusion-catalog",
  "datafusion-common",
  "datafusion-common-runtime",
  "datafusion-datasource",
  "datafusion-execution",
  "datafusion-expr",
- "datafusion-physical-expr",
+ "datafusion-physical-expr-common",
+ "datafusion-physical-plan",
+ "datafusion-session",
+ "futures",
+ "itertools 0.14.0",
+ "object_store",
+ "tokio",
+]
+
+[[package]]
+name = "datafusion-datasource-csv"
+version = "51.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61a1641a40b259bab38131c5e6f48fac0717bedb7dc93690e604142a849e0568"
+dependencies = [
+ "arrow",
+ "async-trait",
+ "bytes",
+ "datafusion-common",
+ "datafusion-common-runtime",
+ "datafusion-datasource",
+ "datafusion-execution",
+ "datafusion-expr",
  "datafusion-physical-expr-common",
  "datafusion-physical-plan",
  "datafusion-session",
@@ -1555,49 +1582,44 @@ dependencies = [
 
 [[package]]
 name = "datafusion-datasource-json"
-version = "50.3.0"
+version = "51.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d7ebeb12c77df0aacad26f21b0d033aeede423a64b2b352f53048a75bf1d6e6"
+checksum = "adeacdb00c1d37271176f8fb6a1d8ce096baba16ea7a4b2671840c5c9c64fe85"
 dependencies = [
  "arrow",
  "async-trait",
  "bytes",
- "datafusion-catalog",
  "datafusion-common",
  "datafusion-common-runtime",
  "datafusion-datasource",
  "datafusion-execution",
  "datafusion-expr",
- "datafusion-physical-expr",
  "datafusion-physical-expr-common",
  "datafusion-physical-plan",
  "datafusion-session",
  "futures",
  "object_store",
- "serde_json",
  "tokio",
 ]
 
 [[package]]
 name = "datafusion-datasource-parquet"
-version = "50.3.0"
+version = "51.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09e783c4c7d7faa1199af2df4761c68530634521b176a8d1331ddbc5a5c75133"
+checksum = "43d0b60ffd66f28bfb026565d62b0a6cbc416da09814766a3797bba7d85a3cd9"
 dependencies = [
  "arrow",
  "async-trait",
  "bytes",
- "datafusion-catalog",
  "datafusion-common",
  "datafusion-common-runtime",
  "datafusion-datasource",
  "datafusion-execution",
  "datafusion-expr",
- "datafusion-functions-aggregate",
+ "datafusion-functions-aggregate-common",
  "datafusion-physical-expr",
  "datafusion-physical-expr-adapter",
  "datafusion-physical-expr-common",
- "datafusion-physical-optimizer",
  "datafusion-physical-plan",
  "datafusion-pruning",
  "datafusion-session",
@@ -1607,21 +1629,20 @@ dependencies = [
  "object_store",
  "parking_lot",
  "parquet",
- "rand 0.9.2",
  "tokio",
 ]
 
 [[package]]
 name = "datafusion-doc"
-version = "50.3.0"
+version = "51.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99ee6b1d9a80d13f9deb2291f45c07044b8e62fb540dbde2453a18be17a36429"
+checksum = "2b99e13947667b36ad713549237362afb054b2d8f8cc447751e23ec61202db07"
 
 [[package]]
 name = "datafusion-execution"
-version = "50.3.0"
+version = "51.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4cec0a57653bec7b933fb248d3ffa3fa3ab3bd33bd140dc917f714ac036f531"
+checksum = "63695643190679037bc946ad46a263b62016931547bf119859c511f7ff2f5178"
 dependencies = [
  "arrow",
  "async-trait",
@@ -1639,9 +1660,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-expr"
-version = "50.3.0"
+version = "51.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef76910bdca909722586389156d0aa4da4020e1631994d50fadd8ad4b1aa05fe"
+checksum = "f9a4787cbf5feb1ab351f789063398f67654a6df75c4d37d7f637dc96f951a91"
 dependencies = [
  "arrow",
  "async-trait",
@@ -1653,6 +1674,7 @@ dependencies = [
  "datafusion-functions-window-common",
  "datafusion-physical-expr-common",
  "indexmap",
+ "itertools 0.14.0",
  "paste",
  "recursive",
  "serde_json",
@@ -1661,9 +1683,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-expr-common"
-version = "50.3.0"
+version = "51.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d155ccbda29591ca71a1344dd6bed26c65a4438072b400df9db59447f590bb6"
+checksum = "5ce2fb1b8c15c9ac45b0863c30b268c69dc9ee7a1ee13ecf5d067738338173dc"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -1674,9 +1696,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-functions"
-version = "50.3.0"
+version = "51.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7de2782136bd6014670fd84fe3b0ca3b3e4106c96403c3ae05c0598577139977"
+checksum = "794a9db7f7b96b3346fc007ff25e994f09b8f0511b4cf7dff651fadfe3ebb28f"
 dependencies = [
  "arrow",
  "arrow-buffer",
@@ -1694,6 +1716,7 @@ dependencies = [
  "itertools 0.14.0",
  "log",
  "md-5",
+ "num-traits",
  "rand 0.9.2",
  "regex",
  "sha2",
@@ -1703,9 +1726,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-functions-aggregate"
-version = "50.3.0"
+version = "51.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07331fc13603a9da97b74fd8a273f4238222943dffdbbed1c4c6f862a30105bf"
+checksum = "1c25210520a9dcf9c2b2cbbce31ebd4131ef5af7fc60ee92b266dc7d159cb305"
 dependencies = [
  "ahash",
  "arrow",
@@ -1724,9 +1747,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-functions-aggregate-common"
-version = "50.3.0"
+version = "51.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5951e572a8610b89968a09b5420515a121fbc305c0258651f318dc07c97ab17"
+checksum = "62f4a66f3b87300bb70f4124b55434d2ae3fe80455f3574701d0348da040b55d"
 dependencies = [
  "ahash",
  "arrow",
@@ -1737,9 +1760,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-functions-nested"
-version = "50.3.0"
+version = "51.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdacca9302c3d8fc03f3e94f338767e786a88a33f5ebad6ffc0e7b50364b9ea3"
+checksum = "ae5c06eed03918dc7fe7a9f082a284050f0e9ecf95d72f57712d1496da03b8c4"
 dependencies = [
  "arrow",
  "arrow-ord",
@@ -1747,6 +1770,7 @@ dependencies = [
  "datafusion-doc",
  "datafusion-execution",
  "datafusion-expr",
+ "datafusion-expr-common",
  "datafusion-functions",
  "datafusion-functions-aggregate",
  "datafusion-functions-aggregate-common",
@@ -1759,9 +1783,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-functions-table"
-version = "50.3.0"
+version = "51.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c37ff8a99434fbbad604a7e0669717c58c7c4f14c472d45067c4b016621d981"
+checksum = "db4fed1d71738fbe22e2712d71396db04c25de4111f1ec252b8f4c6d3b25d7f5"
 dependencies = [
  "arrow",
  "async-trait",
@@ -1775,9 +1799,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-functions-window"
-version = "50.3.0"
+version = "51.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48e2aea7c79c926cffabb13dc27309d4eaeb130f4a21c8ba91cdd241c813652b"
+checksum = "1d92206aa5ae21892f1552b4d61758a862a70956e6fd7a95cb85db1de74bc6d1"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -1793,9 +1817,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-functions-window-common"
-version = "50.3.0"
+version = "51.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fead257ab5fd2ffc3b40fda64da307e20de0040fe43d49197241d9de82a487f"
+checksum = "53ae9bcc39800820d53a22d758b3b8726ff84a5a3e24cecef04ef4e5fdf1c7cc"
 dependencies = [
  "datafusion-common",
  "datafusion-physical-expr-common",
@@ -1803,20 +1827,20 @@ dependencies = [
 
 [[package]]
 name = "datafusion-macros"
-version = "50.3.0"
+version = "51.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec6f637bce95efac05cdfb9b6c19579ed4aa5f6b94d951cfa5bb054b7bb4f730"
+checksum = "1063ad4c9e094b3f798acee16d9a47bd7372d9699be2de21b05c3bd3f34ab848"
 dependencies = [
- "datafusion-expr",
+ "datafusion-doc",
  "quote",
  "syn 2.0.111",
 ]
 
 [[package]]
 name = "datafusion-optimizer"
-version = "50.3.0"
+version = "51.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6583ef666ae000a613a837e69e456681a9faa96347bf3877661e9e89e141d8a"
+checksum = "9f35f9ec5d08b87fd1893a30c2929f2559c2f9806ca072d8fefca5009dc0f06a"
 dependencies = [
  "arrow",
  "chrono",
@@ -1834,9 +1858,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-physical-expr"
-version = "50.3.0"
+version = "51.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8668103361a272cbbe3a61f72eca60c9b7c706e87cc3565bcf21e2b277b84f6"
+checksum = "c30cc8012e9eedcb48bbe112c6eff4ae5ed19cf3003cb0f505662e88b7014c5d"
 dependencies = [
  "ahash",
  "arrow",
@@ -1849,17 +1873,16 @@ dependencies = [
  "hashbrown 0.14.5",
  "indexmap",
  "itertools 0.14.0",
- "log",
  "parking_lot",
  "paste",
- "petgraph 0.8.2",
+ "petgraph",
 ]
 
 [[package]]
 name = "datafusion-physical-expr-adapter"
-version = "50.3.0"
+version = "51.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "815acced725d30601b397e39958e0e55630e0a10d66ef7769c14ae6597298bb0"
+checksum = "7f9ff2dbd476221b1f67337699eff432781c4e6e1713d2aefdaa517dfbf79768"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -1872,9 +1895,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-physical-expr-common"
-version = "50.3.0"
+version = "51.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6652fe7b5bf87e85ed175f571745305565da2c0b599d98e697bcbedc7baa47c3"
+checksum = "90da43e1ec550b172f34c87ec68161986ced70fd05c8d2a2add66eef9c276f03"
 dependencies = [
  "ahash",
  "arrow",
@@ -1886,9 +1909,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-physical-optimizer"
-version = "50.3.0"
+version = "51.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49b7d623eb6162a3332b564a0907ba00895c505d101b99af78345f1acf929b5c"
+checksum = "ce9804f799acd7daef3be7aaffe77c0033768ed8fdbf5fb82fc4c5f2e6bc14e6"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -1900,15 +1923,14 @@ dependencies = [
  "datafusion-physical-plan",
  "datafusion-pruning",
  "itertools 0.14.0",
- "log",
  "recursive",
 ]
 
 [[package]]
 name = "datafusion-physical-plan"
-version = "50.3.0"
+version = "51.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2f7f778a1a838dec124efb96eae6144237d546945587557c9e6936b3414558c"
+checksum = "0acf0ad6b6924c6b1aa7d213b181e012e2d3ec0a64ff5b10ee6282ab0f8532ac"
 dependencies = [
  "ahash",
  "arrow",
@@ -1937,12 +1959,11 @@ dependencies = [
 
 [[package]]
 name = "datafusion-pruning"
-version = "50.3.0"
+version = "51.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd1e59e2ca14fe3c30f141600b10ad8815e2856caa59ebbd0e3e07cd3d127a65"
+checksum = "ac2c2498a1f134a9e11a9f5ed202a2a7d7e9774bd9249295593053ea3be999db"
 dependencies = [
  "arrow",
- "arrow-schema",
  "datafusion-common",
  "datafusion-datasource",
  "datafusion-expr-common",
@@ -1955,36 +1976,27 @@ dependencies = [
 
 [[package]]
 name = "datafusion-session"
-version = "50.3.0"
+version = "51.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21ef8e2745583619bd7a49474e8f45fbe98ebb31a133f27802217125a7b3d58d"
+checksum = "8f96eebd17555386f459037c65ab73aae8df09f464524c709d6a3134ad4f4776"
 dependencies = [
- "arrow",
  "async-trait",
- "dashmap",
  "datafusion-common",
- "datafusion-common-runtime",
  "datafusion-execution",
  "datafusion-expr",
- "datafusion-physical-expr",
  "datafusion-physical-plan",
- "datafusion-sql",
- "futures",
- "itertools 0.14.0",
- "log",
- "object_store",
  "parking_lot",
- "tokio",
 ]
 
 [[package]]
 name = "datafusion-sql"
-version = "50.3.0"
+version = "51.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89abd9868770386fede29e5a4b14f49c0bf48d652c3b9d7a8a0332329b87d50b"
+checksum = "3fc195fe60634b2c6ccfd131b487de46dc30eccae8a3c35a13f136e7f440414f"
 dependencies = [
  "arrow",
  "bigdecimal",
+ "chrono",
  "datafusion-common",
  "datafusion-expr",
  "indexmap",
@@ -2258,9 +2270,8 @@ checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "fsst"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33c3b76530d0755759d6537bdb19b849b2b108b9013a379be1be6036d2cd210c"
+version = "2.0.0-rc.4"
+source = "git+https://github.com/lance-format/lance?tag=v2.0.0-rc.4#584c470f69334600cae384f1ac30bf13f8a6959a"
 dependencies = [
  "arrow-array",
  "rand 0.9.2",
@@ -2353,6 +2364,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
 
 [[package]]
+name = "futures-timer"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f288b0a4f20f9a56b5d1da57e2227c661b7b16168e2f72365f57b63326e29b24"
+
+[[package]]
 name = "futures-util"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2436,9 +2453,9 @@ dependencies = [
 
 [[package]]
 name = "geoarrow-array"
-version = "0.6.2"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d1884b17253d8572e88833c282fcbb442365e4ae5f9052ced2831608253436c"
+checksum = "dc1cc4106ac0a0a512c398961ce95d8150475c84a84e17c4511c3643fa120a17"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -2452,9 +2469,9 @@ dependencies = [
 
 [[package]]
 name = "geoarrow-expr-geo"
-version = "0.6.2"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a67d3b543bc3ebeffdc204b67d69b8f9fcd33d76269ddd4a4618df99f053a934"
+checksum = "fa84300361ce57fb875bcaa6e32b95b0aff5c6b1af692b936bdd58ff343f4394"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -2466,9 +2483,9 @@ dependencies = [
 
 [[package]]
 name = "geoarrow-schema"
-version = "0.6.2"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02f1b18b1c9a44ecd72be02e53d6e63bbccfdc8d1765206226af227327e2be6e"
+checksum = "e97be4e9f523f92bd6a0e0458323f4b783d073d011664decd8dbf05651704f34"
 dependencies = [
  "arrow-schema",
  "geo-traits",
@@ -2479,9 +2496,9 @@ dependencies = [
 
 [[package]]
 name = "geodatafusion"
-version = "0.1.1"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83d676b8d8b5f391ab4270ba31e9b599ee2c3d780405a38e272a0a7565ea189c"
+checksum = "773cfa1fb0d7f7661b76b3fde00f3ffd8e0ff7b3635096f0ff6294fe5ca62a2b"
 dependencies = [
  "arrow-arith",
  "arrow-array",
@@ -2582,13 +2599,14 @@ dependencies = [
 
 [[package]]
 name = "half"
-version = "2.6.0"
+version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "459196ed295495a68f7d7fe1d84f6c4b7ff0e21fe3017b2f283c6fac3ad803c9"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
 dependencies = [
  "cfg-if",
  "crunchy",
  "num-traits",
+ "zerocopy",
 ]
 
 [[package]]
@@ -3051,15 +3069,6 @@ dependencies = [
 
 [[package]]
 name = "itertools"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
-dependencies = [
- "either",
-]
-
-[[package]]
-name = "itertools"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
@@ -3180,9 +3189,8 @@ dependencies = [
 
 [[package]]
 name = "lance"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "993c0199f4c8291dec6e545a523d2ac97875f455bf6f27b8e60504a68c7654d3"
+version = "2.0.0-rc.4"
+source = "git+https://github.com/lance-format/lance?tag=v2.0.0-rc.4#584c470f69334600cae384f1ac30bf13f8a6959a"
 dependencies = [
  "arrow",
  "arrow-arith",
@@ -3246,14 +3254,14 @@ dependencies = [
 
 [[package]]
 name = "lance-arrow"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "590272235088a62bf7fb7d3b13820af76c0d9092a6cffab8989e93c628fc8451"
+version = "2.0.0-rc.4"
+source = "git+https://github.com/lance-format/lance?tag=v2.0.0-rc.4#584c470f69334600cae384f1ac30bf13f8a6959a"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
  "arrow-cast",
  "arrow-data",
+ "arrow-ord",
  "arrow-schema",
  "arrow-select",
  "bytes",
@@ -3266,9 +3274,8 @@ dependencies = [
 
 [[package]]
 name = "lance-bitpacking"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75a1e0c990610227ec0d048f4c2cda80d7474de5c63498694a90408d62dcac32"
+version = "2.0.0-rc.4"
+source = "git+https://github.com/lance-format/lance?tag=v2.0.0-rc.4#584c470f69334600cae384f1ac30bf13f8a6959a"
 dependencies = [
  "arrayref",
  "paste",
@@ -3277,9 +3284,8 @@ dependencies = [
 
 [[package]]
 name = "lance-core"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea4a8f6f2c25f6a74f460a58caecce62a288abaad9172c199e1ec3c004e5d74e"
+version = "2.0.0-rc.4"
+source = "git+https://github.com/lance-format/lance?tag=v2.0.0-rc.4#584c470f69334600cae384f1ac30bf13f8a6959a"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -3292,6 +3298,7 @@ dependencies = [
  "datafusion-sql",
  "deepsize",
  "futures",
+ "itertools 0.13.0",
  "lance-arrow",
  "libc",
  "log",
@@ -3315,9 +3322,8 @@ dependencies = [
 
 [[package]]
 name = "lance-datafusion"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cc44f88d68610cc7df1308cd852ba1ae5c341ac6132a9fce1873843957c2985"
+version = "2.0.0-rc.4"
+source = "git+https://github.com/lance-format/lance?tag=v2.0.0-rc.4#584c470f69334600cae384f1ac30bf13f8a6959a"
 dependencies = [
  "arrow",
  "arrow-array",
@@ -3347,9 +3353,8 @@ dependencies = [
 
 [[package]]
 name = "lance-datagen"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fef9a3d6436f234e98a5e8cbb292fdce0d78febea152d738117d3d70f86cbb58"
+version = "2.0.0-rc.4"
+source = "git+https://github.com/lance-format/lance?tag=v2.0.0-rc.4#584c470f69334600cae384f1ac30bf13f8a6959a"
 dependencies = [
  "arrow",
  "arrow-array",
@@ -3360,15 +3365,15 @@ dependencies = [
  "half",
  "hex",
  "rand 0.9.2",
+ "rand_distr 0.5.1",
  "rand_xoshiro",
  "random_word",
 ]
 
 [[package]]
 name = "lance-encoding"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31f32004e88abb4819d6d6386cf26e3dfc2258d4e3d0b2748364fb279b6787a6"
+version = "2.0.0-rc.4"
+source = "git+https://github.com/lance-format/lance?tag=v2.0.0-rc.4#584c470f69334600cae384f1ac30bf13f8a6959a"
 dependencies = [
  "arrow-arith",
  "arrow-array",
@@ -3405,9 +3410,8 @@ dependencies = [
 
 [[package]]
 name = "lance-file"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d261cb07db8aac64b8926e61cef73caf6d0aa3bd49e9fc8401eff1768fb9aa0"
+version = "2.0.0-rc.4"
+source = "git+https://github.com/lance-format/lance?tag=v2.0.0-rc.4#584c470f69334600cae384f1ac30bf13f8a6959a"
 dependencies = [
  "arrow-arith",
  "arrow-array",
@@ -3439,22 +3443,23 @@ dependencies = [
 
 [[package]]
 name = "lance-geo"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5144f9f1ce0faaac0c791df55d5c9a0945a2a48489f108e12915f8e0b9e7ce2f"
+version = "2.0.0-rc.4"
+source = "git+https://github.com/lance-format/lance?tag=v2.0.0-rc.4#584c470f69334600cae384f1ac30bf13f8a6959a"
 dependencies = [
  "datafusion",
+ "geo-traits",
  "geo-types",
  "geoarrow-array",
  "geoarrow-schema",
  "geodatafusion",
+ "lance-core",
+ "serde",
 ]
 
 [[package]]
 name = "lance-index"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30dfdff485125e321f411f17a12a7878ef51234554237a2f416a1f8988a0a403"
+version = "2.0.0-rc.4"
+source = "git+https://github.com/lance-format/lance?tag=v2.0.0-rc.4#584c470f69334600cae384f1ac30bf13f8a6959a"
 dependencies = [
  "arrow",
  "arrow-arith",
@@ -3478,6 +3483,9 @@ dependencies = [
  "dirs",
  "fst",
  "futures",
+ "geo-types",
+ "geoarrow-array",
+ "geoarrow-schema",
  "half",
  "itertools 0.13.0",
  "jsonb",
@@ -3487,6 +3495,7 @@ dependencies = [
  "lance-datagen",
  "lance-encoding",
  "lance-file",
+ "lance-geo",
  "lance-io",
  "lance-linalg",
  "lance-table",
@@ -3500,10 +3509,12 @@ dependencies = [
  "prost-types",
  "rand 0.9.2",
  "rand_distr 0.5.1",
+ "rangemap",
  "rayon",
  "roaring",
  "serde",
  "serde_json",
+ "smallvec",
  "snafu",
  "tantivy",
  "tempfile",
@@ -3515,9 +3526,8 @@ dependencies = [
 
 [[package]]
 name = "lance-io"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b44d19e7ee99c3cdb417785ded67bac1fd8a9c9cbd9d1751fba0348294e6f3f"
+version = "2.0.0-rc.4"
+source = "git+https://github.com/lance-format/lance?tag=v2.0.0-rc.4#584c470f69334600cae384f1ac30bf13f8a6959a"
 dependencies = [
  "arrow",
  "arrow-arith",
@@ -3557,9 +3567,8 @@ dependencies = [
 
 [[package]]
 name = "lance-linalg"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28e275333cfcd97cabfe7bbd77bad4df48a324499ebdf6c05febeef050efc685"
+version = "2.0.0-rc.4"
+source = "git+https://github.com/lance-format/lance?tag=v2.0.0-rc.4#584c470f69334600cae384f1ac30bf13f8a6959a"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -3575,9 +3584,8 @@ dependencies = [
 
 [[package]]
 name = "lance-namespace"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb58614e43573a083ca6425a3f22e20c67ce69d3259428b9cda25bc8b68ccc69"
+version = "2.0.0-rc.4"
+source = "git+https://github.com/lance-format/lance?tag=v2.0.0-rc.4#584c470f69334600cae384f1ac30bf13f8a6959a"
 dependencies = [
  "arrow",
  "async-trait",
@@ -3589,15 +3597,15 @@ dependencies = [
 
 [[package]]
 name = "lance-namespace-impls"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf12e121a4b69dc511a22cba8206639b134879ba89d5f945c2ffa8c208aa61cc"
+version = "2.0.0-rc.4"
+source = "git+https://github.com/lance-format/lance?tag=v2.0.0-rc.4#584c470f69334600cae384f1ac30bf13f8a6959a"
 dependencies = [
  "arrow",
  "arrow-ipc",
  "arrow-schema",
  "async-trait",
  "bytes",
+ "chrono",
  "futures",
  "lance",
  "lance-core",
@@ -3608,6 +3616,7 @@ dependencies = [
  "object_store",
  "rand 0.9.2",
  "reqwest",
+ "serde",
  "serde_json",
  "snafu",
  "tokio",
@@ -3616,9 +3625,9 @@ dependencies = [
 
 [[package]]
 name = "lance-namespace-reqwest-client"
-version = "0.0.18"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ea349999bcda4eea53fc05d334b3775ec314761e6a706555c777d7a29b18d19"
+checksum = "a2acdba67f84190067532fce07b51a435dd390d7cdc1129a05003e5cb3274cf0"
 dependencies = [
  "reqwest",
  "serde",
@@ -3629,9 +3638,8 @@ dependencies = [
 
 [[package]]
 name = "lance-table"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ef592598d62f12b11117a937859d180e4e46df85643988300e6a7bca44a714f"
+version = "2.0.0-rc.4"
+source = "git+https://github.com/lance-format/lance?tag=v2.0.0-rc.4#584c470f69334600cae384f1ac30bf13f8a6959a"
 dependencies = [
  "arrow",
  "arrow-array",
@@ -3916,6 +3924,12 @@ name = "lz4_flex"
 version = "0.11.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08ab2867e3eeeca90e844d1940eab391c9dc5228783db2ed999acbc0a9ed375a"
+
+[[package]]
+name = "lz4_flex"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab6473172471198271ff72e9379150e9dfd70d8e533e0752a27e515b48dd375e"
 dependencies = [
  "twox-hash",
 ]
@@ -4115,20 +4129,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "num"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35bd024e8b2ff75562e5f34e7f4905839deb4b22955ef5e73d2fea1b9813cb23"
-dependencies = [
- "num-bigint",
- "num-complex",
- "num-integer",
- "num-iter",
- "num-rational",
- "num-traits",
-]
-
-[[package]]
 name = "num-bigint"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4190,17 +4190,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "num-rational"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
-dependencies = [
- "num-bigint",
- "num-integer",
- "num-traits",
-]
-
-[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4244,9 +4233,9 @@ dependencies = [
 
 [[package]]
 name = "object_store"
-version = "0.12.3"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efc4f07659e11cd45a341cd24d71e683e3be65d9ff1f8150061678fe60437496"
+checksum = "fbfbfff40aeccab00ec8a910b57ca8ecf4319b335c542f2edcd19dd25a1e2a00"
 dependencies = [
  "async-trait",
  "base64",
@@ -4430,9 +4419,9 @@ dependencies = [
 
 [[package]]
 name = "parquet"
-version = "56.2.0"
+version = "57.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0dbd48ad52d7dccf8ea1b90a3ddbfaea4f69878dd7683e51c507d4bc52b5b27"
+checksum = "5f6a2926a30477c0b95fea6c28c3072712b139337a242c2cc64817bdc20a8854"
 dependencies = [
  "ahash",
  "arrow-array",
@@ -4450,12 +4439,12 @@ dependencies = [
  "futures",
  "half",
  "hashbrown 0.16.1",
- "lz4_flex",
- "num",
+ "lz4_flex 0.12.0",
  "num-bigint",
+ "num-integer",
+ "num-traits",
  "object_store",
  "paste",
- "ring",
  "seq-macro",
  "simdutf8",
  "snap",
@@ -4526,19 +4515,9 @@ checksum = "df202b0b0f5b8e389955afd5f27b007b00fb948162953f1db9c70d2c7e3157d7"
 
 [[package]]
 name = "petgraph"
-version = "0.7.1"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3672b37090dbd86368a4145bc067582552b29c27377cad4e0a306c97f9bd7772"
-dependencies = [
- "fixedbitset",
- "indexmap",
-]
-
-[[package]]
-name = "petgraph"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54acf3a685220b533e437e264e4d932cfbdc4cc7ec0cd232ed73c08d03b8a7ca"
+checksum = "8701b58ea97060d5e5b155d383a69952a60943f0e6dfe30b04c287beb0b27455"
 dependencies = [
  "fixedbitset",
  "hashbrown 0.15.5",
@@ -4709,9 +4688,9 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.13.5"
+version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2796faa41db3ec313a31f7624d9286acf277b52de526150b7e69f3debf891ee5"
+checksum = "d2ea70524a2f82d518bce41317d0fae74151505651af45faf1ffbd6fd33f0568"
 dependencies = [
  "bytes",
  "prost-derive",
@@ -4719,16 +4698,15 @@ dependencies = [
 
 [[package]]
 name = "prost-build"
-version = "0.13.5"
+version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
+checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
 dependencies = [
  "heck",
- "itertools 0.14.0",
+ "itertools 0.11.0",
  "log",
  "multimap",
- "once_cell",
- "petgraph 0.7.1",
+ "petgraph",
  "prettyplease",
  "prost",
  "prost-types",
@@ -4739,12 +4717,12 @@ dependencies = [
 
 [[package]]
 name = "prost-derive"
-version = "0.13.5"
+version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
+checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.11.0",
  "proc-macro2",
  "quote",
  "syn 2.0.111",
@@ -4752,9 +4730,9 @@ dependencies = [
 
 [[package]]
 name = "prost-types"
-version = "0.13.5"
+version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52c2c1bf36ddb1a1c396b3601a3cec27c2462e45f07c386894ec3ccf5332bd16"
+checksum = "8991c4cbdb8bc5b11f0b074ffe286c30e523de90fee5ba8132f1399f23cb3dd7"
 dependencies = [
  "prost",
 ]
@@ -4845,9 +4823,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.40"
+version = "1.0.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
+checksum = "21b2ebcf727b7760c461f091f9f0f539b77b8e87f2fd88131e7f1b433b3cece4"
 dependencies = [
  "proc-macro2",
 ]
@@ -5040,13 +5018,13 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.11.1"
+version = "1.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
+checksum = "843bc0191f75f3e22651ae5f1e72939ab2f72a4bc30fa80a066bd66edefc24d4"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata 0.4.9",
+ "regex-automata 0.4.13",
  "regex-syntax 0.8.8",
 ]
 
@@ -5061,9 +5039,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.9"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
+checksum = "5276caf25ac86c8d810222b3dbb938e512c55c6831a10f3e6ed1c93b84041f1c"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -5087,6 +5065,12 @@ name = "regex-syntax"
 version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
+
+[[package]]
+name = "relative-path"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba39f3699c378cd8970968dcbff9c43159ea4cfbd88d43c00b22f2ef10a435d2"
 
 [[package]]
 name = "reqsign"
@@ -5226,6 +5210,35 @@ dependencies = [
  "heapless",
  "num-traits",
  "smallvec",
+]
+
+[[package]]
+name = "rstest"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5a3193c063baaa2a95a33f03035c8a72b83d97a54916055ba22d35ed3839d49"
+dependencies = [
+ "futures-timer",
+ "futures-util",
+ "rstest_macros",
+]
+
+[[package]]
+name = "rstest_macros"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c845311f0ff7951c5506121a9ad75aec44d083c31583b2ea5a30bcb0b0abba0"
+dependencies = [
+ "cfg-if",
+ "glob",
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "relative-path",
+ "rustc_version",
+ "syn 2.0.111",
+ "unicode-ident",
 ]
 
 [[package]]
@@ -5708,9 +5721,9 @@ dependencies = [
 
 [[package]]
 name = "sqlparser"
-version = "0.58.0"
+version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec4b661c54b1e4b603b37873a18c59920e4c51ea8ea2cf527d925424dbd4437c"
+checksum = "4591acadbcf52f0af60eafbb2c003232b2b4cd8de5f0e9437cb8b1b59046cc0f"
 dependencies = [
  "log",
  "recursive",
@@ -5872,7 +5885,7 @@ dependencies = [
  "levenshtein_automata",
  "log",
  "lru",
- "lz4_flex",
+ "lz4_flex 0.11.5",
  "measure_time",
  "memmap2",
  "once_cell",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,24 +19,24 @@ panic = "abort"
 [dependencies]
 
 # Lance and Arrow dependencies - using compatible versions
-lance = { version = "1.0.0", default-features = false, features = ["aws", "azure", "gcp", "oss", "huggingface"] }
-lance-arrow = "1.0.0"
-lance-core = "1.0.0"
-lance-index = "1.0.0"
-lance-linalg = "1.0.0"
-lance-namespace = "1.0.0"
-lance-namespace-impls = { version = "1.0.0", features = ["rest"] }
-lance-table = "1.0.0"
+lance = { version = "2.0.0-rc.4", default-features = false, features = ["aws", "azure", "gcp", "oss", "huggingface"] }
+lance-arrow = "2.0.0-rc.4"
+lance-core = "2.0.0-rc.4"
+lance-index = "2.0.0-rc.4"
+lance-linalg = "2.0.0-rc.4"
+lance-namespace = "2.0.0-rc.4"
+lance-namespace-impls = { version = "2.0.0-rc.4", features = ["rest"] }
+lance-table = "2.0.0-rc.4"
 
-arrow = { version = "56.2.0", features = ["ffi"] }
-arrow-array = "56.2.0"
-arrow-schema = "56.2.0"
+arrow = { version = "57.0.0", features = ["ffi"] }
+arrow-array = "57.0.0"
+arrow-schema = "57.0.0"
 
-datafusion = "50.3.0"
-datafusion-common = "50.3.0"
-datafusion-expr = "50.3.0"
-datafusion-functions = "50.3.0"
-datafusion-sql = "50.3.0"
+datafusion = "51.0.0"
+datafusion-common = "51.0.0"
+datafusion-expr = "51.0.0"
+datafusion-functions = "51.0.0"
+datafusion-sql = "51.0.0"
 
 anyhow = "1.0"
 async-trait = "0.1"
@@ -48,3 +48,13 @@ serde_json = "1.0"
 snafu = "0.8.6"
 tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
 rand = "0.8"
+
+[patch.crates-io]
+lance = { git = "https://github.com/lance-format/lance", tag = "v2.0.0-rc.4" }
+lance-arrow = { git = "https://github.com/lance-format/lance", tag = "v2.0.0-rc.4" }
+lance-core = { git = "https://github.com/lance-format/lance", tag = "v2.0.0-rc.4" }
+lance-index = { git = "https://github.com/lance-format/lance", tag = "v2.0.0-rc.4" }
+lance-linalg = { git = "https://github.com/lance-format/lance", tag = "v2.0.0-rc.4" }
+lance-namespace = { git = "https://github.com/lance-format/lance", tag = "v2.0.0-rc.4" }
+lance-namespace-impls = { git = "https://github.com/lance-format/lance", tag = "v2.0.0-rc.4" }
+lance-table = { git = "https://github.com/lance-format/lance", tag = "v2.0.0-rc.4" }

--- a/rust/exec_ir.rs
+++ b/rust/exec_ir.rs
@@ -348,10 +348,9 @@ pub fn output_type_to_arrow(hint: &OutputTypeHint) -> Result<arrow::datatypes::D
         OutputTypeHint::Date => Ok(DataType::Date32),
         OutputTypeHint::TimestampUs => Ok(DataType::Timestamp(TimeUnit::Microsecond, None)),
         OutputTypeHint::Utf8 => Ok(DataType::Utf8),
-        OutputTypeHint::Decimal { precision, scale } => Ok(DataType::Decimal128(
-            *precision as u8,
-            *scale as i8,
-        )),
+        OutputTypeHint::Decimal { precision, scale } => {
+            Ok(DataType::Decimal128(*precision as u8, *scale as i8))
+        }
     }
 }
 

--- a/rust/ffi/dataset.rs
+++ b/rust/ffi/dataset.rs
@@ -565,7 +565,7 @@ fn delete_transaction_with_storage_options_inner(
             .filter(&predicate)
             .map_err(|e| e.to_string())?;
 
-        let Some(filter_expr) = scanner.get_filter().map_err(|e| e.to_string())? else {
+        let Some(filter_expr) = scanner.get_expr_filter().map_err(|e| e.to_string())? else {
             return Ok::<_, String>((None, 0_i64));
         };
 

--- a/rust/ffi/exec.rs
+++ b/rust/ffi/exec.rs
@@ -5,11 +5,11 @@ use std::sync::Arc;
 use arrow::datatypes::{Field, Schema};
 use datafusion::catalog::TableProvider;
 use datafusion::dataframe::DataFrame;
+use datafusion::physical_plan::streaming::{PartitionStream, StreamingTableExec};
+use datafusion::physical_plan::SendableRecordBatchStream;
 use datafusion::prelude::SessionContext;
 use datafusion_common::{DataFusionError, Result as DFResult};
 use datafusion_expr::Expr;
-use datafusion::physical_plan::streaming::{PartitionStream, StreamingTableExec};
-use datafusion::physical_plan::SendableRecordBatchStream;
 use futures::StreamExt;
 
 use crate::error::{clear_last_error, set_last_error, ErrorCode};
@@ -40,8 +40,9 @@ impl PartitionStream for LanceExecPartition {
                 let stream = futures::stream::iter(vec![Err(DataFusionError::Execution(format!(
                     "runtime: {err}"
                 )))]);
-                let adapter =
-                    datafusion::physical_plan::stream::RecordBatchStreamAdapter::new(schema, stream);
+                let adapter = datafusion::physical_plan::stream::RecordBatchStreamAdapter::new(
+                    schema, stream,
+                );
                 return Box::pin(adapter);
             }
         };
@@ -219,8 +220,11 @@ async fn build_exec_df(handle: &DatasetHandle, exec_ir: &[u8]) -> Result<DataFra
         let name = agg.output_name.as_str();
         let expr = if let Some(hint) = &agg.output_type {
             let dtype = output_type_to_arrow(hint)?;
-            Expr::Cast(datafusion_expr::Cast::new(Box::new(datafusion::prelude::col(name)), dtype))
-                .alias(name)
+            Expr::Cast(datafusion_expr::Cast::new(
+                Box::new(datafusion::prelude::col(name)),
+                dtype,
+            ))
+            .alias(name)
         } else {
             datafusion::prelude::col(name)
         };
@@ -270,16 +274,13 @@ fn get_exec_schema_inner(
 
     let schema_res = runtime::block_on(async {
         let df = build_exec_df(&handle, bytes).await?;
-        let plan = df
-            .create_physical_plan()
-            .await
-            .map_err(|e| e.to_string())?;
+        let plan = df.create_physical_plan().await.map_err(|e| e.to_string())?;
         Ok::<_, String>(plan.schema())
     })
     .map_err(|e| FfiError::new(ErrorCode::Exec, format!("runtime: {e}")))?;
 
-    let schema = schema_res
-        .map_err(|e| FfiError::new(ErrorCode::Exec, format!("exec validate: {e}")))?;
+    let schema =
+        schema_res.map_err(|e| FfiError::new(ErrorCode::Exec, format!("exec validate: {e}")))?;
     Ok(Arc::new(Schema::new(schema.fields().clone())))
 }
 
@@ -315,8 +316,8 @@ fn create_dataset_exec_stream_ir_inner(
     })
     .map_err(|e| FfiError::new(ErrorCode::Exec, format!("runtime: {e}")))?;
 
-    let stream = stream_res
-        .map_err(|e| FfiError::new(ErrorCode::Exec, format!("exec stream: {e}")))?;
+    let stream =
+        stream_res.map_err(|e| FfiError::new(ErrorCode::Exec, format!("exec stream: {e}")))?;
 
     let df_stream = crate::datafusion_stream::DataFusionStream::try_new(stream)
         .map_err(|e| FfiError::new(ErrorCode::Exec, format!("runtime: {e}")))?;

--- a/rust/ffi/index.rs
+++ b/rust/ffi/index.rs
@@ -286,7 +286,7 @@ fn dataset_create_index_inner(
             }
             builder.replace(replace).train(train).await
         }) {
-            Ok(Ok(())) => Ok(()),
+            Ok(Ok(_)) => Ok(()),
             Ok(Err(err)) => Err(FfiError::new(
                 ErrorCode::DatasetCreateIndex,
                 format!("dataset create_index: {err}"),

--- a/rust/ffi/knn.rs
+++ b/rust/ffi/knn.rs
@@ -83,10 +83,7 @@ fn get_knn_schema_inner(
     }
     if refine_factor != 0 {
         let refine_factor_u32: u32 = refine_factor.try_into().map_err(|_| {
-            FfiError::new(
-                ErrorCode::InvalidArgument,
-                "refine_factor must fit in u32",
-            )
+            FfiError::new(ErrorCode::InvalidArgument, "refine_factor must fit in u32")
         })?;
         scan.refine(refine_factor_u32);
     }
@@ -194,10 +191,7 @@ fn create_knn_stream_ir_inner(
     }
     if refine_factor != 0 {
         let refine_factor_u32: u32 = refine_factor.try_into().map_err(|_| {
-            FfiError::new(
-                ErrorCode::InvalidArgument,
-                "refine_factor must fit in u32",
-            )
+            FfiError::new(ErrorCode::InvalidArgument, "refine_factor must fit in u32")
         })?;
         scan.refine(refine_factor_u32);
     }
@@ -310,10 +304,7 @@ fn explain_knn_scan_ir_inner(
     }
     if refine_factor != 0 {
         let refine_factor_u32: u32 = refine_factor.try_into().map_err(|_| {
-            FfiError::new(
-                ErrorCode::InvalidArgument,
-                "refine_factor must fit in u32",
-            )
+            FfiError::new(ErrorCode::InvalidArgument, "refine_factor must fit in u32")
         })?;
         scan.refine(refine_factor_u32);
     }

--- a/rust/ffi/namespace.rs
+++ b/rust/ffi/namespace.rs
@@ -145,7 +145,14 @@ pub unsafe extern "C" fn lance_namespace_list_tables(
     delimiter: *const c_char,
     headers_tsv: *const c_char,
 ) -> *const c_char {
-    match list_tables_inner(endpoint, namespace_id, bearer_token, api_key, delimiter, headers_tsv) {
+    match list_tables_inner(
+        endpoint,
+        namespace_id,
+        bearer_token,
+        api_key,
+        delimiter,
+        headers_tsv,
+    ) {
         Ok(tables) => {
             clear_last_error();
             let joined = tables.join("\n");
@@ -228,7 +235,14 @@ pub unsafe extern "C" fn lance_namespace_describe_table(
         }
     }
 
-    match describe_table_info_inner(endpoint, table_id, bearer_token, api_key, delimiter, headers_tsv) {
+    match describe_table_info_inner(
+        endpoint,
+        table_id,
+        bearer_token,
+        api_key,
+        delimiter,
+        headers_tsv,
+    ) {
         Ok((location, storage_options_tsv)) => {
             clear_last_error();
             if !out_location.is_null() {
@@ -326,7 +340,14 @@ pub unsafe extern "C" fn lance_namespace_create_empty_table(
         }
     }
 
-    match create_empty_table_inner(endpoint, table_id, bearer_token, api_key, delimiter, headers_tsv) {
+    match create_empty_table_inner(
+        endpoint,
+        table_id,
+        bearer_token,
+        api_key,
+        delimiter,
+        headers_tsv,
+    ) {
         Ok((location, storage_options_tsv)) => {
             clear_last_error();
             if !out_location.is_null() {
@@ -403,7 +424,14 @@ pub unsafe extern "C" fn lance_namespace_drop_table(
     delimiter: *const c_char,
     headers_tsv: *const c_char,
 ) -> i32 {
-    match drop_table_inner(endpoint, table_id, bearer_token, api_key, delimiter, headers_tsv) {
+    match drop_table_inner(
+        endpoint,
+        table_id,
+        bearer_token,
+        api_key,
+        delimiter,
+        headers_tsv,
+    ) {
         Ok(()) => {
             clear_last_error();
             0
@@ -491,7 +519,14 @@ pub unsafe extern "C" fn lance_open_dataset_in_namespace(
         }
     }
 
-    match open_dataset_in_namespace_inner(endpoint, table_id, bearer_token, api_key, delimiter, headers_tsv) {
+    match open_dataset_in_namespace_inner(
+        endpoint,
+        table_id,
+        bearer_token,
+        api_key,
+        delimiter,
+        headers_tsv,
+    ) {
         Ok((handle, table_uri)) => {
             clear_last_error();
             if !out_table_uri.is_null() {

--- a/rust/ffi/schema_evolution.rs
+++ b/rust/ffi/schema_evolution.rs
@@ -873,7 +873,7 @@ fn dataset_create_scalar_index_inner(
         &ScalarIndexParams::default(),
         replace,
     )) {
-        Ok(Ok(())) => Ok(()),
+        Ok(Ok(_)) => Ok(()),
         Ok(Err(err)) => Err(FfiError::new(
             ErrorCode::DatasetCreateScalarIndex,
             format!("dataset create_index(scalar): {err}"),

--- a/rust/ffi/update.rs
+++ b/rust/ffi/update.rs
@@ -14,7 +14,7 @@ use futures::{StreamExt, TryStreamExt};
 use lance::dataset::transaction::{Operation, Transaction, UpdateMode};
 use lance::dataset::{InsertBuilder, WriteMode, WriteParams};
 use lance::io::exec::Planner;
-use lance::io::ObjectStoreParams;
+use lance::io::{ObjectStoreParams, StorageOptionsAccessor};
 use lance_arrow::RecordBatchExt;
 use lance_core::utils::deletion::DeletionVector;
 use lance_core::ROW_ID;
@@ -255,7 +255,9 @@ fn rewrite_rows_update_transaction_inner(
 
     let mut store_params = ObjectStoreParams::default();
     if !storage_options.is_empty() {
-        store_params.storage_options = Some(storage_options.clone());
+        store_params.storage_options_accessor = Some(Arc::new(
+            StorageOptionsAccessor::with_static_options(storage_options.clone()),
+        ));
     }
 
     let (maybe_txn, rows_updated) = match runtime::block_on(async {
@@ -467,9 +469,10 @@ fn rewrite_rows_update_transaction_inner(
             updated_fragments,
             new_fragments,
             fields_modified: vec![],
-            mem_wal_to_merge: None,
+            merged_generations: Vec::new(),
             fields_for_preserving_frag_bitmap,
             update_mode: Some(UpdateMode::RewriteRows),
+            inserted_rows_filter: None,
         };
 
         let txn = Transaction::new(dataset.manifest.version, operation, None);

--- a/rust/ffi/write.rs
+++ b/rust/ffi/write.rs
@@ -14,7 +14,7 @@ use arrow_array::{
 };
 use arrow_schema::{ArrowError, DataType, Field, Schema, SchemaRef};
 use lance::dataset::{CommitBuilder, Dataset, InsertBuilder, WriteMode, WriteParams};
-use lance::io::ObjectStoreParams;
+use lance::io::{ObjectStoreParams, StorageOptionsAccessor};
 
 use crate::error::{clear_last_error, set_last_error, ErrorCode};
 use crate::runtime;
@@ -117,7 +117,10 @@ struct WriterState {
 impl Drop for WriterHandle {
     fn drop(&mut self) {
         let (sender, join) = {
-            let mut guard = self.state.lock().unwrap_or_else(|poisoned| poisoned.into_inner());
+            let mut guard = self
+                .state
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner());
             (guard.output_sender.take(), guard.output_join.take())
         };
         drop(sender);
@@ -264,9 +267,7 @@ fn convert_list_array_to_fixed_size(
                 }
                 let len = list.value_length(i) as usize;
                 if len != dim {
-                    return Err(format!(
-                        "vector dim mismatch: expected {dim} got {len}"
-                    ));
+                    return Err(format!("vector dim mismatch: expected {dim} got {len}"));
                 }
                 let start = offsets[i] as usize;
                 for j in 0..dim {
@@ -313,9 +314,7 @@ fn convert_list_array_to_fixed_size(
                 }
                 let len = list.value_length(i) as usize;
                 if len != dim {
-                    return Err(format!(
-                        "vector dim mismatch: expected {dim} got {len}"
-                    ));
+                    return Err(format!("vector dim mismatch: expected {dim} got {len}"));
                 }
                 let start = offsets[i] as usize;
                 for j in 0..dim {
@@ -362,9 +361,7 @@ fn convert_list_array_to_fixed_size(
                 }
                 let len = list.value_length(i) as usize;
                 if len != dim {
-                    return Err(format!(
-                        "vector dim mismatch: expected {dim} got {len}"
-                    ));
+                    return Err(format!("vector dim mismatch: expected {dim} got {len}"));
                 }
                 let start = offsets[i] as usize;
                 for j in 0..dim {
@@ -411,9 +408,7 @@ fn convert_list_array_to_fixed_size(
                 }
                 let len = list.value_length(i) as usize;
                 if len != dim {
-                    return Err(format!(
-                        "vector dim mismatch: expected {dim} got {len}"
-                    ));
+                    return Err(format!("vector dim mismatch: expected {dim} got {len}"));
                 }
                 let start = offsets[i] as usize;
                 for j in 0..dim {
@@ -457,8 +452,7 @@ fn build_output_schema(
             DataType::List(field) | DataType::LargeList(field) => field.clone(),
             _ => return Err("vector column has unexpected data type".to_string()),
         };
-        let dim_i32 =
-            i32::try_from(conv.dim).map_err(|_| "vector dim is too large".to_string())?;
+        let dim_i32 = i32::try_from(conv.dim).map_err(|_| "vector dim is too large".to_string())?;
         fields[idx] = Arc::new(Field::new(
             original.name(),
             DataType::FixedSizeList(child_field, dim_i32),
@@ -474,8 +468,10 @@ fn convert_record_batch(
     conversions: &[VectorConversion],
 ) -> Result<RecordBatch, String> {
     if conversions.is_empty() {
-        return Ok(RecordBatch::try_new(output_schema.clone(), input_batch.columns().to_vec())
-            .map_err(|e| e.to_string())?);
+        return Ok(
+            RecordBatch::try_new(output_schema.clone(), input_batch.columns().to_vec())
+                .map_err(|e| e.to_string())?,
+        );
     }
     let mut cols = input_batch.columns().to_vec();
     for conv in conversions {
@@ -484,7 +480,8 @@ fn convert_record_batch(
             .ok_or_else(|| "vector column index is out of bounds".to_string())?
             .as_ref();
         validate_list_vector_dim(arr, conv.list_kind, conv.dim)?;
-        let fixed = convert_list_array_to_fixed_size(arr, conv.list_kind, conv.element_type, conv.dim)?;
+        let fixed =
+            convert_list_array_to_fixed_size(arr, conv.list_kind, conv.element_type, conv.dim)?;
         cols[conv.col_idx] = Arc::new(fixed);
     }
     RecordBatch::try_new(output_schema.clone(), cols).map_err(|e| e.to_string())
@@ -683,7 +680,9 @@ fn open_uncommitted_writer_inner(
 
     let mut store_params = ObjectStoreParams::default();
     if !storage_options.is_empty() {
-        store_params.storage_options = Some(storage_options);
+        store_params.storage_options_accessor = Some(Arc::new(
+            StorageOptionsAccessor::with_static_options(storage_options),
+        ));
     }
 
     let params = WriteParams {
@@ -816,7 +815,9 @@ fn open_writer_inner(
 
     let mut store_params = ObjectStoreParams::default();
     if !storage_options.is_empty() {
-        store_params.storage_options = Some(storage_options);
+        store_params.storage_options_accessor = Some(Arc::new(
+            StorageOptionsAccessor::with_static_options(storage_options),
+        ));
     }
 
     let params = WriteParams {
@@ -899,13 +900,17 @@ fn writer_write_batch_inner(writer: *mut c_void, array: *mut c_void) -> FfiResul
         .downcast_ref::<StructArray>()
         .ok_or_else(|| FfiError::new(ErrorCode::DatasetWriteBatch, "array is not a struct"))?;
 
-    let input_batch = RecordBatch::try_new(handle.input_schema.clone(), struct_array.columns().to_vec())
-        .map_err(|err| {
-            FfiError::new(ErrorCode::DatasetWriteBatch, format!("record batch: {err}"))
-        })?;
+    let input_batch =
+        RecordBatch::try_new(handle.input_schema.clone(), struct_array.columns().to_vec())
+            .map_err(|err| {
+                FfiError::new(ErrorCode::DatasetWriteBatch, format!("record batch: {err}"))
+            })?;
 
     let (sender, to_send) = {
-        let mut guard = handle.state.lock().unwrap_or_else(|poisoned| poisoned.into_inner());
+        let mut guard = handle
+            .state
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
 
         if guard.output_sender.is_none() {
             guard.buffered_batches.push(input_batch);
@@ -917,9 +922,7 @@ fn writer_write_batch_inner(writer: *mut c_void, array: *mut c_void) -> FfiResul
                         continue;
                     }
                     for batch in batches.iter() {
-                        let arr = batch
-                            .column(cand.col_idx)
-                            .as_ref();
+                        let arr = batch.column(cand.col_idx).as_ref();
                         match infer_vector_dim_from_array(arr, cand.list_kind) {
                             Some(Ok(dim)) => {
                                 cand.dim = dim;
@@ -988,7 +991,9 @@ fn writer_write_batch_inner(writer: *mut c_void, array: *mut c_void) -> FfiResul
             let schema = guard
                 .output_schema
                 .as_ref()
-                .ok_or_else(|| FfiError::new(ErrorCode::DatasetWriteBatch, "writer is not initialized"))?
+                .ok_or_else(|| {
+                    FfiError::new(ErrorCode::DatasetWriteBatch, "writer is not initialized")
+                })?
                 .clone();
             let conversions: Vec<VectorConversion> = guard
                 .vector_candidates
@@ -1039,7 +1044,10 @@ fn writer_finish_inner(writer: *mut c_void) -> FfiResult<()> {
 
     let handle = unsafe { &*(writer as *const WriterHandle) };
     let (sender, join, to_send) = {
-        let mut guard = handle.state.lock().unwrap_or_else(|poisoned| poisoned.into_inner());
+        let mut guard = handle
+            .state
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
         if guard.output_sender.is_none() {
             let conversions: Vec<VectorConversion> = guard
                 .vector_candidates
@@ -1073,15 +1081,12 @@ fn writer_finish_inner(writer: *mut c_void) -> FfiResult<()> {
             guard.buffered_batches = out_batches;
         }
 
-        let sender = guard
-            .output_sender
-            .as_ref()
-            .cloned()
-            .ok_or_else(|| FfiError::new(ErrorCode::DatasetWriteFinish, "writer is not initialized"))?;
-        let join = guard
-            .output_join
-            .take()
-            .ok_or_else(|| FfiError::new(ErrorCode::DatasetWriteFinish, "writer is already finished"))?;
+        let sender = guard.output_sender.as_ref().cloned().ok_or_else(|| {
+            FfiError::new(ErrorCode::DatasetWriteFinish, "writer is not initialized")
+        })?;
+        let join = guard.output_join.take().ok_or_else(|| {
+            FfiError::new(ErrorCode::DatasetWriteFinish, "writer is already finished")
+        })?;
         let to_send = std::mem::take(&mut guard.buffered_batches);
         guard.output_sender = None;
         (sender, join, to_send)
@@ -1144,7 +1149,10 @@ fn writer_finish_uncommitted_inner(
 
     let handle = unsafe { &*(writer as *const WriterHandle) };
     let (sender, join, to_send) = {
-        let mut guard = handle.state.lock().unwrap_or_else(|poisoned| poisoned.into_inner());
+        let mut guard = handle
+            .state
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
         if guard.output_sender.is_none() {
             let conversions: Vec<VectorConversion> = guard
                 .vector_candidates
@@ -1178,16 +1186,12 @@ fn writer_finish_uncommitted_inner(
             guard.buffered_batches = out_batches;
         }
 
-        let sender = guard
-            .output_sender
-            .as_ref()
-            .cloned()
-            .ok_or_else(|| {
-                FfiError::new(
-                    ErrorCode::DatasetWriteFinishUncommitted,
-                    "writer is not initialized",
-                )
-            })?;
+        let sender = guard.output_sender.as_ref().cloned().ok_or_else(|| {
+            FfiError::new(
+                ErrorCode::DatasetWriteFinishUncommitted,
+                "writer is not initialized",
+            )
+        })?;
         let join = guard.output_join.take().ok_or_else(|| {
             FfiError::new(
                 ErrorCode::DatasetWriteFinishUncommitted,
@@ -1321,7 +1325,9 @@ fn commit_transaction_inner(
 
     let mut store_params = ObjectStoreParams::default();
     if !storage_options.is_empty() {
-        store_params.storage_options = Some(storage_options);
+        store_params.storage_options_accessor = Some(Arc::new(
+            StorageOptionsAccessor::with_static_options(storage_options),
+        ));
     }
 
     let txn =

--- a/rust/lib.rs
+++ b/rust/lib.rs
@@ -3,8 +3,8 @@
 mod constants;
 mod datafusion_stream;
 mod error;
-mod ffi;
 mod exec_ir;
+mod ffi;
 mod filter_ir;
 mod runtime;
 mod scanner;


### PR DESCRIPTION
## Summary
- Bump Lance crates to 2.0.0-rc.4 and align Arrow/DataFusion versions.
- Resolve Lance crates from the v2.0.0-rc.4 git tag and refresh the lockfile.
- Update FFI call sites for Lance 2.0 API changes (scanner filter, update transaction fields, object store params, index creation return type).

## Resolver / dependency changes
- Arrow/arrow-* now resolve to 57.x (lockfile currently 57.2.0).
- DataFusion/datafusion-* now resolve to 51.x.
- Lance crates now resolve from the v2.0.0-rc.4 tag via [patch.crates-io].

## Checks
- `cargo fmt --all`
- `cargo check --manifest-path Cargo.toml`
- `cargo clippy --manifest-path Cargo.toml --all-targets`

Triggering tag: `refs/tags/v2.0.0-rc.4`
