### PR TITLE
chore: update lance dependency to v4.0.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2236,9 +2236,9 @@ checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "fsst"
-version = "4.0.0"
+version = "4.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2195cc7f87e84bd695586137de99605e7e9579b26ec5e01b82960ddb4d0922f2"
+checksum = "2b3a6f3550e61b999febd7168d462db953948eff4fc3448276b3d10d10324dbb"
 dependencies = [
  "arrow-array",
  "rand 0.9.2",
@@ -2974,9 +2974,9 @@ dependencies = [
 
 [[package]]
 name = "lance"
-version = "4.0.0"
+version = "4.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efe6c3ddd79cdfd2b7e1c23cafae52806906bc40fbd97de9e8cf2f8c7a75fc04"
+checksum = "f63e285ceee2b4ca8eb3a8742266cc1ac8161599767a8ecb4d8c2f9fd43d8b29"
 dependencies = [
  "arrow",
  "arrow-arith",
@@ -3041,9 +3041,9 @@ dependencies = [
 
 [[package]]
 name = "lance-arrow"
-version = "4.0.0"
+version = "4.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d9f5d95bdda2a2b790f1fb8028b5b6dcf661abeb3133a8bca0f3d24b054af87"
+checksum = "5c55e62fc04422ef4cd4af6f863ada32641ae23124f9b2e9c567a40d617e8c97"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -3063,9 +3063,9 @@ dependencies = [
 
 [[package]]
 name = "lance-bitpacking"
-version = "4.0.0"
+version = "4.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f827d6ab9f8f337a9509d5ad66a12f3314db8713868260521c344ef6135eb4e4"
+checksum = "a48d232a2908645af0040f96c60a6387fea2df75e762d7033e93e17bb420c6a1"
 dependencies = [
  "arrayref",
  "paste",
@@ -3074,9 +3074,9 @@ dependencies = [
 
 [[package]]
 name = "lance-core"
-version = "4.0.0"
+version = "4.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f1e25df6a79bf72ee6bcde0851f19b1cd36c5848c1b7db83340882d3c9fdecb"
+checksum = "ce071baaff88fcdcf67f1dd0af54e17656f52ae75aaeb75f25f9cf4da29241f2"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -3113,9 +3113,9 @@ dependencies = [
 
 [[package]]
 name = "lance-datafusion"
-version = "4.0.0"
+version = "4.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93146de8ae720cb90edef81c2f2d0a1b065fc2f23ecff2419546f389b0fa70a4"
+checksum = "11ebc97ee94fa8e1af6fd0520066c7e7e0eab38a100e750ba9aabad644c5aa57"
 dependencies = [
  "arrow",
  "arrow-array",
@@ -3145,9 +3145,9 @@ dependencies = [
 
 [[package]]
 name = "lance-datagen"
-version = "4.0.0"
+version = "4.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccec8ce4d8e0a87a99c431dab2364398029f2ffb649c1a693c60c79e05ed30dd"
+checksum = "9b90dbb2829875b3a3d00f88fd3a3e39a9e4c7d34c266f67da6550fcda54c76e"
 dependencies = [
  "arrow",
  "arrow-array",
@@ -3165,9 +3165,9 @@ dependencies = [
 
 [[package]]
 name = "lance-encoding"
-version = "4.0.0"
+version = "4.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c1aec0bbbac6bce829bc10f1ba066258126100596c375fb71908ecf11c2c2a5"
+checksum = "65ec429cc2e18ad1b7e43cc7ec57a2f2e49229cfbd934da45e619751a886b8cd"
 dependencies = [
  "arrow-arith",
  "arrow-array",
@@ -3204,9 +3204,9 @@ dependencies = [
 
 [[package]]
 name = "lance-file"
-version = "4.0.0"
+version = "4.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14a8c548804f5b17486dc2d3282356ed1957095a852780283bc401fdd69e9075"
+checksum = "418afe3f82487615fa09222b95a4b5853103f3f0425996d24a537ca750381f83"
 dependencies = [
  "arrow-arith",
  "arrow-array",
@@ -3238,9 +3238,9 @@ dependencies = [
 
 [[package]]
 name = "lance-index"
-version = "4.0.0"
+version = "4.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2da212f0090ea59f79ac3686660f596520c167fe1cb5f408900cf71d215f0e03"
+checksum = "936b3deeb6ee075646d18f27b01cf2d2e846c3f5f6c5fa45b30aa41dd5b4c4e2"
 dependencies = [
  "arrow",
  "arrow-arith",
@@ -3304,9 +3304,9 @@ dependencies = [
 
 [[package]]
 name = "lance-io"
-version = "4.0.0"
+version = "4.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41d958eb4b56f03bbe0f5f85eb2b4e9657882812297b6f711f201ffc995f259f"
+checksum = "4103e4cebe146af15bfb198c8142d6ea37d5b25fa04158bf2d9be4597bf174d3"
 dependencies = [
  "arrow",
  "arrow-arith",
@@ -3347,9 +3347,9 @@ dependencies = [
 
 [[package]]
 name = "lance-linalg"
-version = "4.0.0"
+version = "4.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0285b70da35def7ed95e150fae1d5308089554e1290470403ed3c50cb235bc5e"
+checksum = "c00c7ad71eca93635404519e77add6689947c9342134bb2133578f81249bf809"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -3365,9 +3365,9 @@ dependencies = [
 
 [[package]]
 name = "lance-namespace"
-version = "4.0.0"
+version = "4.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f78e2a828b654e062a495462c6e3eb4fcf0e7e907d761b8f217fc09ccd3ceac"
+checksum = "e0c59a574e72a4b72da8096bcaaa1b1e5b44f6a83da164cc714c286fab30c369"
 dependencies = [
  "arrow",
  "async-trait",
@@ -3380,9 +3380,9 @@ dependencies = [
 
 [[package]]
 name = "lance-namespace-impls"
-version = "4.0.0"
+version = "4.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2392314f3da38f00d166295e44244208a65ccfc256e274fa8631849fc3f4d94"
+checksum = "3151e786935053b417aad0d6f4920cdd0cbf47246725b09a0a85408788027131"
 dependencies = [
  "arrow",
  "arrow-ipc",
@@ -3423,9 +3423,9 @@ dependencies = [
 
 [[package]]
 name = "lance-table"
-version = "4.0.0"
+version = "4.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3df9c4adca3eb2074b3850432a9fb34248a3d90c3d6427d158b13ff9355664ee"
+checksum = "943b9c503f23ebab9e0dbee356f528bc4cbcafded87a6848451f205b0bb473d7"
 dependencies = [
  "arrow",
  "arrow-array",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,14 +19,14 @@ panic = "abort"
 [dependencies]
 
 # Lance and Arrow dependencies - using compatible versions
-lance = { version = "4.0.0", default-features = false, features = ["aws", "azure", "gcp", "oss", "huggingface"] }
-lance-arrow = "4.0.0"
-lance-core = "4.0.0"
-lance-index = "4.0.0"
-lance-linalg = "4.0.0"
-lance-namespace = "4.0.0"
-lance-namespace-impls = { version = "4.0.0", features = ["rest"] }
-lance-table = "4.0.0"
+lance = { version = "4.0.1", default-features = false, features = ["aws", "azure", "gcp", "oss", "huggingface"] }
+lance-arrow = "4.0.1"
+lance-core = "4.0.1"
+lance-index = "4.0.1"
+lance-linalg = "4.0.1"
+lance-namespace = "4.0.1"
+lance-namespace-impls = { version = "4.0.1", features = ["rest"] }
+lance-table = "4.0.1"
 
 arrow = { version = "57.0.0", features = ["ffi"] }
 arrow-array = "57.0.0"

--- a/rust/ffi/dir_namespace.rs
+++ b/rust/ffi/dir_namespace.rs
@@ -142,22 +142,23 @@ fn open_dataset_in_dir_namespace_inner(
                 format!("dir namespace build '{root}': {err}"),
             )
         })?;
-        let mut builder = DatasetBuilder::from_namespace(
-            Arc::new(namespace),
-            vec![table_name.to_string()],
-        )
-            .await
-            .map_err(|err| {
-                FfiError::new(
-                    ErrorCode::DatasetOpen,
-                    format!("dir namespace describe '{root}/{table_name}': {err}"),
-                )
-            })?;
+        let mut builder =
+            DatasetBuilder::from_namespace(Arc::new(namespace), vec![table_name.to_string()])
+                .await
+                .map_err(|err| {
+                    FfiError::new(
+                        ErrorCode::DatasetOpen,
+                        format!("dir namespace describe '{root}/{table_name}': {err}"),
+                    )
+                })?;
         if let Some(session) = session {
             builder = builder.with_session(session);
         }
         builder.load().await.map_err(|err| {
-            FfiError::new(ErrorCode::DatasetOpen, format!("dir namespace dataset open: {err}"))
+            FfiError::new(
+                ErrorCode::DatasetOpen,
+                format!("dir namespace dataset open: {err}"),
+            )
         })
     })
     .map_err(|err| FfiError::new(ErrorCode::Runtime, format!("runtime: {err}")))??;

--- a/rust/ffi/merge.rs
+++ b/rust/ffi/merge.rs
@@ -158,8 +158,8 @@ fn merge_begin_with_storage_options_inner(
     let session = unsafe { optional_session_handle(session)? };
 
     let input_schema: Arc<arrow_schema::Schema> = match runtime::block_on(async {
-        let mut builder = DatasetBuilder::from_uri(path.as_str())
-            .with_storage_options(storage_options.clone());
+        let mut builder =
+            DatasetBuilder::from_uri(path.as_str()).with_storage_options(storage_options.clone());
         if let Some(session) = session.clone() {
             builder = builder.with_session(session);
         }

--- a/rust/ffi/namespace.rs
+++ b/rust/ffi/namespace.rs
@@ -580,22 +580,23 @@ fn open_dataset_in_namespace_inner(
 
     let (dataset, table_uri) = runtime::block_on(async move {
         record_namespace_describe();
-        let mut builder = DatasetBuilder::from_namespace(
-            Arc::new(namespace),
-            vec![table_id.to_string()],
-        )
-            .await
-            .map_err(|err| {
-                FfiError::new(
-                    ErrorCode::NamespaceDescribeTable,
-                    format!("namespace describe_table: {err}"),
-                )
-            })?;
+        let mut builder =
+            DatasetBuilder::from_namespace(Arc::new(namespace), vec![table_id.to_string()])
+                .await
+                .map_err(|err| {
+                    FfiError::new(
+                        ErrorCode::NamespaceDescribeTable,
+                        format!("namespace describe_table: {err}"),
+                    )
+                })?;
         if let Some(session) = session {
             builder = builder.with_session(session);
         }
         let dataset = builder.load().await.map_err(|err| {
-            FfiError::new(ErrorCode::DatasetOpen, format!("namespace dataset open: {err}"))
+            FfiError::new(
+                ErrorCode::DatasetOpen,
+                format!("namespace dataset open: {err}"),
+            )
         })?;
         let table_uri = dataset.uri().to_string();
         Ok::<_, FfiError>((Arc::new(dataset), table_uri))

--- a/rust/ffi/session.rs
+++ b/rust/ffi/session.rs
@@ -1,14 +1,14 @@
 use std::ffi::c_void;
 use std::ptr;
-use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
 
 use lance::session::Session;
 
 use crate::error::{clear_last_error, set_last_error, ErrorCode};
 
 use super::types::SessionHandle;
-use super::util::{FfiError, FfiResult, optional_session_handle, u64_to_usize};
+use super::util::{optional_session_handle, u64_to_usize, FfiError, FfiResult};
 
 static DATASET_OPEN_COUNT: AtomicU64 = AtomicU64::new(0);
 static NAMESPACE_DESCRIBE_COUNT: AtomicU64 = AtomicU64::new(0);
@@ -124,7 +124,7 @@ fn session_get_stats_inner(session: *mut c_void) -> FfiResult<LanceSessionStats>
 #[no_mangle]
 pub unsafe extern "C" fn lance_debug_get_counters(out_counters: *mut LanceDebugCounters) -> i32 {
     if out_counters.is_null() {
-        set_last_error(ErrorCode::InvalidArgument, "out_counters is null".to_string());
+        set_last_error(ErrorCode::InvalidArgument, "out_counters is null");
         return -1;
     }
 
@@ -161,8 +161,8 @@ mod tests {
 
     use crate::runtime;
 
-    use super::*;
     use super::super::dataset::{lance_close_dataset, lance_open_dataset_with_session};
+    use super::*;
 
     #[test]
     fn test_create_session_and_get_stats() {
@@ -180,12 +180,15 @@ mod tests {
 
     #[test]
     fn test_open_dataset_with_session_records_debug_counters() {
-        let dataset_dir = std::env::temp_dir().join(format!("ffi-session-{}", rand::random::<u64>()));
+        let dataset_dir =
+            std::env::temp_dir().join(format!("ffi-session-{}", rand::random::<u64>()));
         let uri = dataset_dir.to_string_lossy().to_string();
         let schema = Arc::new(Schema::new(vec![Field::new("id", DataType::Int32, false)]));
-        let batch =
-            RecordBatch::try_new(schema.clone(), vec![Arc::new(Int32Array::from(vec![1, 2, 3]))])
-                .unwrap();
+        let batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![Arc::new(Int32Array::from(vec![1, 2, 3]))],
+        )
+        .unwrap();
         let reader = RecordBatchIterator::new(vec![Ok(batch)].into_iter(), schema);
 
         unsafe {
@@ -193,13 +196,9 @@ mod tests {
             let session = lance_create_session(0, 0);
             assert!(!session.is_null());
 
-            runtime::block_on(Dataset::write(
-                reader,
-                &uri,
-                Some(WriteParams::default()),
-            ))
-            .unwrap()
-            .unwrap();
+            runtime::block_on(Dataset::write(reader, &uri, Some(WriteParams::default())))
+                .unwrap()
+                .unwrap();
 
             let uri_c = CString::new(uri.clone()).unwrap();
             let first = lance_open_dataset_with_session(uri_c.as_ptr(), session);

--- a/rust/ffi/types.rs
+++ b/rust/ffi/types.rs
@@ -2,8 +2,8 @@ use std::sync::Arc;
 
 use arrow::array::RecordBatch;
 use arrow::datatypes::Schema;
-use lance::Dataset;
 use lance::session::Session;
+use lance::Dataset;
 
 use crate::datafusion_stream::DataFusionStream;
 use crate::scanner::{LanceStream, LanceTakeStream};

--- a/rust/ffi/update.rs
+++ b/rust/ffi/update.rs
@@ -271,9 +271,8 @@ fn rewrite_rows_update_transaction_inner(
     }
 
     let (maybe_txn, rows_updated) = match runtime::block_on(async {
-        let mut builder =
-            lance::dataset::builder::DatasetBuilder::from_uri(path.as_str())
-                .with_storage_options(storage_options);
+        let mut builder = lance::dataset::builder::DatasetBuilder::from_uri(path.as_str())
+            .with_storage_options(storage_options);
         if let Some(session) = session.clone() {
             builder = builder.with_session(session);
         }


### PR DESCRIPTION
## Summary

- Updates the Lance Rust dependency family from 4.0.0 to 4.0.1 using crates.io releases.
- Keeps existing dependency features and flags unchanged.
- Leaves Arrow and DataFusion manifest pins unchanged; the resolver accepted the existing Cargo.toml pins.
- Applies cargo fmt output and a small clippy cleanup in `rust/ffi/session.rs`.

## Resolver changes

- `Cargo.lock` updates the Lance crate family and related Lance transitive crates (`fsst`, `lance-bitpacking`, `lance-datafusion`, `lance-datagen`, `lance-encoding`, `lance-file`, `lance-io`) to 4.0.1.
- No `[patch.crates-io]` Lance overrides are present.

## Validation

- `cargo fmt --all`
- `cargo check --manifest-path Cargo.toml`
- `cargo clippy --manifest-path Cargo.toml --all-targets`

Note: the GitHub Actions runner was missing `protoc`, so `protobuf-compiler` was installed before rerunning the Rust checks.

Triggering tag: https://github.com/lance-format/lance/releases/tag/v4.0.1 (`refs/tags/v4.0.1`)
