### PR TITLE
Benchmark updates on duckdb

### DIFF
--- a/benches/laion_1m/sql/20_build_duckdb_indexed.sql
+++ b/benches/laion_1m/sql/20_build_duckdb_indexed.sql
@@ -25,6 +25,7 @@ SELECT
   image_path
 FROM read_parquet('benches/laion_1m/data/laion_1m_lz4.parquet');
 
+CREATE INDEX laion_1m_sample_id_idx ON laion_1m(sample_id);
 CREATE INDEX laion_1m_nsfw_idx ON laion_1m(nsfw);
 CREATE INDEX laion_1m_width_idx ON laion_1m(width);
 CREATE INDEX laion_1m_img_emb_hnsw_idx ON laion_1m USING HNSW (img_emb);

--- a/benches/laion_1m/sql/workloads/duckdb_indexed/_init.sql
+++ b/benches/laion_1m/sql/workloads/duckdb_indexed/_init.sql
@@ -1,6 +1,7 @@
 LOAD fts;
 LOAD vss;
 
+SET hnsw_enable_experimental_persistence = true;
 SET scalar_subquery_error_on_multiple_rows=false;
 
 CREATE OR REPLACE TEMP VIEW laion_1m_filtered AS

--- a/benches/laion_1m/sql/workloads/duckdb_indexed/blob_read.sql
+++ b/benches/laion_1m/sql/workloads/duckdb_indexed/blob_read.sql
@@ -1,4 +1,4 @@
-SELECT d.sample_id, d.caption, octet_length(d.image_bytes) AS image_bytes_len
+SELECT d.sample_id, d.caption, d.image_bytes
 FROM blob_candidates c
 JOIN laion_1m d USING (sample_id)
 ORDER BY c.ord;

--- a/benches/laion_1m/sql/workloads/duckdb_indexed/fts.sql
+++ b/benches/laion_1m/sql/workloads/duckdb_indexed/fts.sql
@@ -9,5 +9,5 @@ FROM (
     AND width >= 512
 ) t
 WHERE score IS NOT NULL
-ORDER BY score DESC, sample_id
+ORDER BY score DESC
 LIMIT 20;

--- a/benches/laion_1m/sql/workloads/duckdb_indexed/hybrid.sql
+++ b/benches/laion_1m/sql/workloads/duckdb_indexed/hybrid.sql
@@ -2,20 +2,20 @@ WITH vec_candidates AS (
   SELECT
     sample_id,
     array_distance(img_emb, getvariable('qvec')) AS distance
-  FROM laion_1m_filtered
-  ORDER BY distance ASC, sample_id
+  FROM laion_1m
+  ORDER BY distance ASC
   LIMIT 200
 ),
 vec AS (
   SELECT
     sample_id,
-    row_number() OVER (ORDER BY distance ASC, sample_id) AS vector_rank
+    row_number() OVER (ORDER BY distance ASC) AS vector_rank
   FROM vec_candidates
 ),
 fts AS (
   SELECT
     sample_id,
-    row_number() OVER (ORDER BY score DESC, sample_id) AS lexical_rank
+    row_number() OVER (ORDER BY score DESC) AS lexical_rank
   FROM (
     SELECT
       sample_id,
@@ -24,10 +24,10 @@ fts AS (
       SELECT
         sample_id,
         fts_main_laion_1m.match_bm25(sample_id, 'wedding bride', fields := 'caption') AS score
-      FROM laion_1m_filtered
+      FROM laion_1m
     ) t
     WHERE score IS NOT NULL
-    ORDER BY score DESC, sample_id
+    ORDER BY score DESC
     LIMIT 200
   ) ranked_fts
 )
@@ -36,5 +36,5 @@ SELECT
   COALESCE(0.5 / (60 + vec.vector_rank), 0.0) + COALESCE(0.5 / (60 + fts.lexical_rank), 0.0) AS hybrid_score
 FROM vec
 FULL OUTER JOIN fts USING (sample_id)
-ORDER BY hybrid_score DESC, sample_id
+ORDER BY hybrid_score DESC
 LIMIT 20;

