### PR TITLE
chore: update lance dependency to v2.0.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2270,9 +2270,9 @@ checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "fsst"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f03a771ab914e207dd26bd2f12666839555ec8ecc7e1770e1ed6f9900d899a4"
+checksum = "5f9e5c0b1c67a38cb92b41535d44623483beb9511592ae23a3bf42ddec758690"
 dependencies = [
  "arrow-array",
  "rand 0.9.2",
@@ -3190,9 +3190,9 @@ dependencies = [
 
 [[package]]
 name = "lance"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47b685aca3f97ee02997c83ded16f59c747ccb69e74c8abbbae4aa3d22cf1301"
+checksum = "2b7f07b905df393a5554eba19055c620f9ea25a3e40a013bda4bd8dc4ca66f01"
 dependencies = [
  "arrow",
  "arrow-arith",
@@ -3256,9 +3256,9 @@ dependencies = [
 
 [[package]]
 name = "lance-arrow"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "daf00c7537df524cc518a089f0d156a036d95ca3f5bc2bc1f0a9f9293e9b62ef"
+checksum = "100e076cb81c8f0c24cd2881c706fc53e037c7d6e81eb320e929e265d157effb"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -3277,9 +3277,9 @@ dependencies = [
 
 [[package]]
 name = "lance-bitpacking"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46752e4ac8fc5590a445e780b63a8800adc7a770bd74770a8dc66963778e4e77"
+checksum = "588318d3d1ba0f97162fab39a323a0a49866bb35b32af42572c6b6a12296fa27"
 dependencies = [
  "arrayref",
  "paste",
@@ -3288,9 +3288,9 @@ dependencies = [
 
 [[package]]
 name = "lance-core"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d13d87d07305c6d4b4dc7780fb1107babf782a0e5b1dc7872e17ae1f8fd11ca"
+checksum = "6fa01d1cf490ccfd3b8eaeee2781415d0419e6be8366040e57e43677abf2644e"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -3327,9 +3327,9 @@ dependencies = [
 
 [[package]]
 name = "lance-datafusion"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6451b5af876eaef8bec4b38a39dadac9d44621e1ecf85d0cdf6097a5d0aa8721"
+checksum = "ef89a39e3284eef76f79e63f23de8881a0583ad6feb20ed39f47eadd847a2b88"
 dependencies = [
  "arrow",
  "arrow-array",
@@ -3359,9 +3359,9 @@ dependencies = [
 
 [[package]]
 name = "lance-datagen"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1736708dd7867dfbab8fcc930b21c96717c6c00be73b7d9a240336a4ed80375"
+checksum = "fc2a60eef5c47e65d91e2ffa8e7e1629c52e7190c8b88a371a1a60601dc49371"
 dependencies = [
  "arrow",
  "arrow-array",
@@ -3379,9 +3379,9 @@ dependencies = [
 
 [[package]]
 name = "lance-encoding"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6b6ca4ff94833240d5ba4a94a742cba786d1949b3c3fa7e11d6f0050443432a"
+checksum = "95ce4a6631308aa681b2671af8f2a845ff781f8d4e755a2a7ccd012379467094"
 dependencies = [
  "arrow-arith",
  "arrow-array",
@@ -3418,9 +3418,9 @@ dependencies = [
 
 [[package]]
 name = "lance-file"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55fbe959bffe185543aed3cbeb14484f1aa2e55886034fdb1ea3d8cc9b70aad8"
+checksum = "e2d4d82357cbfaa1a18494226c15b1cb3c8ed0b6c84b91146323c82047ede419"
 dependencies = [
  "arrow-arith",
  "arrow-array",
@@ -3452,9 +3452,9 @@ dependencies = [
 
 [[package]]
 name = "lance-geo"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a52b0adabc953d457f336a784a3b37353a180e6a79905f544949746e0d4c6483"
+checksum = "a7183fc870da62826f0f97df8007b634da053eb310157856efe1dc74f446951c"
 dependencies = [
  "datafusion",
  "geo-traits",
@@ -3468,9 +3468,9 @@ dependencies = [
 
 [[package]]
 name = "lance-index"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b67654bf86fd942dd2cf08294ee7e91053427cd148225f49c9ff398ff9a40fd"
+checksum = "20e9c5aa7024a63af9ae89ee8c0f23c8421b7896742e5cd4a271a60f9956cb80"
 dependencies = [
  "arrow",
  "arrow-arith",
@@ -3537,9 +3537,9 @@ dependencies = [
 
 [[package]]
 name = "lance-io"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8eb0ccc1c414e31687d83992d546af0a0237c8d2f4bf2ae3d347d539fd0fc141"
+checksum = "c7d2af0b17fb374a8181bcf1a10bce5703ae3ee4373c1587ce4bba23e15e45c8"
 dependencies = [
  "arrow",
  "arrow-arith",
@@ -3579,9 +3579,9 @@ dependencies = [
 
 [[package]]
 name = "lance-linalg"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "083404cf12dcdb1a7df98fb58f9daf626b6e43a2f794b37b6b89b4012a0e1f78"
+checksum = "5125aa62696e75a7475807564b4921f252d8815be606b84bc00e6def0f5c24bb"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -3597,9 +3597,9 @@ dependencies = [
 
 [[package]]
 name = "lance-namespace"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c12778d2aabf9c2bfd16e2509ebe120e562a288d8ae630ec6b6b204868df41b2"
+checksum = "70545c2676ce954dfd801da5c6a631a70bba967826cd3a8f31b47d1f04bbfed3"
 dependencies = [
  "arrow",
  "async-trait",
@@ -3611,9 +3611,9 @@ dependencies = [
 
 [[package]]
 name = "lance-namespace-impls"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8863aababdd13a6d2c8d6179dc6981f4f8f49d8b66a00c5dd75115aec4cadc99"
+checksum = "92519f9f27d62655030aac62ea0db9614b65f086ebe651c1b0a96e351b668022"
 dependencies = [
  "arrow",
  "arrow-ipc",
@@ -3653,9 +3653,9 @@ dependencies = [
 
 [[package]]
 name = "lance-table"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0fcc83f197ce2000c4abe4f5e0873490ab1f41788fa76571c4209b87d4daf50"
+checksum = "b06ad37bd90045de8ef533df170c6098e6ff6ecb427aade47d7db8e2c86f2678"
 dependencies = [
  "arrow",
  "arrow-array",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,14 +19,14 @@ panic = "abort"
 [dependencies]
 
 # Lance and Arrow dependencies - using compatible versions
-lance = { version = "2.0.0", default-features = false, features = ["aws", "azure", "gcp", "oss", "huggingface"] }
-lance-arrow = "2.0.0"
-lance-core = "2.0.0"
-lance-index = "2.0.0"
-lance-linalg = "2.0.0"
-lance-namespace = "2.0.0"
-lance-namespace-impls = { version = "2.0.0", features = ["rest"] }
-lance-table = "2.0.0"
+lance = { version = "2.0.1", default-features = false, features = ["aws", "azure", "gcp", "oss", "huggingface"] }
+lance-arrow = "2.0.1"
+lance-core = "2.0.1"
+lance-index = "2.0.1"
+lance-linalg = "2.0.1"
+lance-namespace = "2.0.1"
+lance-namespace-impls = { version = "2.0.1", features = ["rest"] }
+lance-table = "2.0.1"
 
 arrow = { version = "57.0.0", features = ["ffi"] }
 arrow-array = "57.0.0"


### PR DESCRIPTION
## Summary
- Bump Lance crates to 2.0.1 from crates.io (lance, lance-arrow, lance-core, lance-index, lance-linalg, lance-namespace, lance-namespace-impls, lance-table).
- No Arrow/DataFusion resolver changes were needed for this update.

## Checks
- cargo fmt --all
- cargo check --manifest-path Cargo.toml
- cargo clippy --manifest-path Cargo.toml --all-targets

## Reference
- refs/tags/v2.0.1
