### PR TITLE
fix: compile error error: could not convert xx from

### DIFF
--- a/src/lance_scan.cpp
+++ b/src/lance_scan.cpp
@@ -2190,7 +2190,7 @@ LanceExecPushdown(ClientContext &context, Optimizer &optimizer,
         agg_op.group_index, agg_op.aggregate_index, agg_op.groups.size(),
         expected_types, std::move(exec_get));
     exec->SetEstimatedCardinality(estimated_cardinality);
-    return exec;
+    return std::move(exec);
   };
 
   if (op->type == LogicalOperatorType::LOGICAL_ORDER_BY) {

--- a/src/lance_storage.cpp
+++ b/src/lance_storage.cpp
@@ -1147,7 +1147,7 @@ public:
                               state->open_path + LanceFormatErrorSuffix());
           }
 
-          return state;
+          return std::move(state);
         }
 
         struct LocalState final : public LocalSinkState {};


### PR DESCRIPTION
I used `gcc 12.3.1`  and run  `GEN=ninja make debug`

gcc -v
Using built-in specs.
COLLECT_GCC=gcc
COLLECT_LTO_WRAPPER=/usr/libexec/gcc/x86_64-TencentOS-linux/12/lto-wrapper
Target: x86_64-TencentOS-linux
Configured with: ../configure --enable-bootstrap --enable-languages=c,c++,fortran,objc,obj-c++,ada,go,d,lto --with-pkgversion='Tencent Compiler 12.3.1.7' --prefix=/usr --mandir=/usr/share/man --infodir=/usr/share/info --with-bugurl=https://gcc.gnu.org/bugzilla/ --enable-shared --enable-threads=posix --enable-checking=release --disable-multilib --with-system-zlib --enable-__cxa_atexit --disable-libunwind-exceptions --enable-gnu-unique-object --enable-linker-build-id --with-gcc-major-version-only --enable-libstdcxx-backtrace --with-linker-hash-style=gnu --enable-plugin --enable-initfini-array --without-isl --enable-gnu-indirect-function --enable-cet --with-tune=generic --with-arch_32=i686 --build=x86_64-TencentOS-linux --with-build-config=bootstrap-lto --enable-link-serialization=1
Thread model: posix
Supported LTO compression algorithms: zlib zstd
gcc version 12.3.1 20230912 (TencentOS 12.3.1.7-1) (Tencent Compiler 12.3.1.7) 


src/lance_scan.cpp:2193:12: error: could not convert ‘exec’ from ‘unique_ptr<duckdb::LogicalLanceExec,default_delete<duckdb::LogicalLanceExec>,[...]>’ to ‘unique_ptr<duckdb::LogicalOperator,default_delete<duckdb::LogicalOperator>,[...]>’
 2193 |     return exec;
      |            ^~~~
      |            |
      |            unique_ptr<duckdb::LogicalLanceExec,default_delete<duckdb::LogicalLanceExec>,[...]>
[394/440] Building CXX object extension/lance/CMakeFiles/lance_loadable_extension.dir/src/lance_storage.cpp.o
FAILED: extension/lance/CMakeFiles/lance_loadable_extension.dir/src/lance_storage.cpp.o

src/lance_storage.cpp:1150:18: error: could not convert ‘state’ from ‘unique_ptr<duckdb::LanceDuckCatalog::PlanCreateTableAs(duckdb::ClientContext&, duckdb::PhysicalPlanGenerator&, duckdb::LogicalCreateTable&, duckdb::PhysicalOperator&)::PhysicalLanceCreateTableAs::GlobalState,default_delete<duckdb::LanceDuckCatalog::PlanCreateTableAs(duckdb::ClientContext&, duckdb::PhysicalPlanGenerator&, duckdb::LogicalCreateTable&, duckdb::PhysicalOperator&)::PhysicalLanceCreateTableAs::GlobalState>,[...]>’ to ‘unique_ptr<duckdb::GlobalSinkState,default_delete<duckdb::GlobalSinkState>,[...]>’
 1150 |           return state;
      |                  ^~~~~
      |                  |
      |                  unique_ptr<duckdb::LanceDuckCatalog::PlanCreateTableAs(duckdb::ClientContext&, duckdb::PhysicalPlanGenerator&, duckdb::LogicalCreateTable&, duckdb::PhysicalOperator&)::PhysicalLanceCreateTableAs::GlobalState,default_delete<duckdb::LanceDuckCatalog::PlanCreateTableAs(duckdb::ClientContext&, duckdb::PhysicalPlanGenerator&, duckdb::LogicalCreateTable&, duckdb::PhysicalOperator&)::PhysicalLanceCreateTableAs::GlobalState>,[...]>
      
      