--- a/benches/laion_1m/sql/workloads/duckdb_indexed/vector_exact.sql
+++ b/benches/laion_1m/sql/workloads/duckdb_indexed/vector_exact.sql
@@ -1,15 +1,4 @@
-WITH needle(search_vec) AS (
-  SELECT getvariable('qvec')
-),
-matches AS (
-  SELECT
-    m.row.sample_id AS sample_id,
-    m.row.caption AS caption,
-    m.score AS distance
-  FROM needle,
-       vss_match(laion_1m_filtered, search_vec, img_emb, 20) t,
-       UNNEST(t.matches) AS u(m)
-)
-SELECT sample_id, caption, distance
-FROM matches
-ORDER BY distance ASC, sample_id;
+SELECT sample_id, caption, array_distance(img_emb, getvariable('qvec')) AS distance
+FROM laion_1m_filtered
+ORDER BY distance ASC
+LIMIT 20;

--- a/benches/laion_1m/sql/workloads/duckdb_indexed/vector_indexed.sql
+++ b/benches/laion_1m/sql/workloads/duckdb_indexed/vector_indexed.sql
@@ -1,4 +1,4 @@
 SELECT sample_id, caption, array_distance(img_emb, getvariable('qvec')) AS distance
-FROM laion_1m_filtered
-ORDER BY distance ASC, sample_id
+FROM laion_1m
+ORDER BY distance ASC
 LIMIT 20;

--- a/benches/laion_1m/sql/workloads/lance/blob_read.sql
+++ b/benches/laion_1m/sql/workloads/lance/blob_read.sql
@@ -1,4 +1,4 @@
-SELECT d.sample_id, d.caption, octet_length(d.image_bytes) AS image_bytes_len
+SELECT d.sample_id, d.caption, d.image_bytes
 FROM blob_candidates c
 JOIN 'benches/laion_1m/data/laion_1m_v22.lance' d USING (sample_id)
 ORDER BY c.ord;

--- a/benches/laion_1m/sql/workloads/lance/fts.sql
+++ b/benches/laion_1m/sql/workloads/lance/fts.sql
@@ -8,4 +8,4 @@ FROM lance_fts(
 )
 WHERE nsfw = 'UNLIKELY'
   AND width >= 512
-ORDER BY _score DESC, sample_id;
+ORDER BY _score DESC;

--- a/benches/laion_1m/sql/workloads/lance/hybrid.sql
+++ b/benches/laion_1m/sql/workloads/lance/hybrid.sql
@@ -11,8 +11,6 @@ FROM lance_hybrid_search(
   refine_factor = 2,
   alpha = 0.5,
   oversample_factor = 4,
-  prefilter = true
+  prefilter = false
 )
-WHERE nsfw = 'UNLIKELY'
-  AND width >= 512
-ORDER BY _hybrid_score DESC, sample_id;
+ORDER BY _hybrid_score DESC;

--- a/benches/laion_1m/sql/workloads/lance/vector_exact.sql
+++ b/benches/laion_1m/sql/workloads/lance/vector_exact.sql
@@ -9,4 +9,4 @@ FROM lance_vector_search(
 )
 WHERE nsfw = 'UNLIKELY'
   AND width >= 512
-ORDER BY _distance ASC, sample_id;
+ORDER BY _distance ASC;

--- a/benches/laion_1m/sql/workloads/lance/vector_indexed.sql
+++ b/benches/laion_1m/sql/workloads/lance/vector_indexed.sql
@@ -7,8 +7,6 @@ FROM lance_vector_search(
   use_index = true,
   nprobs = 16,
   refine_factor = 2,
-  prefilter = true
+  prefilter = false
 )
-WHERE nsfw = 'UNLIKELY'
-  AND width >= 512
-ORDER BY _distance ASC, sample_id;
+ORDER BY _distance ASC;

--- a/benches/laion_1m/sql/workloads/parquet/blob_read.sql
+++ b/benches/laion_1m/sql/workloads/parquet/blob_read.sql
@@ -1,4 +1,4 @@
-SELECT p.sample_id, p.caption, octet_length(p.image_bytes) AS image_bytes_len
+SELECT p.sample_id, p.caption, p.image_bytes
 FROM blob_candidates c
 JOIN laion_1m_parquet p USING (sample_id)
 ORDER BY c.ord;

