### PR TITLE
chore: update lance dependency to v3.0.0-beta.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -991,9 +991,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.10.1"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "bytes-utils"
@@ -1263,6 +1263,16 @@ version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0f58bbc28f91df819d0aa2a2c00cd19754769c2fad90579b3592b1c9ba7a3115"
 dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-skiplist"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df29de440c58ca2cc6e587ec3d22347551a32435fbde9d2bff64e78a9ffa151b"
+dependencies = [
+ "crossbeam-epoch",
  "crossbeam-utils",
 ]
 
@@ -2270,8 +2280,8 @@ checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "fsst"
-version = "2.0.0-rc.4"
-source = "git+https://github.com/lance-format/lance?tag=v2.0.0-rc.4#584c470f69334600cae384f1ac30bf13f8a6959a"
+version = "3.0.0-beta.2"
+source = "git+https://github.com/lance-format/lance?tag=v3.0.0-beta.2#bcabf1dc35cab448c4c6ee107c236823f43ec442"
 dependencies = [
  "arrow-array",
  "rand 0.9.2",
@@ -3189,8 +3199,8 @@ dependencies = [
 
 [[package]]
 name = "lance"
-version = "2.0.0-rc.4"
-source = "git+https://github.com/lance-format/lance?tag=v2.0.0-rc.4#584c470f69334600cae384f1ac30bf13f8a6959a"
+version = "3.0.0-beta.2"
+source = "git+https://github.com/lance-format/lance?tag=v3.0.0-beta.2#bcabf1dc35cab448c4c6ee107c236823f43ec442"
 dependencies = [
  "arrow",
  "arrow-arith",
@@ -3208,6 +3218,7 @@ dependencies = [
  "byteorder",
  "bytes",
  "chrono",
+ "crossbeam-skiplist",
  "dashmap",
  "datafusion",
  "datafusion-expr",
@@ -3247,6 +3258,7 @@ dependencies = [
  "tantivy",
  "tokio",
  "tokio-stream",
+ "tokio-util",
  "tracing",
  "url",
  "uuid",
@@ -3254,8 +3266,8 @@ dependencies = [
 
 [[package]]
 name = "lance-arrow"
-version = "2.0.0-rc.4"
-source = "git+https://github.com/lance-format/lance?tag=v2.0.0-rc.4#584c470f69334600cae384f1ac30bf13f8a6959a"
+version = "3.0.0-beta.2"
+source = "git+https://github.com/lance-format/lance?tag=v3.0.0-beta.2#bcabf1dc35cab448c4c6ee107c236823f43ec442"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -3274,8 +3286,8 @@ dependencies = [
 
 [[package]]
 name = "lance-bitpacking"
-version = "2.0.0-rc.4"
-source = "git+https://github.com/lance-format/lance?tag=v2.0.0-rc.4#584c470f69334600cae384f1ac30bf13f8a6959a"
+version = "3.0.0-beta.2"
+source = "git+https://github.com/lance-format/lance?tag=v3.0.0-beta.2#bcabf1dc35cab448c4c6ee107c236823f43ec442"
 dependencies = [
  "arrayref",
  "paste",
@@ -3284,8 +3296,8 @@ dependencies = [
 
 [[package]]
 name = "lance-core"
-version = "2.0.0-rc.4"
-source = "git+https://github.com/lance-format/lance?tag=v2.0.0-rc.4#584c470f69334600cae384f1ac30bf13f8a6959a"
+version = "3.0.0-beta.2"
+source = "git+https://github.com/lance-format/lance?tag=v3.0.0-beta.2#bcabf1dc35cab448c4c6ee107c236823f43ec442"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -3322,8 +3334,8 @@ dependencies = [
 
 [[package]]
 name = "lance-datafusion"
-version = "2.0.0-rc.4"
-source = "git+https://github.com/lance-format/lance?tag=v2.0.0-rc.4#584c470f69334600cae384f1ac30bf13f8a6959a"
+version = "3.0.0-beta.2"
+source = "git+https://github.com/lance-format/lance?tag=v3.0.0-beta.2#bcabf1dc35cab448c4c6ee107c236823f43ec442"
 dependencies = [
  "arrow",
  "arrow-array",
@@ -3353,8 +3365,8 @@ dependencies = [
 
 [[package]]
 name = "lance-datagen"
-version = "2.0.0-rc.4"
-source = "git+https://github.com/lance-format/lance?tag=v2.0.0-rc.4#584c470f69334600cae384f1ac30bf13f8a6959a"
+version = "3.0.0-beta.2"
+source = "git+https://github.com/lance-format/lance?tag=v3.0.0-beta.2#bcabf1dc35cab448c4c6ee107c236823f43ec442"
 dependencies = [
  "arrow",
  "arrow-array",
@@ -3372,8 +3384,8 @@ dependencies = [
 
 [[package]]
 name = "lance-encoding"
-version = "2.0.0-rc.4"
-source = "git+https://github.com/lance-format/lance?tag=v2.0.0-rc.4#584c470f69334600cae384f1ac30bf13f8a6959a"
+version = "3.0.0-beta.2"
+source = "git+https://github.com/lance-format/lance?tag=v3.0.0-beta.2#bcabf1dc35cab448c4c6ee107c236823f43ec442"
 dependencies = [
  "arrow-arith",
  "arrow-array",
@@ -3410,8 +3422,8 @@ dependencies = [
 
 [[package]]
 name = "lance-file"
-version = "2.0.0-rc.4"
-source = "git+https://github.com/lance-format/lance?tag=v2.0.0-rc.4#584c470f69334600cae384f1ac30bf13f8a6959a"
+version = "3.0.0-beta.2"
+source = "git+https://github.com/lance-format/lance?tag=v3.0.0-beta.2#bcabf1dc35cab448c4c6ee107c236823f43ec442"
 dependencies = [
  "arrow-arith",
  "arrow-array",
@@ -3443,8 +3455,8 @@ dependencies = [
 
 [[package]]
 name = "lance-geo"
-version = "2.0.0-rc.4"
-source = "git+https://github.com/lance-format/lance?tag=v2.0.0-rc.4#584c470f69334600cae384f1ac30bf13f8a6959a"
+version = "3.0.0-beta.2"
+source = "git+https://github.com/lance-format/lance?tag=v3.0.0-beta.2#bcabf1dc35cab448c4c6ee107c236823f43ec442"
 dependencies = [
  "datafusion",
  "geo-traits",
@@ -3458,8 +3470,8 @@ dependencies = [
 
 [[package]]
 name = "lance-index"
-version = "2.0.0-rc.4"
-source = "git+https://github.com/lance-format/lance?tag=v2.0.0-rc.4#584c470f69334600cae384f1ac30bf13f8a6959a"
+version = "3.0.0-beta.2"
+source = "git+https://github.com/lance-format/lance?tag=v3.0.0-beta.2#bcabf1dc35cab448c4c6ee107c236823f43ec442"
 dependencies = [
  "arrow",
  "arrow-arith",
@@ -3526,8 +3538,8 @@ dependencies = [
 
 [[package]]
 name = "lance-io"
-version = "2.0.0-rc.4"
-source = "git+https://github.com/lance-format/lance?tag=v2.0.0-rc.4#584c470f69334600cae384f1ac30bf13f8a6959a"
+version = "3.0.0-beta.2"
+source = "git+https://github.com/lance-format/lance?tag=v3.0.0-beta.2#bcabf1dc35cab448c4c6ee107c236823f43ec442"
 dependencies = [
  "arrow",
  "arrow-arith",
@@ -3567,8 +3579,8 @@ dependencies = [
 
 [[package]]
 name = "lance-linalg"
-version = "2.0.0-rc.4"
-source = "git+https://github.com/lance-format/lance?tag=v2.0.0-rc.4#584c470f69334600cae384f1ac30bf13f8a6959a"
+version = "3.0.0-beta.2"
+source = "git+https://github.com/lance-format/lance?tag=v3.0.0-beta.2#bcabf1dc35cab448c4c6ee107c236823f43ec442"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -3584,8 +3596,8 @@ dependencies = [
 
 [[package]]
 name = "lance-namespace"
-version = "2.0.0-rc.4"
-source = "git+https://github.com/lance-format/lance?tag=v2.0.0-rc.4#584c470f69334600cae384f1ac30bf13f8a6959a"
+version = "3.0.0-beta.2"
+source = "git+https://github.com/lance-format/lance?tag=v3.0.0-beta.2#bcabf1dc35cab448c4c6ee107c236823f43ec442"
 dependencies = [
  "arrow",
  "async-trait",
@@ -3597,8 +3609,8 @@ dependencies = [
 
 [[package]]
 name = "lance-namespace-impls"
-version = "2.0.0-rc.4"
-source = "git+https://github.com/lance-format/lance?tag=v2.0.0-rc.4#584c470f69334600cae384f1ac30bf13f8a6959a"
+version = "3.0.0-beta.2"
+source = "git+https://github.com/lance-format/lance?tag=v3.0.0-beta.2#bcabf1dc35cab448c4c6ee107c236823f43ec442"
 dependencies = [
  "arrow",
  "arrow-ipc",
@@ -3638,8 +3650,8 @@ dependencies = [
 
 [[package]]
 name = "lance-table"
-version = "2.0.0-rc.4"
-source = "git+https://github.com/lance-format/lance?tag=v2.0.0-rc.4#584c470f69334600cae384f1ac30bf13f8a6959a"
+version = "3.0.0-beta.2"
+source = "git+https://github.com/lance-format/lance?tag=v3.0.0-beta.2#bcabf1dc35cab448c4c6ee107c236823f43ec442"
 dependencies = [
  "arrow",
  "arrow-array",
@@ -4703,7 +4715,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
 dependencies = [
  "heck",
- "itertools 0.11.0",
+ "itertools 0.14.0",
  "log",
  "multimap",
  "petgraph",
@@ -4722,7 +4734,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools 0.11.0",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.111",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,14 +19,14 @@ panic = "abort"
 [dependencies]
 
 # Lance and Arrow dependencies - using compatible versions
-lance = { version = "2.0.0-rc.4", default-features = false, features = ["aws", "azure", "gcp", "oss", "huggingface"] }
-lance-arrow = "2.0.0-rc.4"
-lance-core = "2.0.0-rc.4"
-lance-index = "2.0.0-rc.4"
-lance-linalg = "2.0.0-rc.4"
-lance-namespace = "2.0.0-rc.4"
-lance-namespace-impls = { version = "2.0.0-rc.4", features = ["rest"] }
-lance-table = "2.0.0-rc.4"
+lance = { version = "3.0.0-beta.2", default-features = false, features = ["aws", "azure", "gcp", "oss", "huggingface"] }
+lance-arrow = "3.0.0-beta.2"
+lance-core = "3.0.0-beta.2"
+lance-index = "3.0.0-beta.2"
+lance-linalg = "3.0.0-beta.2"
+lance-namespace = "3.0.0-beta.2"
+lance-namespace-impls = { version = "3.0.0-beta.2", features = ["rest"] }
+lance-table = "3.0.0-beta.2"
 
 arrow = { version = "57.0.0", features = ["ffi"] }
 arrow-array = "57.0.0"
@@ -50,11 +50,11 @@ tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
 rand = "0.8"
 
 [patch.crates-io]
-lance = { git = "https://github.com/lance-format/lance", tag = "v2.0.0-rc.4" }
-lance-arrow = { git = "https://github.com/lance-format/lance", tag = "v2.0.0-rc.4" }
-lance-core = { git = "https://github.com/lance-format/lance", tag = "v2.0.0-rc.4" }
-lance-index = { git = "https://github.com/lance-format/lance", tag = "v2.0.0-rc.4" }
-lance-linalg = { git = "https://github.com/lance-format/lance", tag = "v2.0.0-rc.4" }
-lance-namespace = { git = "https://github.com/lance-format/lance", tag = "v2.0.0-rc.4" }
-lance-namespace-impls = { git = "https://github.com/lance-format/lance", tag = "v2.0.0-rc.4" }
-lance-table = { git = "https://github.com/lance-format/lance", tag = "v2.0.0-rc.4" }
+lance = { git = "https://github.com/lance-format/lance", tag = "v3.0.0-beta.2" }
+lance-arrow = { git = "https://github.com/lance-format/lance", tag = "v3.0.0-beta.2" }
+lance-core = { git = "https://github.com/lance-format/lance", tag = "v3.0.0-beta.2" }
+lance-index = { git = "https://github.com/lance-format/lance", tag = "v3.0.0-beta.2" }
+lance-linalg = { git = "https://github.com/lance-format/lance", tag = "v3.0.0-beta.2" }
+lance-namespace = { git = "https://github.com/lance-format/lance", tag = "v3.0.0-beta.2" }
+lance-namespace-impls = { git = "https://github.com/lance-format/lance", tag = "v3.0.0-beta.2" }
+lance-table = { git = "https://github.com/lance-format/lance", tag = "v3.0.0-beta.2" }


### PR DESCRIPTION
## Summary
- bump Lance Rust crates to v3.0.0-beta.2 (including git patch tags)
- refresh Cargo.lock for the new Lance dependency graph

## Resolver changes
- none observed (Arrow/DataFusion pins unchanged)

## Checks
- `cargo fmt --all`
- `cargo check --manifest-path Cargo.toml`
- `cargo clippy --manifest-path Cargo.toml --all-targets`

## Release reference
- refs/tags/v3.0.0-beta.2
