### PR TITLE
feat(cache): reuse shared sessions for writes

### DIFF
--- a/rust/ffi/dataset.rs
+++ b/rust/ffi/dataset.rs
@@ -604,6 +604,7 @@ pub unsafe extern "C" fn lance_delete_transaction_with_storage_options(
     options_len: usize,
     filter_ir: *const u8,
     filter_ir_len: usize,
+    session: *mut c_void,
     out_transaction: *mut *mut c_void,
     out_deleted_rows: *mut i64,
 ) -> i32 {
@@ -614,6 +615,7 @@ pub unsafe extern "C" fn lance_delete_transaction_with_storage_options(
         options_len,
         filter_ir,
         filter_ir_len,
+        session,
         out_transaction,
         out_deleted_rows,
     ) {
@@ -636,6 +638,7 @@ fn delete_transaction_with_storage_options_inner(
     options_len: usize,
     filter_ir: *const u8,
     filter_ir_len: usize,
+    session: *mut c_void,
     out_transaction: *mut *mut c_void,
     out_deleted_rows: *mut i64,
 ) -> FfiResult<()> {
@@ -704,13 +707,14 @@ fn delete_transaction_with_storage_options_inner(
             .to_string(),
         None => "true".to_string(),
     };
+    let session = unsafe { optional_session_handle(session)? };
 
     let (maybe_txn, deleted_rows) = match runtime::block_on(async {
-        let dataset = DatasetBuilder::from_uri(path_str)
-            .with_storage_options(storage_options)
-            .load()
-            .await
-            .map_err(|e| e.to_string())?;
+        let mut builder = DatasetBuilder::from_uri(path_str).with_storage_options(storage_options);
+        if let Some(session) = session.clone() {
+            builder = builder.with_session(session);
+        }
+        let dataset = builder.load().await.map_err(|e| e.to_string())?;
         let dataset = Arc::new(dataset);
 
         let mut scanner = dataset.scan();

--- a/rust/ffi/merge.rs
+++ b/rust/ffi/merge.rs
@@ -18,12 +18,13 @@ use crate::error::{clear_last_error, set_last_error, ErrorCode};
 use crate::runtime;
 
 use super::update::{apply_deletions, build_row_id_index};
-use super::util::{cstr_to_str, slice_from_ptr, FfiError, FfiResult};
+use super::util::{cstr_to_str, optional_session_handle, slice_from_ptr, FfiError, FfiResult};
 
 struct MergeHandle {
     input_schema: Arc<arrow_schema::Schema>,
     data_type: DataType,
     path: String,
+    session: Option<Arc<lance::session::Session>>,
     storage_options: HashMap<String, String>,
     max_rows_per_file: usize,
     max_rows_per_group: usize,
@@ -55,6 +56,7 @@ pub unsafe extern "C" fn lance_merge_begin_with_storage_options(
     max_rows_per_file: u64,
     max_rows_per_group: u64,
     max_bytes_per_file: u64,
+    session: *mut c_void,
     out_merge_handle: *mut *mut c_void,
 ) -> i32 {
     match merge_begin_with_storage_options_inner(
@@ -65,6 +67,7 @@ pub unsafe extern "C" fn lance_merge_begin_with_storage_options(
         max_rows_per_file,
         max_rows_per_group,
         max_bytes_per_file,
+        session,
         out_merge_handle,
     ) {
         Ok(()) => {
@@ -87,6 +90,7 @@ fn merge_begin_with_storage_options_inner(
     max_rows_per_file: u64,
     max_rows_per_group: u64,
     max_bytes_per_file: u64,
+    session: *mut c_void,
     out_merge_handle: *mut *mut c_void,
 ) -> FfiResult<()> {
     if out_merge_handle.is_null() {
@@ -151,13 +155,15 @@ fn merge_begin_with_storage_options_inner(
             format!("invalid max_bytes_per_file: {err}"),
         )
     })?;
+    let session = unsafe { optional_session_handle(session)? };
 
     let input_schema: Arc<arrow_schema::Schema> = match runtime::block_on(async {
-        DatasetBuilder::from_uri(path.as_str())
-            .with_storage_options(storage_options.clone())
-            .load()
-            .await
-            .map_err(|e| e.to_string())
+        let mut builder = DatasetBuilder::from_uri(path.as_str())
+            .with_storage_options(storage_options.clone());
+        if let Some(session) = session.clone() {
+            builder = builder.with_session(session);
+        }
+        builder.load().await.map_err(|e| e.to_string())
     }) {
         Ok(Ok(dataset)) => Arc::new(dataset.schema().into()),
         Ok(Err(message)) => {
@@ -179,6 +185,7 @@ fn merge_begin_with_storage_options_inner(
         input_schema,
         data_type,
         path,
+        session,
         storage_options,
         max_rows_per_file,
         max_rows_per_group,
@@ -335,11 +342,12 @@ fn merge_finish_uncommitted_inner(
     let handle = unsafe { Box::from_raw(merge_handle as *mut MergeHandle) };
 
     let maybe_txn = match runtime::block_on(async move {
-        let dataset = DatasetBuilder::from_uri(handle.path.as_str())
-            .with_storage_options(handle.storage_options.clone())
-            .load()
-            .await
-            .map_err(|e| e.to_string())?;
+        let mut builder = DatasetBuilder::from_uri(handle.path.as_str())
+            .with_storage_options(handle.storage_options.clone());
+        if let Some(session) = handle.session.clone() {
+            builder = builder.with_session(session);
+        }
+        let dataset = builder.load().await.map_err(|e| e.to_string())?;
         let dataset = Arc::new(dataset);
 
         let mut new_fragments = Vec::new();
@@ -356,6 +364,7 @@ fn merge_finish_uncommitted_inner(
                 max_rows_per_file: handle.max_rows_per_file,
                 max_rows_per_group: handle.max_rows_per_group,
                 max_bytes_per_file: handle.max_bytes_per_file,
+                session: handle.session.clone(),
                 store_params: Some(store_params),
                 ..Default::default()
             };

--- a/rust/ffi/update.rs
+++ b/rust/ffi/update.rs
@@ -28,7 +28,7 @@ use crate::expr_ir::parse_expr_ir;
 use crate::filter_ir::parse_filter_ir;
 use crate::runtime;
 
-use super::util::{cstr_to_str, slice_from_ptr, FfiError, FfiResult};
+use super::util::{cstr_to_str, optional_session_handle, slice_from_ptr, FfiError, FfiResult};
 
 #[no_mangle]
 pub unsafe extern "C" fn lance_overwrite_update_transaction_with_irs_and_storage_options(
@@ -45,6 +45,7 @@ pub unsafe extern "C" fn lance_overwrite_update_transaction_with_irs_and_storage
     max_rows_per_file: u64,
     max_rows_per_group: u64,
     max_bytes_per_file: u64,
+    session: *mut c_void,
     out_transaction: *mut *mut c_void,
     out_rows_updated: *mut u64,
 ) -> i32 {
@@ -62,6 +63,7 @@ pub unsafe extern "C" fn lance_overwrite_update_transaction_with_irs_and_storage
         max_rows_per_file,
         max_rows_per_group,
         max_bytes_per_file,
+        session,
         out_transaction,
         out_rows_updated,
     ) {
@@ -128,6 +130,7 @@ fn rewrite_rows_update_transaction_inner(
     max_rows_per_file: u64,
     max_rows_per_group: u64,
     max_bytes_per_file: u64,
+    session: *mut c_void,
     out_transaction: *mut *mut c_void,
     out_rows_updated: *mut u64,
 ) -> FfiResult<()> {
@@ -258,6 +261,7 @@ fn rewrite_rows_update_transaction_inner(
             format!("invalid max_bytes_per_file: {err}"),
         )
     })?;
+    let session = unsafe { optional_session_handle(session)? };
 
     let mut store_params = ObjectStoreParams::default();
     if !storage_options.is_empty() {
@@ -267,11 +271,13 @@ fn rewrite_rows_update_transaction_inner(
     }
 
     let (maybe_txn, rows_updated) = match runtime::block_on(async {
-        let dataset = lance::dataset::builder::DatasetBuilder::from_uri(path.as_str())
-            .with_storage_options(storage_options)
-            .load()
-            .await
-            .map_err(|e| e.to_string())?;
+        let mut builder =
+            lance::dataset::builder::DatasetBuilder::from_uri(path.as_str())
+                .with_storage_options(storage_options);
+        if let Some(session) = session.clone() {
+            builder = builder.with_session(session);
+        }
+        let dataset = builder.load().await.map_err(|e| e.to_string())?;
         let dataset = Arc::new(dataset);
 
         let arrow_schema: Arc<arrow_schema::Schema> = Arc::new(dataset.schema().into());
@@ -387,6 +393,7 @@ fn rewrite_rows_update_transaction_inner(
             max_rows_per_file,
             max_rows_per_group,
             max_bytes_per_file,
+            session: session.clone(),
             store_params: Some(store_params),
             ..Default::default()
         };

--- a/rust/ffi/write.rs
+++ b/rust/ffi/write.rs
@@ -20,7 +20,7 @@ use crate::error::{clear_last_error, set_last_error, ErrorCode};
 use crate::runtime;
 
 use super::session::record_commit;
-use super::util::{cstr_to_str, slice_from_ptr, FfiError, FfiResult};
+use super::util::{cstr_to_str, optional_session_handle, slice_from_ptr, FfiError, FfiResult};
 
 #[repr(C)]
 struct RawArrowArray {
@@ -529,6 +529,7 @@ pub unsafe extern "C" fn lance_open_writer_with_storage_options(
     max_rows_per_group: u64,
     max_bytes_per_file: u64,
     data_storage_version: *const c_char,
+    session: *mut c_void,
     schema: *const c_void,
 ) -> *mut c_void {
     match open_writer_inner(
@@ -541,6 +542,7 @@ pub unsafe extern "C" fn lance_open_writer_with_storage_options(
         max_rows_per_group,
         max_bytes_per_file,
         data_storage_version,
+        session,
         schema,
     ) {
         Ok(handle) => {
@@ -565,6 +567,7 @@ pub unsafe extern "C" fn lance_open_uncommitted_writer_with_storage_options(
     max_rows_per_group: u64,
     max_bytes_per_file: u64,
     data_storage_version: *const c_char,
+    session: *mut c_void,
     schema: *const c_void,
 ) -> *mut c_void {
     match open_uncommitted_writer_inner(
@@ -577,6 +580,7 @@ pub unsafe extern "C" fn lance_open_uncommitted_writer_with_storage_options(
         max_rows_per_group,
         max_bytes_per_file,
         data_storage_version,
+        session,
         schema,
     ) {
         Ok(handle) => {
@@ -627,6 +631,7 @@ fn open_uncommitted_writer_inner(
     max_rows_per_group: u64,
     max_bytes_per_file: u64,
     data_storage_version: *const c_char,
+    session: *mut c_void,
     schema: *const c_void,
 ) -> FfiResult<WriterHandle> {
     let path = unsafe { cstr_to_str(path, "path")? }.to_string();
@@ -718,6 +723,7 @@ fn open_uncommitted_writer_inner(
             })
         })
         .transpose()?;
+    let session = unsafe { optional_session_handle(session)? };
 
     let mut store_params = ObjectStoreParams::default();
     if !storage_options.is_empty() {
@@ -732,6 +738,7 @@ fn open_uncommitted_writer_inner(
         max_rows_per_group,
         max_bytes_per_file,
         data_storage_version,
+        session,
         store_params: Some(store_params),
         ..Default::default()
     };
@@ -775,6 +782,7 @@ fn open_writer_inner(
     max_rows_per_group: u64,
     max_bytes_per_file: u64,
     data_storage_version: *const c_char,
+    session: *mut c_void,
     schema: *const c_void,
 ) -> FfiResult<WriterHandle> {
     let path = unsafe { cstr_to_str(path, "path")? }.to_string();
@@ -866,6 +874,7 @@ fn open_writer_inner(
             })
         })
         .transpose()?;
+    let session = unsafe { optional_session_handle(session)? };
 
     let mut store_params = ObjectStoreParams::default();
     if !storage_options.is_empty() {
@@ -880,6 +889,7 @@ fn open_writer_inner(
         max_rows_per_group,
         max_bytes_per_file,
         data_storage_version,
+        session,
         store_params: Some(store_params),
         ..Default::default()
     };
@@ -1313,9 +1323,17 @@ pub unsafe extern "C" fn lance_commit_transaction_with_storage_options(
     option_keys: *const *const c_char,
     option_values: *const *const c_char,
     options_len: usize,
+    session: *mut c_void,
     transaction: *mut c_void,
 ) -> i32 {
-    match commit_transaction_inner(path, option_keys, option_values, options_len, transaction) {
+    match commit_transaction_inner(
+        path,
+        option_keys,
+        option_values,
+        options_len,
+        session,
+        transaction,
+    ) {
         Ok(()) => {
             clear_last_error();
             0
@@ -1332,6 +1350,7 @@ fn commit_transaction_inner(
     option_keys: *const *const c_char,
     option_values: *const *const c_char,
     options_len: usize,
+    session: *mut c_void,
     transaction: *mut c_void,
 ) -> FfiResult<()> {
     let path = unsafe { cstr_to_str(path, "path")? }.to_string();
@@ -1383,12 +1402,15 @@ fn commit_transaction_inner(
             StorageOptionsAccessor::with_static_options(storage_options),
         ));
     }
+    let session = unsafe { optional_session_handle(session)? };
 
     let txn =
         unsafe { Box::from_raw(transaction as *mut lance::dataset::transaction::Transaction) };
-    let fut = CommitBuilder::new(path.as_str())
-        .with_store_params(store_params)
-        .execute(*txn);
+    let mut builder = CommitBuilder::new(path.as_str()).with_store_params(store_params);
+    if let Some(session) = session {
+        builder = builder.with_session(session);
+    }
+    let fut = builder.execute(*txn);
     match runtime::block_on(fut) {
         Ok(Ok(_)) => {
             record_commit();

--- a/src/include/lance_common.hpp
+++ b/src/include/lance_common.hpp
@@ -94,8 +94,9 @@ void ResolveLanceStorageOptionsForTable(ClientContext &context,
                                         string &out_display_uri);
 
 int64_t LanceTruncateDatasetWithStorageOptions(
-    const string &open_path, const vector<string> &option_keys,
-    const vector<string> &option_values, const string &display_uri);
+    ClientContext &context, const string &open_path,
+    const vector<string> &option_keys, const vector<string> &option_values,
+    const string &display_uri);
 
 int64_t LanceTruncateDataset(ClientContext &context, const string &dataset_uri);
 

--- a/src/include/lance_ffi.hpp
+++ b/src/include/lance_ffi.hpp
@@ -104,7 +104,7 @@ int32_t lance_dataset_delete(void *dataset, const uint8_t *filter_ir,
 int32_t lance_delete_transaction_with_storage_options(
     const char *path, const char **option_keys, const char **option_values,
     size_t options_len, const uint8_t *filter_ir, size_t filter_ir_len,
-    void **out_transaction, int64_t *out_deleted_rows);
+    void *session, void **out_transaction, int64_t *out_deleted_rows);
 
 int32_t lance_dataset_add_columns(void *dataset,
                                   const ArrowSchema *new_columns_schema,
@@ -204,12 +204,12 @@ void *lance_open_writer_with_storage_options(
     const char *path, const char *mode, const char **option_keys,
     const char **option_values, size_t options_len, uint64_t max_rows_per_file,
     uint64_t max_rows_per_group, uint64_t max_bytes_per_file,
-    const char *data_storage_version, const ArrowSchema *schema);
+    const char *data_storage_version, void *session, const ArrowSchema *schema);
 void *lance_open_uncommitted_writer_with_storage_options(
     const char *path, const char *mode, const char **option_keys,
     const char **option_values, size_t options_len, uint64_t max_rows_per_file,
     uint64_t max_rows_per_group, uint64_t max_bytes_per_file,
-    const char *data_storage_version, const ArrowSchema *schema);
+    const char *data_storage_version, void *session, const ArrowSchema *schema);
 int32_t lance_writer_write_batch(void *writer, ArrowArray *array);
 int32_t lance_writer_finish(void *writer);
 int32_t lance_writer_finish_uncommitted(void *writer, void **out_transaction);
@@ -217,7 +217,7 @@ void lance_close_writer(void *writer);
 
 int32_t lance_commit_transaction_with_storage_options(
     const char *path, const char **option_keys, const char **option_values,
-    size_t options_len, void *transaction);
+    size_t options_len, void *session, void *transaction);
 void lance_free_transaction(void *transaction);
 
 int32_t lance_overwrite_update_transaction_with_irs_and_storage_options(
@@ -225,13 +225,13 @@ int32_t lance_overwrite_update_transaction_with_irs_and_storage_options(
     size_t options_len, const uint8_t *predicate_ir, size_t predicate_ir_len,
     const char **set_columns, const uint8_t **set_expr_irs,
     const size_t *set_expr_ir_lens, size_t set_len, uint64_t max_rows_per_file,
-    uint64_t max_rows_per_group, uint64_t max_bytes_per_file,
+    uint64_t max_rows_per_group, uint64_t max_bytes_per_file, void *session,
     void **out_transaction, uint64_t *out_rows_updated);
 
 int32_t lance_merge_begin_with_storage_options(
     const char *path, const char **option_keys, const char **option_values,
     size_t options_len, uint64_t max_rows_per_file, uint64_t max_rows_per_group,
-    uint64_t max_bytes_per_file, void **out_merge_handle);
+    uint64_t max_bytes_per_file, void *session, void **out_merge_handle);
 int32_t lance_merge_add_delete_rowids(void *merge_handle,
                                       const uint64_t *row_ids,
                                       size_t row_ids_len);

--- a/src/lance_common.cpp
+++ b/src/lance_common.cpp
@@ -542,8 +542,9 @@ void ResolveLanceStorageOptionsForTable(ClientContext &context,
 }
 
 int64_t LanceTruncateDatasetWithStorageOptions(
-    const string &open_path, const vector<string> &option_keys,
-    const vector<string> &option_values, const string &display_uri) {
+    ClientContext &context, const string &open_path,
+    const vector<string> &option_keys, const vector<string> &option_values,
+    const string &display_uri) {
   vector<const char *> key_ptrs;
   vector<const char *> value_ptrs;
   BuildStorageOptionPointerArrays(option_keys, option_values, key_ptrs,
@@ -594,7 +595,8 @@ int64_t LanceTruncateDatasetWithStorageOptions(
       key_ptrs.empty() ? nullptr : key_ptrs.data(),
       value_ptrs.empty() ? nullptr : value_ptrs.data(), option_keys.size(),
       LANCE_DEFAULT_MAX_ROWS_PER_FILE, LANCE_DEFAULT_MAX_ROWS_PER_GROUP,
-      LANCE_DEFAULT_MAX_BYTES_PER_FILE, nullptr, &schema_root.arrow_schema);
+      LANCE_DEFAULT_MAX_BYTES_PER_FILE, nullptr, LanceGetSessionHandle(context),
+      &schema_root.arrow_schema);
   if (!writer) {
     throw IOException("Failed to open Lance writer: " + open_path +
                       LanceFormatErrorSuffix());
@@ -616,7 +618,7 @@ int64_t LanceTruncateDataset(ClientContext &context,
   vector<string> option_values;
   ResolveLanceStorageOptions(context, dataset_uri, open_path, option_keys,
                              option_values);
-  return LanceTruncateDatasetWithStorageOptions(open_path, option_keys,
+  return LanceTruncateDatasetWithStorageOptions(context, open_path, option_keys,
                                                 option_values, dataset_uri);
 }
 

--- a/src/lance_delete.cpp
+++ b/src/lance_delete.cpp
@@ -14,6 +14,7 @@
 #include "lance_ffi.hpp"
 #include "lance_filter_ir.hpp"
 #include "lance_insert.hpp"
+#include "lance_session_state.hpp"
 #include "lance_table_entry.hpp"
 
 namespace duckdb {
@@ -186,7 +187,8 @@ public:
     auto rc = lance_delete_transaction_with_storage_options(
         open_path.c_str(), key_ptrs.empty() ? nullptr : key_ptrs.data(),
         value_ptrs.empty() ? nullptr : value_ptrs.data(), option_keys.size(),
-        filter_ptr, filter_ir.size(), &txn, &deleted_rows);
+        filter_ptr, filter_ir.size(), LanceGetSessionHandle(context.client),
+        &txn, &deleted_rows);
     if (rc != 0) {
       throw IOException("Failed to create Lance DELETE transaction for '" +
                         open_path + "'" + LanceFormatErrorSuffix());
@@ -202,7 +204,7 @@ public:
       rc = lance_commit_transaction_with_storage_options(
           open_path.c_str(), key_ptrs.empty() ? nullptr : key_ptrs.data(),
           value_ptrs.empty() ? nullptr : value_ptrs.data(), option_keys.size(),
-          txn);
+          LanceGetSessionHandle(context.client), txn);
       if (rc != 0) {
         throw IOException("Failed to commit Lance DELETE transaction for '" +
                           open_path + "'" + LanceFormatErrorSuffix());

--- a/src/lance_insert.cpp
+++ b/src/lance_insert.cpp
@@ -10,6 +10,7 @@
 #include "lance_dataset_cache.hpp"
 #include "lance_ffi.hpp"
 #include "lance_insert.hpp"
+#include "lance_session_state.hpp"
 #include "lance_table_entry.hpp"
 
 #include <cstdint>
@@ -113,7 +114,8 @@ public:
           value_ptrs.empty() ? nullptr : value_ptrs.data(),
           gstate.option_keys.size(), LANCE_DEFAULT_MAX_ROWS_PER_FILE,
           LANCE_DEFAULT_MAX_ROWS_PER_GROUP, LANCE_DEFAULT_MAX_BYTES_PER_FILE,
-          nullptr, &gstate.schema_root.arrow_schema);
+          nullptr, LanceGetSessionHandle(context.client),
+          &gstate.schema_root.arrow_schema);
       if (!gstate.writer) {
         throw IOException("Failed to open Lance writer: " + gstate.open_path +
                           LanceFormatErrorSuffix());

--- a/src/lance_merge.cpp
+++ b/src/lance_merge.cpp
@@ -16,6 +16,7 @@
 #include "lance_ffi.hpp"
 #include "lance_insert.hpp"
 #include "lance_merge.hpp"
+#include "lance_session_state.hpp"
 #include "lance_table_entry.hpp"
 
 #include <cstdint>
@@ -440,7 +441,8 @@ void LanceMergeGlobalState::EnsureMergeHandle(ClientContext &context) {
       open_path.c_str(), key_ptrs.empty() ? nullptr : key_ptrs.data(),
       value_ptrs.empty() ? nullptr : value_ptrs.data(), option_keys.size(),
       LANCE_DEFAULT_MAX_ROWS_PER_FILE, LANCE_DEFAULT_MAX_ROWS_PER_GROUP,
-      LANCE_DEFAULT_MAX_BYTES_PER_FILE, &merge_handle);
+      LANCE_DEFAULT_MAX_BYTES_PER_FILE, LanceGetSessionHandle(context),
+      &merge_handle);
   if (rc != 0 || !merge_handle) {
     throw IOException("Failed to start Lance MERGE transaction for '" +
                       open_path + "'" + LanceFormatErrorSuffix());

--- a/src/lance_storage.cpp
+++ b/src/lance_storage.cpp
@@ -42,6 +42,7 @@
 #include "lance_ffi.hpp"
 #include "lance_insert.hpp"
 #include "lance_merge.hpp"
+#include "lance_session_state.hpp"
 #include "lance_table_entry.hpp"
 #include "lance_update.hpp"
 
@@ -987,7 +988,7 @@ public:
         value_ptrs.empty() ? nullptr : value_ptrs.data(), option_keys.size(),
         LANCE_DEFAULT_MAX_ROWS_PER_FILE, LANCE_DEFAULT_MAX_ROWS_PER_GROUP,
         LANCE_DEFAULT_MAX_BYTES_PER_FILE, data_storage_version_ptr,
-        &schema_root.arrow_schema);
+        LanceGetSessionHandle(context), &schema_root.arrow_schema);
     if (!writer) {
       throw IOException("Failed to open Lance writer: " + dataset_path +
                         LanceFormatErrorSuffix());
@@ -1329,7 +1330,7 @@ public:
               state->option_keys.size(), LANCE_DEFAULT_MAX_ROWS_PER_FILE,
               LANCE_DEFAULT_MAX_ROWS_PER_GROUP,
               LANCE_DEFAULT_MAX_BYTES_PER_FILE, data_storage_version_ptr,
-              &state->schema_root.arrow_schema);
+              LanceGetSessionHandle(context), &state->schema_root.arrow_schema);
           if (!state->writer) {
             throw IOException("Failed to open Lance writer: " +
                               state->open_path + LanceFormatErrorSuffix());
@@ -1812,7 +1813,8 @@ public:
       auto rc = lance_commit_transaction_with_storage_options(
           pending.path.c_str(), key_ptrs.empty() ? nullptr : key_ptrs.data(),
           value_ptrs.empty() ? nullptr : value_ptrs.data(),
-          pending.option_keys.size(), pending.transaction);
+          pending.option_keys.size(), LanceGetSessionHandle(context),
+          pending.transaction);
       if (rc != 0) {
         // Best-effort cleanup of any remaining pending transactions.
         // Note: the transaction pointer is consumed by the commit call, even on

--- a/src/lance_truncate.cpp
+++ b/src/lance_truncate.cpp
@@ -173,7 +173,7 @@ static void LanceTruncateFunc(ClientContext &context, TableFunctionInput &data,
   ResolveLanceStorageOptionsForTable(context, *lance_entry, open_path,
                                      option_keys, option_values, display_uri);
   auto row_count = LanceTruncateDatasetWithStorageOptions(
-      open_path, option_keys, option_values, display_uri);
+      context, open_path, option_keys, option_values, display_uri);
   LanceInvalidateDatasetCacheForTable(context, *lance_entry);
 
   output.SetCardinality(1);

--- a/src/lance_update.cpp
+++ b/src/lance_update.cpp
@@ -23,6 +23,7 @@
 #include "lance_filter_ir.hpp"
 #include "lance_insert.hpp"
 #include "lance_scan_bind_data.hpp"
+#include "lance_session_state.hpp"
 #include "lance_table_entry.hpp"
 #include "lance_update.hpp"
 
@@ -235,7 +236,8 @@ public:
         predicate_ptr, predicate_ir.size(), set_col_ptrs.data(),
         set_expr_ir_ptrs.data(), set_expr_ir_lens.data(), set_columns.size(),
         LANCE_DEFAULT_MAX_ROWS_PER_FILE, LANCE_DEFAULT_MAX_ROWS_PER_GROUP,
-        LANCE_DEFAULT_MAX_BYTES_PER_FILE, &txn, &rows_updated);
+        LANCE_DEFAULT_MAX_BYTES_PER_FILE, LanceGetSessionHandle(context.client),
+        &txn, &rows_updated);
     if (rc != 0) {
       throw IOException("Failed to create Lance UPDATE transaction for '" +
                         open_path + "'" + LanceFormatErrorSuffix());

--- a/src/lance_write.cpp
+++ b/src/lance_write.cpp
@@ -8,6 +8,7 @@
 #include "lance_common.hpp"
 #include "lance_dataset_cache.hpp"
 #include "lance_ffi.hpp"
+#include "lance_session_state.hpp"
 
 #include <cstdint>
 
@@ -152,12 +153,13 @@ LanceWriteInitGlobal(ClientContext &context, FunctionData &bind_data_p,
       bind_data.data_storage_version.empty()
           ? nullptr
           : bind_data.data_storage_version.c_str();
+  auto *session = LanceGetSessionHandle(context);
   state->writer = lance_open_writer_with_storage_options(
       open_path.c_str(), bind_data.mode.c_str(),
       key_ptrs.empty() ? nullptr : key_ptrs.data(),
       value_ptrs.empty() ? nullptr : value_ptrs.data(), option_keys.size(),
       bind_data.max_rows_per_file, bind_data.max_rows_per_group,
-      bind_data.max_bytes_per_file, data_storage_version_ptr,
+      bind_data.max_bytes_per_file, data_storage_version_ptr, session,
       &state->schema_root.arrow_schema);
   if (!state->writer) {
     throw IOException("Failed to open Lance writer: " + open_path +

--- a/test/sql/session_cache_scope.test
+++ b/test/sql/session_cache_scope.test
@@ -13,3 +13,13 @@ query II con2
 EXPLAIN ANALYZE SELECT count(*) FROM 'test/data/test_data.lance';
 ----
 analyzed_plan	<REGEX>:[\s\S]*Lance Session Cache: scope=database_shared[\s\S]*object_cache_hit=true[\s\S]*Lance Dataset Cache: entries=1 hits=0 misses=1[\s\S]*
+
+query II con1
+EXPLAIN ANALYZE COPY (SELECT 1::BIGINT AS id) TO 'test/.tmp/session_cache_scope_write.lance' (FORMAT lance, mode 'overwrite');
+----
+analyzed_plan	<REGEX>:[\s\S]*Lance Session Cache: scope=database_shared[\s\S]*object_cache_hit=false[\s\S]*
+
+query II con2
+EXPLAIN ANALYZE COPY (SELECT 2::BIGINT AS id) TO 'test/.tmp/session_cache_scope_write.lance' (FORMAT lance, mode 'append');
+----
+analyzed_plan	<REGEX>:[\s\S]*Lance Session Cache: scope=database_shared[\s\S]*object_cache_hit=true[\s\S]*


### PR DESCRIPTION
This extends the database-level shared Lance session from read paths into write paths. Writers, uncommitted transactions, commit, delete, update, merge, and truncate now all reuse the same shared session so write-heavy workloads can benefit from the same manifest, metadata, index, and object-store caches.

The change also adds a scope regression in `session_cache_scope.test` to verify that write-side profiling shows database-shared session reuse across connections. Local validation covered `cargo check`, `make debug`, and the DML/cache regression tests for insert, update, delete, merge, truncate, copy, precise invalidation, and session cache scope.
