### PR TITLE
fix(maintenance): open namespace-backed Lance tables via catalog entry

### DIFF
--- a/src/include/lance_common.hpp
+++ b/src/include/lance_common.hpp
@@ -82,6 +82,17 @@ bool TryLanceNamespaceDropTable(ClientContext &context, const string &endpoint,
 
 class LanceTableEntry;
 
+// Resolve a string like "catalog.schema.table" to a LanceTableEntry* if it
+// names a Lance-backed table in an attached catalog.  Returns nullptr for
+// inputs that look like filesystem / URL paths, or when the lookup does not
+// yield a Lance table (missing entry, non-Lance table, malformed qualified
+// name).  This is the canonical way to re-resolve a dataset from its
+// original first-argument literal so we can take the namespace-aware
+// LanceOpenDatasetForTable() path instead of passing the virtual
+// namespace URI directly to lance-io.
+LanceTableEntry *TryResolveLanceTableEntry(ClientContext &context,
+                                           const string &input);
+
 void *LanceOpenDatasetForTable(ClientContext &context,
                                const LanceTableEntry &table,
                                string &out_display_uri);

--- a/src/lance_common.cpp
+++ b/src/lance_common.cpp
@@ -3,11 +3,14 @@
 #include "lance_ffi.hpp"
 #include "lance_session_state.hpp"
 #include "lance_table_entry.hpp"
+#include "duckdb/catalog/catalog.hpp"
+#include "duckdb/catalog/catalog_entry/table_catalog_entry.hpp"
 #include "duckdb/catalog/catalog_transaction.hpp"
 #include "duckdb/common/arrow/arrow_wrapper.hpp"
 #include "duckdb/common/string_util.hpp"
 #include "duckdb/execution/expression_executor.hpp"
 #include "duckdb/main/secret/secret_manager.hpp"
+#include "duckdb/parser/qualified_name.hpp"
 #include "duckdb/planner/expression/bound_conjunction_expression.hpp"
 #include "duckdb/planner/expression/bound_reference_expression.hpp"
 
@@ -464,6 +467,36 @@ BuildNamespaceAuthOverrideOptions(const string &bearer_token_override,
     options["api_key"] = Value(api_key_override);
   }
   return options;
+}
+
+LanceTableEntry *TryResolveLanceTableEntry(ClientContext &context,
+                                           const string &input) {
+  // Fast-path bail-out: obvious filesystem / URL literals can never match a
+  // qualified catalog identifier.  Avoids parsing attempts and potential
+  // secondary lookups that would just end up throwing ParserException.
+  if (input.empty() || input.find('/') != string::npos ||
+      input.find('\\') != string::npos || input.find("://") != string::npos) {
+    return nullptr;
+  }
+
+  QualifiedName qname;
+  try {
+    qname = QualifiedName::Parse(input);
+  } catch (ParserException &) {
+    return nullptr;
+  }
+
+  EntryLookupInfo lookup_info(CatalogType::TABLE_ENTRY, qname.name);
+  auto entry = Catalog::GetEntry(context, qname.catalog, qname.schema,
+                                 lookup_info, OnEntryNotFound::RETURN_NULL);
+  if (!entry) {
+    return nullptr;
+  }
+  auto *table_entry = dynamic_cast<TableCatalogEntry *>(entry.get());
+  if (!table_entry) {
+    return nullptr;
+  }
+  return dynamic_cast<LanceTableEntry *>(table_entry);
 }
 
 void *LanceOpenDatasetForTable(ClientContext &context,

--- a/src/lance_maintenance.cpp
+++ b/src/lance_maintenance.cpp
@@ -1,5 +1,7 @@
 #include "duckdb.hpp"
 
+#include "duckdb/catalog/catalog.hpp"
+#include "duckdb/catalog/catalog_entry/table_catalog_entry.hpp"
 #include "duckdb/common/string_util.hpp"
 #include "duckdb/function/table_function.hpp"
 #include "duckdb/main/config.hpp"
@@ -11,12 +13,38 @@
 #include "lance_common.hpp"
 #include "lance_ffi.hpp"
 #include "lance_resolver.hpp"
+#include "lance_table_entry.hpp"
 
 #include <cctype>
 #include <cstring>
 #include <unordered_map>
 
 namespace duckdb {
+
+// When the user passes a qualified table name (e.g.
+// "catalog.schema.table") to the maintenance table functions, the
+// registered dataset resolvers may produce a "virtual" URI that
+// lance-io cannot open directly -- namespace-backed Lance tables
+// expose themselves through an "http://<endpoint>/<table-id>" handle
+// whose real location (cos:// / file://) is only reachable through
+// the namespace REST API.
+//
+// To stay correct in that case we keep the original first-argument
+// literal in the bind data, and at execution time re-resolve it via
+// TryResolveLanceTableEntry() so we can take the namespace-aware
+// LanceOpenDatasetForTable() path.  If the input does not name a
+// Lance table (plain file path, or table not yet in the catalog for
+// any reason), we transparently fall back to LanceOpenDataset() on
+// the resolved URI -- preserving the original "open by path" contract.
+static void *TryOpenDatasetForMaintenanceInput(ClientContext &context,
+                                               const string &input_str,
+                                               string &out_display_uri) {
+  auto *lance_entry = TryResolveLanceTableEntry(context, input_str);
+  if (!lance_entry) {
+    return nullptr;
+  }
+  return LanceOpenDatasetForTable(context, *lance_entry, out_display_uri);
+}
 
 static constexpr const char *LANCE_AUTO_CLEANUP_INTERVAL_KEY =
     "lance.auto_cleanup.interval";
@@ -56,26 +84,34 @@ enum class LanceMaintenanceOp : uint8_t {
 };
 
 struct LanceMaintenanceBindData final : public FunctionData {
-  LanceMaintenanceBindData(string dataset_uri_p, LanceMaintenanceOp op_p,
-                           string options_json_p, string index_name_p)
-      : dataset_uri(std::move(dataset_uri_p)), op(op_p),
+  LanceMaintenanceBindData(string dataset_uri_p, string input_str_p,
+                           LanceMaintenanceOp op_p, string options_json_p,
+                           string index_name_p)
+      : dataset_uri(std::move(dataset_uri_p)),
+        input_str(std::move(input_str_p)), op(op_p),
         options_json(std::move(options_json_p)),
         index_name(std::move(index_name_p)) {}
 
   string dataset_uri;
+  // Original first-argument literal preserved so the executor can re-resolve
+  // it as a Lance catalog table entry when the registered resolver produced
+  // a virtual URI (e.g. namespace-backed tables).  See
+  // TryOpenDatasetForMaintenanceInput().
+  string input_str;
   LanceMaintenanceOp op;
   string options_json;
   string index_name;
 
   unique_ptr<FunctionData> Copy() const override {
-    return make_uniq<LanceMaintenanceBindData>(dataset_uri, op, options_json,
-                                               index_name);
+    return make_uniq<LanceMaintenanceBindData>(dataset_uri, input_str, op,
+                                               options_json, index_name);
   }
 
   bool Equals(const FunctionData &other_p) const override {
     auto &other = other_p.Cast<LanceMaintenanceBindData>();
-    return dataset_uri == other.dataset_uri && op == other.op &&
-           options_json == other.options_json && index_name == other.index_name;
+    return dataset_uri == other.dataset_uri && input_str == other.input_str &&
+           op == other.op && options_json == other.options_json &&
+           index_name == other.index_name;
   }
 };
 
@@ -99,6 +135,8 @@ LanceMaintenanceBind(ClientContext &context, TableFunctionBindInput &input,
   auto dataset_uri = ResolveLanceDatasetUri(
       context, input.inputs[0], LanceResolvePolicy::FALLBACK_TO_PATH,
       "__lance_maintenance");
+  string input_str =
+      input.inputs[0].IsNull() ? string() : input.inputs[0].GetValue<string>();
 
   string options_json;
   string index_name;
@@ -126,9 +164,9 @@ LanceMaintenanceBind(ClientContext &context, TableFunctionBindInput &input,
   return_types = {LogicalType::VARCHAR, LogicalType::VARCHAR,
                   LogicalType::VARCHAR};
   names = {"Operation", "Target", "MetricsJSON"};
-  return make_uniq<LanceMaintenanceBindData>(std::move(dataset_uri), op,
-                                             std::move(options_json),
-                                             std::move(index_name));
+  return make_uniq<LanceMaintenanceBindData>(
+      std::move(dataset_uri), std::move(input_str), op, std::move(options_json),
+      std::move(index_name));
 }
 
 static unique_ptr<FunctionData>
@@ -189,9 +227,15 @@ static void LanceMaintenanceFunc(ClientContext &context,
   const char *options_ptr =
       bind_data.options_json.empty() ? nullptr : bind_data.options_json.c_str();
 
-  void *dataset = LanceOpenDataset(context, bind_data.dataset_uri);
+  string display_uri = bind_data.dataset_uri;
+  void *dataset = TryOpenDatasetForMaintenanceInput(
+      context, bind_data.input_str, display_uri);
   if (!dataset) {
-    throw IOException("Failed to open Lance dataset: " + bind_data.dataset_uri +
+    display_uri = bind_data.dataset_uri;
+    dataset = LanceOpenDataset(context, bind_data.dataset_uri);
+  }
+  if (!dataset) {
+    throw IOException("Failed to open Lance dataset: " + display_uri +
                       LanceFormatErrorSuffix());
   }
 
@@ -222,7 +266,7 @@ static void LanceMaintenanceFunc(ClientContext &context,
 
   if (rc != 0) {
     throw IOException("Failed to execute Lance maintenance operation '" +
-                      op_name + "' on dataset: " + bind_data.dataset_uri +
+                      op_name + "' on dataset: " + display_uri +
                       LanceFormatErrorSuffix());
   }
 
@@ -234,21 +278,23 @@ static void LanceMaintenanceFunc(ClientContext &context,
 
   output.SetCardinality(1);
   output.SetValue(0, 0, Value(op_name));
-  output.SetValue(1, 0, Value(bind_data.dataset_uri));
+  output.SetValue(1, 0, Value(display_uri));
   output.SetValue(2, 0, Value(metrics_json));
 }
 
 struct LanceAutoCleanupSetBindData final : public FunctionData {
-  LanceAutoCleanupSetBindData(string dataset_uri_p, bool unset_p,
-                              int64_t interval_p, string older_than_p,
-                              bool has_retain_versions_p,
+  LanceAutoCleanupSetBindData(string dataset_uri_p, string input_str_p,
+                              bool unset_p, int64_t interval_p,
+                              string older_than_p, bool has_retain_versions_p,
                               int64_t retain_versions_p)
-      : dataset_uri(std::move(dataset_uri_p)), unset(unset_p),
-        interval(interval_p), older_than(std::move(older_than_p)),
+      : dataset_uri(std::move(dataset_uri_p)),
+        input_str(std::move(input_str_p)), unset(unset_p), interval(interval_p),
+        older_than(std::move(older_than_p)),
         has_retain_versions(has_retain_versions_p),
         retain_versions(retain_versions_p) {}
 
   string dataset_uri;
+  string input_str;
   bool unset = false;
   int64_t interval = 0;
   string older_than;
@@ -257,32 +303,35 @@ struct LanceAutoCleanupSetBindData final : public FunctionData {
 
   unique_ptr<FunctionData> Copy() const override {
     return make_uniq<LanceAutoCleanupSetBindData>(
-        dataset_uri, unset, interval, older_than, has_retain_versions,
-        retain_versions);
+        dataset_uri, input_str, unset, interval, older_than,
+        has_retain_versions, retain_versions);
   }
 
   bool Equals(const FunctionData &other_p) const override {
     auto &other = other_p.Cast<LanceAutoCleanupSetBindData>();
-    return dataset_uri == other.dataset_uri && unset == other.unset &&
-           interval == other.interval && older_than == other.older_than &&
+    return dataset_uri == other.dataset_uri && input_str == other.input_str &&
+           unset == other.unset && interval == other.interval &&
+           older_than == other.older_than &&
            has_retain_versions == other.has_retain_versions &&
            retain_versions == other.retain_versions;
   }
 };
 
 struct LanceAutoCleanupShowBindData final : public FunctionData {
-  explicit LanceAutoCleanupShowBindData(string dataset_uri_p)
-      : dataset_uri(std::move(dataset_uri_p)) {}
+  LanceAutoCleanupShowBindData(string dataset_uri_p, string input_str_p)
+      : dataset_uri(std::move(dataset_uri_p)),
+        input_str(std::move(input_str_p)) {}
 
   string dataset_uri;
+  string input_str;
 
   unique_ptr<FunctionData> Copy() const override {
-    return make_uniq<LanceAutoCleanupShowBindData>(dataset_uri);
+    return make_uniq<LanceAutoCleanupShowBindData>(dataset_uri, input_str);
   }
 
   bool Equals(const FunctionData &other_p) const override {
     auto &other = other_p.Cast<LanceAutoCleanupShowBindData>();
-    return dataset_uri == other.dataset_uri;
+    return dataset_uri == other.dataset_uri && input_str == other.input_str;
   }
 };
 
@@ -307,6 +356,8 @@ LanceSetAutoCleanupBind(ClientContext &context, TableFunctionBindInput &input,
   auto dataset_uri = ResolveLanceDatasetUri(
       context, input.inputs[0], LanceResolvePolicy::FALLBACK_TO_PATH,
       "__lance_set_auto_cleanup");
+  string input_str =
+      input.inputs[0].IsNull() ? string() : input.inputs[0].GetValue<string>();
 
   bool unset = false;
   if (!input.inputs[4].IsNull()) {
@@ -351,8 +402,8 @@ LanceSetAutoCleanupBind(ClientContext &context, TableFunctionBindInput &input,
                   LogicalType::VARCHAR};
   names = {"Operation", "Target", "MetricsJSON"};
   return make_uniq<LanceAutoCleanupSetBindData>(
-      std::move(dataset_uri), unset, interval, std::move(older_than),
-      has_retain_versions, retain_versions);
+      std::move(dataset_uri), std::move(input_str), unset, interval,
+      std::move(older_than), has_retain_versions, retain_versions);
 }
 
 static unique_ptr<FunctionData>
@@ -365,9 +416,12 @@ LanceShowAutoCleanupBind(ClientContext &context, TableFunctionBindInput &input,
   auto dataset_uri = ResolveLanceDatasetUri(
       context, input.inputs[0], LanceResolvePolicy::FALLBACK_TO_PATH,
       "__lance_show_auto_cleanup");
+  string input_str =
+      input.inputs[0].IsNull() ? string() : input.inputs[0].GetValue<string>();
   return_types = {LogicalType::VARCHAR, LogicalType::VARCHAR};
   names = {"Key", "Value"};
-  return make_uniq<LanceAutoCleanupShowBindData>(std::move(dataset_uri));
+  return make_uniq<LanceAutoCleanupShowBindData>(std::move(dataset_uri),
+                                                 std::move(input_str));
 }
 
 static void UpdateDatasetConfigOrThrow(void *dataset, const string &dataset_uri,
@@ -390,9 +444,15 @@ static void LanceSetAutoCleanupFunc(ClientContext &context,
   gstate.finished = true;
 
   auto &bind_data = data.bind_data->Cast<LanceAutoCleanupSetBindData>();
-  void *dataset = LanceOpenDataset(context, bind_data.dataset_uri);
+  string display_uri = bind_data.dataset_uri;
+  void *dataset = TryOpenDatasetForMaintenanceInput(
+      context, bind_data.input_str, display_uri);
   if (!dataset) {
-    throw IOException("Failed to open Lance dataset: " + bind_data.dataset_uri +
+    display_uri = bind_data.dataset_uri;
+    dataset = LanceOpenDataset(context, bind_data.dataset_uri);
+  }
+  if (!dataset) {
+    throw IOException("Failed to open Lance dataset: " + display_uri +
                       LanceFormatErrorSuffix());
   }
 
@@ -400,31 +460,31 @@ static void LanceSetAutoCleanupFunc(ClientContext &context,
   string metrics_json;
   try {
     if (bind_data.unset) {
-      UpdateDatasetConfigOrThrow(dataset, bind_data.dataset_uri,
+      UpdateDatasetConfigOrThrow(dataset, display_uri,
                                  LANCE_AUTO_CLEANUP_INTERVAL_KEY, nullptr);
-      UpdateDatasetConfigOrThrow(dataset, bind_data.dataset_uri,
+      UpdateDatasetConfigOrThrow(dataset, display_uri,
                                  LANCE_AUTO_CLEANUP_OLDER_THAN_KEY, nullptr);
-      UpdateDatasetConfigOrThrow(dataset, bind_data.dataset_uri,
+      UpdateDatasetConfigOrThrow(dataset, display_uri,
                                  LANCE_AUTO_CLEANUP_RETAIN_VERSIONS_KEY,
                                  nullptr);
       op_name = "unset_auto_cleanup";
       metrics_json = "{\"enabled\":false}";
     } else {
       auto interval = to_string(bind_data.interval);
-      UpdateDatasetConfigOrThrow(dataset, bind_data.dataset_uri,
+      UpdateDatasetConfigOrThrow(dataset, display_uri,
                                  LANCE_AUTO_CLEANUP_INTERVAL_KEY,
                                  interval.c_str());
-      UpdateDatasetConfigOrThrow(dataset, bind_data.dataset_uri,
+      UpdateDatasetConfigOrThrow(dataset, display_uri,
                                  LANCE_AUTO_CLEANUP_OLDER_THAN_KEY,
                                  bind_data.older_than.c_str());
 
       if (bind_data.has_retain_versions) {
         auto retain_versions = to_string(bind_data.retain_versions);
-        UpdateDatasetConfigOrThrow(dataset, bind_data.dataset_uri,
+        UpdateDatasetConfigOrThrow(dataset, display_uri,
                                    LANCE_AUTO_CLEANUP_RETAIN_VERSIONS_KEY,
                                    retain_versions.c_str());
       } else {
-        UpdateDatasetConfigOrThrow(dataset, bind_data.dataset_uri,
+        UpdateDatasetConfigOrThrow(dataset, display_uri,
                                    LANCE_AUTO_CLEANUP_RETAIN_VERSIONS_KEY,
                                    nullptr);
       }
@@ -447,7 +507,7 @@ static void LanceSetAutoCleanupFunc(ClientContext &context,
 
   output.SetCardinality(1);
   output.SetValue(0, 0, Value(op_name));
-  output.SetValue(1, 0, Value(bind_data.dataset_uri));
+  output.SetValue(1, 0, Value(display_uri));
   output.SetValue(2, 0, Value(metrics_json));
 }
 
@@ -455,9 +515,15 @@ static unique_ptr<GlobalTableFunctionState>
 LanceShowAutoCleanupInitGlobal(ClientContext &context,
                                TableFunctionInitInput &input) {
   auto &bind_data = input.bind_data->Cast<LanceAutoCleanupShowBindData>();
-  void *dataset = LanceOpenDataset(context, bind_data.dataset_uri);
+  string display_uri = bind_data.dataset_uri;
+  void *dataset = TryOpenDatasetForMaintenanceInput(
+      context, bind_data.input_str, display_uri);
   if (!dataset) {
-    throw IOException("Failed to open Lance dataset: " + bind_data.dataset_uri +
+    display_uri = bind_data.dataset_uri;
+    dataset = LanceOpenDataset(context, bind_data.dataset_uri);
+  }
+  if (!dataset) {
+    throw IOException("Failed to open Lance dataset: " + display_uri +
                       LanceFormatErrorSuffix());
   }
 

--- a/src/lance_search.cpp
+++ b/src/lance_search.cpp
@@ -82,32 +82,10 @@ static bool TryLanceExplainKnn(void *dataset, const string &vector_column,
   return true;
 }
 
-static LanceTableEntry *TryResolveLanceTableEntry(ClientContext &context,
-                                                  const string &input) {
-  if (input.empty() || input.find('/') != string::npos ||
-      input.find('\\') != string::npos || input.find("://") != string::npos) {
-    return nullptr;
-  }
-
-  QualifiedName qname;
-  try {
-    qname = QualifiedName::Parse(input);
-  } catch (ParserException &) {
-    return nullptr;
-  }
-
-  EntryLookupInfo lookup_info(CatalogType::TABLE_ENTRY, qname.name);
-  auto entry = Catalog::GetEntry(context, qname.catalog, qname.schema,
-                                 lookup_info, OnEntryNotFound::RETURN_NULL);
-  if (!entry) {
-    return nullptr;
-  }
-  auto *table_entry = dynamic_cast<TableCatalogEntry *>(entry.get());
-  if (!table_entry) {
-    return nullptr;
-  }
-  return dynamic_cast<LanceTableEntry *>(table_entry);
-}
+// TryResolveLanceTableEntry() is now defined in lance_common.cpp so that
+// the maintenance helpers (compact / cleanup / optimize_index /
+// auto_cleanup) can share the same "catalog.schema.table" -> entry
+// resolution logic.
 
 static shared_ptr<LanceDatasetCacheEntry>
 OpenSearchDatasetEntry(ClientContext &context, const Value &input,

--- a/test/sql/namespace_rest_maintenance.test
+++ b/test/sql/namespace_rest_maintenance.test
@@ -1,0 +1,94 @@
+# name: test/sql/namespace_rest_maintenance.test
+# description: Maintenance SQL surface works against tables resolved through a REST Lance namespace (requires external service)
+# group: [sql]
+
+require-env LANCE_TEST_NAMESPACE 1
+
+test-env LANCE_NAMESPACE_ENDPOINT http://127.0.0.1:2333
+
+test-env LANCE_NAMESPACE_ID default
+
+test-env LANCE_NAMESPACE_TABLE default.table
+
+require lance
+
+# ---------------------------------------------------------------------------
+# Setup: attach a REST namespace.  Tables resolved through this catalog have
+# their dataset_uri set to the *virtual* "<endpoint>/<table_id>" handle, which
+# lance-io cannot open directly.  The maintenance bind path used to forward
+# that virtual URI to LanceOpenDataset() and fail with an IO error -- this
+# test guards the fix that re-resolves the original input via
+# LanceOpenDatasetForTable() so the namespace REST API can produce the real
+# cos:// / file:// location.
+# ---------------------------------------------------------------------------
+
+statement ok
+ATTACH '${LANCE_NAMESPACE_ID}' AS maintenance_rest_ns (TYPE LANCE, ENDPOINT '${LANCE_NAMESPACE_ENDPOINT}');
+
+# Sanity check: we can read the table through the namespace.
+query I
+SELECT count(*) FROM maintenance_rest_ns.main."${LANCE_NAMESPACE_TABLE}"
+----
+<REGEX>:[0-9]+
+
+# ---------------------------------------------------------------------------
+# OPTIMIZE (compact) — exercises LanceMaintenanceFunc fallback path.
+# ---------------------------------------------------------------------------
+
+query TTT
+OPTIMIZE maintenance_rest_ns.main."${LANCE_NAMESPACE_TABLE}";
+----
+compact	<REGEX>:.*	<REGEX>:\{.*\}
+
+# ---------------------------------------------------------------------------
+# VACUUM LANCE (cleanup) — exercises the same fallback path with options.
+# ---------------------------------------------------------------------------
+
+query TTT
+VACUUM LANCE maintenance_rest_ns.main."${LANCE_NAMESPACE_TABLE}" WITH (
+  older_than_seconds = 0,
+  delete_unverified = false,
+  error_if_tagged_old_versions = true
+);
+----
+cleanup	<REGEX>:.*	<REGEX>:\{.*\}
+
+# ---------------------------------------------------------------------------
+# SHOW MAINTENANCE — exercises LanceShowAutoCleanupInitGlobal fallback path.
+# ---------------------------------------------------------------------------
+
+query TT
+SHOW MAINTENANCE ON maintenance_rest_ns.main."${LANCE_NAMESPACE_TABLE}";
+----
+enabled	<REGEX>:(true|false)
+
+# ---------------------------------------------------------------------------
+# ALTER TABLE ... SET/UNSET AUTO_CLEANUP — exercises LanceSetAutoCleanupFunc.
+# Round-trip set + unset so we leave the table in its original state.
+# ---------------------------------------------------------------------------
+
+query TTT
+ALTER TABLE maintenance_rest_ns.main."${LANCE_NAMESPACE_TABLE}"
+SET AUTO_CLEANUP WITH (
+  interval = 1,
+  older_than = '1s',
+  retain_versions = 2
+);
+----
+set_auto_cleanup	<REGEX>:.*	<REGEX>:\{.*"enabled":true.*"interval":1.*"older_than":"1s".*"retain_versions":2.*\}
+
+query TT
+SHOW MAINTENANCE ON maintenance_rest_ns.main."${LANCE_NAMESPACE_TABLE}";
+----
+enabled	true
+interval	1
+older_than	1s
+retain_versions	2
+
+query TTT
+ALTER TABLE maintenance_rest_ns.main."${LANCE_NAMESPACE_TABLE}" UNSET AUTO_CLEANUP;
+----
+unset_auto_cleanup	<REGEX>:.*	{"enabled":false}
+
+statement ok
+DETACH maintenance_rest_ns;


### PR DESCRIPTION
Root cause: maintenance table functions (compact / cleanup / optimize_index / set_auto_cleanup / show_auto_cleanup) bind by passing the first argument through ResolveLanceDatasetUri() and then call LanceOpenDataset(bind_data.dataset_uri) at execute time.

For namespace-backed Lance tables, DefaultCatalogResolver returns LanceTableEntry::DatasetUri(), which for REST namespaces is the "virtual" handle 'endpoint + "/" + table_id' (e.g. 'http://host:2333/cat$sch$tbl'). lance-io cannot open that handle directly -- the real cos:// / file:// location is only reachable through the namespace REST API via LanceOpenDatasetForTable().

As a result, OPTIMIZE / VACUUM LANCE / SHOW MAINTENANCE / ALTER TABLE SET AUTO_CLEANUP / ALTER TABLE UNSET AUTO_CLEANUP all fail with 'IO Error: Failed to open Lance dataset: http://...' whenever the target is a REST namespace table. Directory namespaces are unaffected because their DatasetUri() is already the real on-disk path.

Fix: at execute time, re-resolve the original first-argument literal as a Lance catalog entry and route through LanceOpenDatasetForTable(), which handles the namespace REST API path. Fall back to the old LanceOpenDataset(dataset_uri) when the input is a plain path literal so the existing 'open by path' contract is preserved.

Changes:
- Promote TryResolveLanceTableEntry() from a static helper in lance_search.cpp to a public symbol in lance_common.{hpp,cpp} so the search and maintenance code paths share one canonical implementation. The shared version uses OnEntryNotFound::RETURN_NULL and only catches ParserException, so genuine errors (auth failures, network errors, catalog corruption) are no longer silently swallowed by 'catch(...)'.
- lance_maintenance.cpp: store the original first-argument literal alongside dataset_uri in LanceMaintenanceBindData, LanceAutoCleanupSetBindData, and LanceAutoCleanupShowBindData. At execute time, try TryOpenDatasetForMaintenanceInput() first (TryResolveLanceTableEntry + LanceOpenDatasetForTable) and only fall back to LanceOpenDataset(dataset_uri) when the input does not name a Lance catalog entry.
- The displayed Target column now reflects the resolved real URI returned by LanceOpenDatasetForTable() instead of the virtual namespace handle.
- Add test/sql/namespace_rest_maintenance.test exercising compact, cleanup, set / unset / show auto_cleanup against a REST namespace table. Gated by LANCE_TEST_NAMESPACE=1, mirroring namespace_rest_attach.test.

Compatibility:
- Path-based callers (e.g. OPTIMIZE 'cos://bucket/x.lance') are unchanged: TryResolveLanceTableEntry short-circuits on inputs containing '/', '\\', or '://' and the executor falls back to the original LanceOpenDataset() path.
- Directory-namespace callers (e.g. OPTIMIZE dir_ns.main.tbl) are unchanged: dir-namespace tables are not IsNamespaceBacked(), so LanceOpenDatasetForTable() forwards to LanceOpenDataset(table.DatasetUri()) -- the same real path that the previous code was already using.