### PR TITLE
feat(cache): share Lance sessions per database

### DIFF
--- a/src/include/lance_session_state.hpp
+++ b/src/include/lance_session_state.hpp
@@ -2,21 +2,43 @@
 
 #include "duckdb.hpp"
 #include "duckdb/main/client_context_state.hpp"
+#include "duckdb/storage/object_cache.hpp"
 
 namespace duckdb {
 
-class LanceSessionState final : public ClientContextState {
+class LanceSharedSessionEntry final : public ObjectCacheEntry {
 public:
-  LanceSessionState();
-  ~LanceSessionState() override;
-  void WriteProfilingInformation(std::ostream &ss) override;
+  LanceSharedSessionEntry();
+  ~LanceSharedSessionEntry() override;
+
+  static string ObjectType();
+  string GetObjectType() override;
+  optional_idx GetEstimatedCacheMemory() const override;
 
   void *Handle() const { return session; }
+  uint64_t Id() const { return session_id; }
 
 private:
   void *session = nullptr;
+  uint64_t session_id = 0;
 };
 
+class LanceSessionState final : public ClientContextState {
+public:
+  explicit LanceSessionState(ClientContext &context);
+  ~LanceSessionState() override;
+  void WriteProfilingInformation(std::ostream &ss) override;
+
+  void *Handle() const;
+
+private:
+  bool shared_session_cache_hit = false;
+  shared_ptr<LanceSharedSessionEntry> shared_session;
+};
+
+shared_ptr<LanceSharedSessionEntry>
+GetOrCreateLanceSharedSessionEntry(ClientContext &context,
+                                   bool *out_cache_hit = nullptr);
 shared_ptr<LanceSessionState>
 GetOrCreateLanceSessionState(ClientContext &context);
 void *LanceGetSessionHandle(ClientContext &context);

--- a/src/lance_session_state.cpp
+++ b/src/lance_session_state.cpp
@@ -3,13 +3,17 @@
 #include "lance_common.hpp"
 #include "lance_ffi.hpp"
 
-#include "duckdb/main/client_context_state.hpp"
+#include <atomic>
 
 namespace duckdb {
 
 static constexpr const char *LANCE_SESSION_STATE_KEY = "lance_session_state";
+static constexpr const char *LANCE_SHARED_SESSION_CACHE_KEY =
+    "lance.shared_session.v1";
+static std::atomic<uint64_t> LANCE_SHARED_SESSION_ID_GEN{1};
 
-LanceSessionState::LanceSessionState() {
+LanceSharedSessionEntry::LanceSharedSessionEntry() {
+  session_id = LANCE_SHARED_SESSION_ID_GEN.fetch_add(1);
   session = lance_create_session(0, 0);
   if (!session) {
     throw IOException("Failed to create Lance session" +
@@ -17,27 +21,72 @@ LanceSessionState::LanceSessionState() {
   }
 }
 
-LanceSessionState::~LanceSessionState() {
+LanceSharedSessionEntry::~LanceSharedSessionEntry() {
   if (session) {
     lance_close_session(session);
     session = nullptr;
   }
 }
 
+string LanceSharedSessionEntry::ObjectType() { return "lance_shared_session"; }
+
+string LanceSharedSessionEntry::GetObjectType() { return ObjectType(); }
+
+optional_idx LanceSharedSessionEntry::GetEstimatedCacheMemory() const {
+  return optional_idx{};
+}
+
+shared_ptr<LanceSharedSessionEntry>
+GetOrCreateLanceSharedSessionEntry(ClientContext &context,
+                                   bool *out_cache_hit) {
+  auto &cache = ObjectCache::GetObjectCache(context);
+  auto existing =
+      cache.Get<LanceSharedSessionEntry>(LANCE_SHARED_SESSION_CACHE_KEY);
+  if (out_cache_hit) {
+    *out_cache_hit = existing != nullptr;
+  }
+  auto entry = existing ? existing
+                        : cache.GetOrCreate<LanceSharedSessionEntry>(
+                              LANCE_SHARED_SESSION_CACHE_KEY);
+  if (!entry || !entry->Handle()) {
+    throw IOException("Failed to access shared Lance session");
+  }
+  return entry;
+}
+
+LanceSessionState::LanceSessionState(ClientContext &context)
+    : shared_session(GetOrCreateLanceSharedSessionEntry(
+          context, &shared_session_cache_hit)) {}
+
+LanceSessionState::~LanceSessionState() = default;
+
+void *LanceSessionState::Handle() const {
+  return shared_session ? shared_session->Handle() : nullptr;
+}
+
 void LanceSessionState::WriteProfilingInformation(std::ostream &ss) {
-  LanceSessionStats stats;
-  memset(&stats, 0, sizeof(stats));
+  LanceSessionStats stats{};
+
+  auto *session = Handle();
   if (session && lance_session_get_stats(session, &stats) == 0) {
-    ss << "Lance Session Cache: approx_num_items=" << stats.approx_num_items
+    ss << "Lance Session Cache: scope=database_shared shared_session_id="
+       << shared_session->Id()
+       << " object_cache_hit=" << (shared_session_cache_hit ? "true" : "false")
+       << " approx_num_items=" << stats.approx_num_items
        << " size_bytes=" << stats.size_bytes << "\n";
     return;
   }
-  ss << "Lance Session Cache: unavailable\n";
+
+  ss << "Lance Session Cache: scope=database_shared shared_session_id="
+     << (shared_session ? shared_session->Id() : 0)
+     << " object_cache_hit=" << (shared_session_cache_hit ? "true" : "false")
+     << " unavailable\n";
 }
+
 shared_ptr<LanceSessionState>
 GetOrCreateLanceSessionState(ClientContext &context) {
   return context.registered_state->GetOrCreate<LanceSessionState>(
-      LANCE_SESSION_STATE_KEY);
+      LANCE_SESSION_STATE_KEY, context);
 }
 
 void *LanceGetSessionHandle(ClientContext &context) {

--- a/test/sql/session_cache_scope.test
+++ b/test/sql/session_cache_scope.test
@@ -1,0 +1,15 @@
+# name: test/sql/session_cache_scope.test
+# description: Lance session cache is shared per database while dataset cache remains connection-local
+# group: [sql]
+
+require lance
+
+query II con1
+EXPLAIN ANALYZE SELECT count(*) FROM 'test/data/test_data.lance';
+----
+analyzed_plan	<REGEX>:[\s\S]*Lance Session Cache: scope=database_shared[\s\S]*object_cache_hit=false[\s\S]*Lance Dataset Cache: entries=1 hits=0 misses=1[\s\S]*
+
+query II con2
+EXPLAIN ANALYZE SELECT count(*) FROM 'test/data/test_data.lance';
+----
+analyzed_plan	<REGEX>:[\s\S]*Lance Session Cache: scope=database_shared[\s\S]*object_cache_hit=true[\s\S]*Lance Dataset Cache: entries=1 hits=0 misses=1[\s\S]*


### PR DESCRIPTION
This PR promotes Lance `Session` ownership from connection-local state to a database-level shared cache by storing it in DuckDB's `ObjectCache`. It keeps dataset snapshots connection-local, so we reuse manifest/index/object-store state across connections without widening dataset snapshot staleness semantics.

It also adds a DuckDB-native verification path through `EXPLAIN ANALYZE`, so we can observe shared-session reuse and confirm dataset cache remains connection-local after the change. This was validated locally with `cargo check`, debug/release builds, and targeted cache SQL tests.