--- a/benches/laion_1m/sql/workloads/parquet/fts.sql
+++ b/benches/laion_1m/sql/workloads/parquet/fts.sql
@@ -9,5 +9,5 @@ WITH scored AS (
 SELECT sample_id, caption, lexical_score
 FROM scored
 WHERE lexical_score > 0
-ORDER BY lexical_score DESC, sample_id
+ORDER BY lexical_score DESC
 LIMIT 20;

--- a/benches/laion_1m/sql/workloads/parquet/hybrid.sql
+++ b/benches/laion_1m/sql/workloads/parquet/hybrid.sql
@@ -2,14 +2,14 @@ WITH vec_candidates AS (
   SELECT
     sample_id,
     array_distance(img_emb::FLOAT[768], getvariable('qvec')) AS distance
-  FROM laion_1m_filtered
-  ORDER BY distance ASC, sample_id
+  FROM laion_1m_parquet
+  ORDER BY distance ASC
   LIMIT 200
 ),
 vec AS (
   SELECT
     sample_id,
-    row_number() OVER (ORDER BY distance ASC, sample_id) AS vector_rank
+    row_number() OVER (ORDER BY distance ASC) AS vector_rank
   FROM vec_candidates
 ),
 fts_candidates AS (
@@ -17,17 +17,17 @@ fts_candidates AS (
     sample_id,
     CASE WHEN regexp_matches(lower(caption), 'wedding') THEN 1 ELSE 0 END
     + CASE WHEN regexp_matches(lower(caption), 'bride') THEN 1 ELSE 0 END AS lexical_score
-  FROM laion_1m_filtered
+  FROM laion_1m_parquet
 ),
 fts AS (
   SELECT
     sample_id,
-    row_number() OVER (ORDER BY lexical_score DESC, sample_id) AS lexical_rank
+    row_number() OVER (ORDER BY lexical_score DESC) AS lexical_rank
   FROM (
     SELECT sample_id, lexical_score
     FROM fts_candidates
     WHERE lexical_score > 0
-    ORDER BY lexical_score DESC, sample_id
+    ORDER BY lexical_score DESC
     LIMIT 200
   ) ranked_fts
 )
@@ -36,5 +36,5 @@ SELECT
   COALESCE(0.5 / (60 + vec.vector_rank), 0.0) + COALESCE(0.5 / (60 + fts.lexical_rank), 0.0) AS hybrid_score
 FROM vec
 FULL OUTER JOIN fts USING (sample_id)
-ORDER BY hybrid_score DESC, sample_id
+ORDER BY hybrid_score DESC
 LIMIT 20;

--- a/benches/laion_1m/sql/workloads/parquet/vector_exact.sql
+++ b/benches/laion_1m/sql/workloads/parquet/vector_exact.sql
@@ -1,4 +1,4 @@
 SELECT sample_id, caption, array_distance(img_emb::FLOAT[768], getvariable('qvec')) AS distance
 FROM laion_1m_filtered
-ORDER BY distance ASC, sample_id
+ORDER BY distance ASC
 LIMIT 20;

--- a/benches/laion_1m/sql/workloads/parquet/vector_indexed.sql
+++ b/benches/laion_1m/sql/workloads/parquet/vector_indexed.sql
@@ -1,4 +1,4 @@
 SELECT sample_id, caption, array_distance(img_emb::FLOAT[768], getvariable('qvec')) AS distance
-FROM laion_1m_filtered
-ORDER BY distance ASC, sample_id
+FROM laion_1m_parquet
+ORDER BY distance ASC
 LIMIT 20;


### PR DESCRIPTION
The following has been modified:

- **`vector_exact`**: DuckDB does not really do well with vss_match, so we rather keep it with the same plain approach as parquet.
- **`vector_index`**: This is the biggest one, `HNSW` was not really firing because of the `WHERE` clause (current limitation). It also only accepts one column in the `ORDER BY` clause, that's why `sample_id` is removed everywhere for consistency. This does not modify the performance of lance.
- **`hybrid_search`**: The same performance optimization from vector_index applies, we needed HNSW to fire so we removed the extra column in `ORDER BY`.
- **`blob_read`**: Most of the performance was regarding the table scan, which without an index on the join column it was not very optimizable for DuckDB. We changed that and instead of returning `octet_length` we now deserialize the whole image since it feels more inline with "blob_read". I don't mind if we do`octet_length` but then what are we really proving with this query?

> HNSW was also dormant because SET hnsw_enable_experimental_persistence = true was never set in the query session