### PR TITLE
chore: update lance dependency to v2.0.0 (stable only)

### DIFF
--- a/.github/workflows/codex-update-lance-dependency.yml
+++ b/.github/workflows/codex-update-lance-dependency.yml
@@ -63,6 +63,18 @@ jobs:
         with:
           components: rustfmt, clippy
 
+      - name: Validate stable release tag
+        env:
+          TAG: ${{ inputs.tag }}
+        run: |
+          set -euo pipefail
+          VERSION="${TAG#refs/tags/}"
+          VERSION="${VERSION#v}"
+          if ! [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Only stable Lance versions are allowed (got: ${TAG})" >&2
+            exit 1
+          fi
+
       - name: Configure git user
         run: |
           git config user.name "lance-community"
@@ -89,6 +101,7 @@ jobs:
              - In the [dependencies] section, update the versions for these crates to "${VERSION}":
                lance, lance-arrow, lance-core, lance-index, lance-linalg, lance-namespace, lance-namespace-impls, lance-table.
              - Keep existing features/flags unchanged.
+             - Do not add or keep a [patch.crates-io] section for Lance crates; dependencies must come from crates.io stable releases only.
           2. Update Cargo.lock to match the new versions.
              - Prefer precise updates like:
                cargo update -p lance --precise ${VERSION}
@@ -119,4 +132,3 @@ jobs:
 
           printenv OPENAI_API_KEY | codex login --with-api-key
           codex --config shell_environment_policy.ignore_default_excludes=true exec --dangerously-bypass-approvals-and-sandbox "$(cat /tmp/codex-prompt.txt)"
-

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2270,8 +2270,9 @@ checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "fsst"
-version = "2.0.0-rc.4"
-source = "git+https://github.com/lance-format/lance?tag=v2.0.0-rc.4#584c470f69334600cae384f1ac30bf13f8a6959a"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f03a771ab914e207dd26bd2f12666839555ec8ecc7e1770e1ed6f9900d899a4"
 dependencies = [
  "arrow-array",
  "rand 0.9.2",
@@ -3189,8 +3190,9 @@ dependencies = [
 
 [[package]]
 name = "lance"
-version = "2.0.0-rc.4"
-source = "git+https://github.com/lance-format/lance?tag=v2.0.0-rc.4#584c470f69334600cae384f1ac30bf13f8a6959a"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b685aca3f97ee02997c83ded16f59c747ccb69e74c8abbbae4aa3d22cf1301"
 dependencies = [
  "arrow",
  "arrow-arith",
@@ -3254,8 +3256,9 @@ dependencies = [
 
 [[package]]
 name = "lance-arrow"
-version = "2.0.0-rc.4"
-source = "git+https://github.com/lance-format/lance?tag=v2.0.0-rc.4#584c470f69334600cae384f1ac30bf13f8a6959a"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daf00c7537df524cc518a089f0d156a036d95ca3f5bc2bc1f0a9f9293e9b62ef"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -3274,8 +3277,9 @@ dependencies = [
 
 [[package]]
 name = "lance-bitpacking"
-version = "2.0.0-rc.4"
-source = "git+https://github.com/lance-format/lance?tag=v2.0.0-rc.4#584c470f69334600cae384f1ac30bf13f8a6959a"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46752e4ac8fc5590a445e780b63a8800adc7a770bd74770a8dc66963778e4e77"
 dependencies = [
  "arrayref",
  "paste",
@@ -3284,8 +3288,9 @@ dependencies = [
 
 [[package]]
 name = "lance-core"
-version = "2.0.0-rc.4"
-source = "git+https://github.com/lance-format/lance?tag=v2.0.0-rc.4#584c470f69334600cae384f1ac30bf13f8a6959a"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d13d87d07305c6d4b4dc7780fb1107babf782a0e5b1dc7872e17ae1f8fd11ca"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -3322,8 +3327,9 @@ dependencies = [
 
 [[package]]
 name = "lance-datafusion"
-version = "2.0.0-rc.4"
-source = "git+https://github.com/lance-format/lance?tag=v2.0.0-rc.4#584c470f69334600cae384f1ac30bf13f8a6959a"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6451b5af876eaef8bec4b38a39dadac9d44621e1ecf85d0cdf6097a5d0aa8721"
 dependencies = [
  "arrow",
  "arrow-array",
@@ -3353,8 +3359,9 @@ dependencies = [
 
 [[package]]
 name = "lance-datagen"
-version = "2.0.0-rc.4"
-source = "git+https://github.com/lance-format/lance?tag=v2.0.0-rc.4#584c470f69334600cae384f1ac30bf13f8a6959a"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1736708dd7867dfbab8fcc930b21c96717c6c00be73b7d9a240336a4ed80375"
 dependencies = [
  "arrow",
  "arrow-array",
@@ -3372,8 +3379,9 @@ dependencies = [
 
 [[package]]
 name = "lance-encoding"
-version = "2.0.0-rc.4"
-source = "git+https://github.com/lance-format/lance?tag=v2.0.0-rc.4#584c470f69334600cae384f1ac30bf13f8a6959a"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6b6ca4ff94833240d5ba4a94a742cba786d1949b3c3fa7e11d6f0050443432a"
 dependencies = [
  "arrow-arith",
  "arrow-array",
@@ -3410,8 +3418,9 @@ dependencies = [
 
 [[package]]
 name = "lance-file"
-version = "2.0.0-rc.4"
-source = "git+https://github.com/lance-format/lance?tag=v2.0.0-rc.4#584c470f69334600cae384f1ac30bf13f8a6959a"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55fbe959bffe185543aed3cbeb14484f1aa2e55886034fdb1ea3d8cc9b70aad8"
 dependencies = [
  "arrow-arith",
  "arrow-array",
@@ -3443,8 +3452,9 @@ dependencies = [
 
 [[package]]
 name = "lance-geo"
-version = "2.0.0-rc.4"
-source = "git+https://github.com/lance-format/lance?tag=v2.0.0-rc.4#584c470f69334600cae384f1ac30bf13f8a6959a"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a52b0adabc953d457f336a784a3b37353a180e6a79905f544949746e0d4c6483"
 dependencies = [
  "datafusion",
  "geo-traits",
@@ -3458,8 +3468,9 @@ dependencies = [
 
 [[package]]
 name = "lance-index"
-version = "2.0.0-rc.4"
-source = "git+https://github.com/lance-format/lance?tag=v2.0.0-rc.4#584c470f69334600cae384f1ac30bf13f8a6959a"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b67654bf86fd942dd2cf08294ee7e91053427cd148225f49c9ff398ff9a40fd"
 dependencies = [
  "arrow",
  "arrow-arith",
@@ -3526,8 +3537,9 @@ dependencies = [
 
 [[package]]
 name = "lance-io"
-version = "2.0.0-rc.4"
-source = "git+https://github.com/lance-format/lance?tag=v2.0.0-rc.4#584c470f69334600cae384f1ac30bf13f8a6959a"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8eb0ccc1c414e31687d83992d546af0a0237c8d2f4bf2ae3d347d539fd0fc141"
 dependencies = [
  "arrow",
  "arrow-arith",
@@ -3567,8 +3579,9 @@ dependencies = [
 
 [[package]]
 name = "lance-linalg"
-version = "2.0.0-rc.4"
-source = "git+https://github.com/lance-format/lance?tag=v2.0.0-rc.4#584c470f69334600cae384f1ac30bf13f8a6959a"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "083404cf12dcdb1a7df98fb58f9daf626b6e43a2f794b37b6b89b4012a0e1f78"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -3584,8 +3597,9 @@ dependencies = [
 
 [[package]]
 name = "lance-namespace"
-version = "2.0.0-rc.4"
-source = "git+https://github.com/lance-format/lance?tag=v2.0.0-rc.4#584c470f69334600cae384f1ac30bf13f8a6959a"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c12778d2aabf9c2bfd16e2509ebe120e562a288d8ae630ec6b6b204868df41b2"
 dependencies = [
  "arrow",
  "async-trait",
@@ -3597,8 +3611,9 @@ dependencies = [
 
 [[package]]
 name = "lance-namespace-impls"
-version = "2.0.0-rc.4"
-source = "git+https://github.com/lance-format/lance?tag=v2.0.0-rc.4#584c470f69334600cae384f1ac30bf13f8a6959a"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8863aababdd13a6d2c8d6179dc6981f4f8f49d8b66a00c5dd75115aec4cadc99"
 dependencies = [
  "arrow",
  "arrow-ipc",
@@ -3638,8 +3653,9 @@ dependencies = [
 
 [[package]]
 name = "lance-table"
-version = "2.0.0-rc.4"
-source = "git+https://github.com/lance-format/lance?tag=v2.0.0-rc.4#584c470f69334600cae384f1ac30bf13f8a6959a"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0fcc83f197ce2000c4abe4f5e0873490ab1f41788fa76571c4209b87d4daf50"
 dependencies = [
  "arrow",
  "arrow-array",
@@ -4703,7 +4719,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
 dependencies = [
  "heck",
- "itertools 0.11.0",
+ "itertools 0.14.0",
  "log",
  "multimap",
  "petgraph",
@@ -4722,7 +4738,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools 0.11.0",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.111",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,14 +19,14 @@ panic = "abort"
 [dependencies]
 
 # Lance and Arrow dependencies - using compatible versions
-lance = { version = "2.0.0-rc.4", default-features = false, features = ["aws", "azure", "gcp", "oss", "huggingface"] }
-lance-arrow = "2.0.0-rc.4"
-lance-core = "2.0.0-rc.4"
-lance-index = "2.0.0-rc.4"
-lance-linalg = "2.0.0-rc.4"
-lance-namespace = "2.0.0-rc.4"
-lance-namespace-impls = { version = "2.0.0-rc.4", features = ["rest"] }
-lance-table = "2.0.0-rc.4"
+lance = { version = "2.0.0", default-features = false, features = ["aws", "azure", "gcp", "oss", "huggingface"] }
+lance-arrow = "2.0.0"
+lance-core = "2.0.0"
+lance-index = "2.0.0"
+lance-linalg = "2.0.0"
+lance-namespace = "2.0.0"
+lance-namespace-impls = { version = "2.0.0", features = ["rest"] }
+lance-table = "2.0.0"
 
 arrow = { version = "57.0.0", features = ["ffi"] }
 arrow-array = "57.0.0"
@@ -48,13 +48,3 @@ serde_json = "1.0"
 snafu = "0.8.6"
 tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
 rand = "0.8"
-
-[patch.crates-io]
-lance = { git = "https://github.com/lance-format/lance", tag = "v2.0.0-rc.4" }
-lance-arrow = { git = "https://github.com/lance-format/lance", tag = "v2.0.0-rc.4" }
-lance-core = { git = "https://github.com/lance-format/lance", tag = "v2.0.0-rc.4" }
-lance-index = { git = "https://github.com/lance-format/lance", tag = "v2.0.0-rc.4" }
-lance-linalg = { git = "https://github.com/lance-format/lance", tag = "v2.0.0-rc.4" }
-lance-namespace = { git = "https://github.com/lance-format/lance", tag = "v2.0.0-rc.4" }
-lance-namespace-impls = { git = "https://github.com/lance-format/lance", tag = "v2.0.0-rc.4" }
-lance-table = { git = "https://github.com/lance-format/lance", tag = "v2.0.0-rc.4" }

--- a/ci/check_lance_release.py
+++ b/ci/check_lance_release.py
@@ -121,6 +121,10 @@ def fetch_remote_tags() -> list[TagInfo]:
     return tags
 
 
+def stable_release_tags(tags: Iterable[TagInfo]) -> list[TagInfo]:
+    return [tag for tag in tags if not tag.semver.prerelease]
+
+
 def normalize_cargo_version(raw: str) -> str:
     trimmed = raw.strip()
     for prefix in ("^", "~", "="):
@@ -186,7 +190,10 @@ def main(argv: Sequence[str] | None = None) -> int:
     current_semver = parse_semver(current_version)
 
     tags = fetch_remote_tags()
-    latest = determine_latest_tag(tags)
+    stable_tags = stable_release_tags(tags)
+    if not stable_tags:
+        raise RuntimeError("No stable Lance tags were found from GitHub API output")
+    latest = determine_latest_tag(stable_tags)
     needs_update = latest.semver > current_semver
 
     payload = {
@@ -204,4 +211,3 @@ def main(argv: Sequence[str] | None = None) -> int:
 
 if __name__ == "__main__":
     raise SystemExit(main())
-


### PR DESCRIPTION
## Summary
- bump Lance Rust dependencies to stable `2.0.0` (from `2.0.0-rc.4`)
- remove `[patch.crates-io]` overrides so Lance crates resolve from crates.io only
- keep CI updates stable-only:
  - `ci/check_lance_release.py` now filters to stable tags
  - `codex-update-lance-dependency` now rejects non-stable tags and explicitly forbids adding Lance `[patch.crates-io]`

## Lockfile / Resolver Notes
- `Cargo.lock` now resolves Lance crates (`lance*`, `fsst`) from crates.io instead of git tag sources.
- `itertools` edge used by prost resolver moved from `0.11.0` to `0.14.0` in lockfile.

## Validation
- `cargo update -p lance -p lance-arrow -p lance-core -p lance-index -p lance-linalg -p lance-namespace -p lance-namespace-impls -p lance-table`
- `cargo check --manifest-path Cargo.toml`
- `python3 -m py_compile ci/check_lance_release.py`
- `rg -n "\[patch\.crates-io\]" Cargo.toml` (no match)
- `rg -n "git\+https://github.com/lance-format/lance" Cargo.lock` (no match)

## Triggering release tag
- `v2.0.0`
