### PR TITLE
fix(namespace): forward storage_options to dataset open after from_namespace

### DIFF
--- a/rust/ffi/dir_namespace.rs
+++ b/rust/ffi/dir_namespace.rs
@@ -134,7 +134,7 @@ fn open_dataset_in_dir_namespace_inner(
     let dataset = runtime::block_on(async {
         let mut ns_builder = DirectoryNamespaceBuilder::new(&root).manifest_enabled(false);
         if !storage_options.is_empty() {
-            ns_builder = ns_builder.storage_options(storage_options);
+            ns_builder = ns_builder.storage_options(storage_options.clone());
         }
         let namespace = ns_builder.build().await.map_err(|err| {
             FfiError::new(
@@ -151,6 +151,24 @@ fn open_dataset_in_dir_namespace_inner(
                         format!("dir namespace describe '{root}/{table_name}': {err}"),
                     )
                 })?;
+        // Forward the caller's storage_options to the dataset open path.
+        //
+        // `DirectoryNamespace::describe_table` returns `storage_options: None`
+        // when no credential vendor is configured, by design — to avoid
+        // leaking the namespace's own static credentials to clients (see
+        // lance-namespace-impls/src/dir.rs::get_storage_options_for_table).
+        // Without this re-injection, `builder.load()` builds an ObjectStore
+        // with empty options. For non-AWS S3-compatible endpoints (TOS,
+        // MinIO, R2, ...) this falls into AWS bucket-region resolution
+        // (lance-io/src/object_store/providers/aws.rs:217) and fails with
+        // "Bucket '<name>' not found".
+        //
+        // `with_storage_options` merges into any accessor already attached
+        // by `from_namespace`, preserving a `StorageOptionsProvider` if one
+        // was returned by a credential vendor.
+        if !storage_options.is_empty() {
+            builder = builder.with_storage_options(storage_options);
+        }
         if let Some(session) = session {
             builder = builder.with_session(session);
         }

--- a/test/sql/namespace_attach_s3_minio.test
+++ b/test/sql/namespace_attach_s3_minio.test
@@ -1,12 +1,12 @@
 # name: test/sql/namespace_attach_s3_minio.test
-# description: ATTACH TYPE LANCE directory namespace against S3-compatible storage (MinIO).
-#              Regression test for: tables under the ATTACH prefix were invisible
-#              to the catalog because `DatasetBuilder::from_namespace + load`
-#              opened the dataset with empty storage_options, falling into AWS
-#              bucket-region resolution (aws.rs:217) and failing with
-#              "Bucket '<name>' not found". The fix forwards the caller's
-#              storage_options into the dataset builder after `from_namespace`.
+# description: ATTACH TYPE LANCE directory namespace against S3-compatible MinIO (regression for #206).
 # group: [sql]
+
+# Before the fix, the catalog was always empty on non-AWS S3-compatible endpoints:
+# `DatasetBuilder::from_namespace + load` opened the dataset with empty
+# storage_options, fell into AWS bucket-region resolution (`aws.rs:217`), and
+# failed with "Bucket '<name>' not found". The fix forwards the caller's
+# storage_options into the dataset builder after `from_namespace`.
 
 require-env LANCE_TEST_S3 1
 
@@ -23,6 +23,12 @@ test-env LANCE_S3_SECRET_ACCESS_KEY minioadmin
 test-env LANCE_S3_NS_PREFIX ns_attach_test
 
 require lance
+
+statement ok
+INSTALL httpfs;
+
+statement ok
+LOAD httpfs;
 
 statement ok
 CREATE SECRET (

--- a/test/sql/namespace_attach_s3_minio.test
+++ b/test/sql/namespace_attach_s3_minio.test
@@ -1,0 +1,96 @@
+# name: test/sql/namespace_attach_s3_minio.test
+# description: ATTACH TYPE LANCE directory namespace against S3-compatible storage (MinIO).
+#              Regression test for: tables under the ATTACH prefix were invisible
+#              to the catalog because `DatasetBuilder::from_namespace + load`
+#              opened the dataset with empty storage_options, falling into AWS
+#              bucket-region resolution (aws.rs:217) and failing with
+#              "Bucket '<name>' not found". The fix forwards the caller's
+#              storage_options into the dataset builder after `from_namespace`.
+# group: [sql]
+
+require-env LANCE_TEST_S3 1
+
+test-env LANCE_S3_ENDPOINT http://127.0.0.1:9000
+
+test-env LANCE_S3_REGION us-east-1
+
+test-env LANCE_S3_BUCKET lance-test
+
+test-env LANCE_S3_ACCESS_KEY_ID minioadmin
+
+test-env LANCE_S3_SECRET_ACCESS_KEY minioadmin
+
+test-env LANCE_S3_NS_PREFIX ns_attach_test
+
+require lance
+
+statement ok
+CREATE SECRET (
+  TYPE LANCE,
+  PROVIDER config,
+  SCOPE 's3://${LANCE_S3_BUCKET}/',
+  ACCESS_KEY_ID '${LANCE_S3_ACCESS_KEY_ID}',
+  SECRET_ACCESS_KEY '${LANCE_S3_SECRET_ACCESS_KEY}',
+  REGION '${LANCE_S3_REGION}',
+  ENDPOINT '${LANCE_S3_ENDPOINT}',
+  VIRTUAL_HOSTED_STYLE_REQUEST false,
+  ALLOW_HTTP true
+);
+
+# Seed two datasets directly under the namespace prefix.
+statement ok
+COPY (SELECT 1::BIGINT AS id, 'a'::VARCHAR AS s UNION ALL SELECT 2::BIGINT, 'b')
+TO 's3://${LANCE_S3_BUCKET}/${LANCE_S3_NS_PREFIX}/alpha.lance' (FORMAT lance, mode 'overwrite');
+
+statement ok
+COPY (SELECT 10::BIGINT AS id UNION ALL SELECT 20::BIGINT UNION ALL SELECT 30::BIGINT)
+TO 's3://${LANCE_S3_BUCKET}/${LANCE_S3_NS_PREFIX}/beta.lance' (FORMAT lance, mode 'overwrite');
+
+# ATTACH the prefix as a directory namespace and verify that the tables are
+# visible through the catalog. Before the fix, this catalog was always empty
+# on non-AWS S3-compatible endpoints because dataset open returned NULL for
+# every entry.
+statement ok
+ATTACH 's3://${LANCE_S3_BUCKET}/${LANCE_S3_NS_PREFIX}' AS ns (TYPE LANCE, READ_ONLY false);
+
+query TT
+SELECT table_name, database_name FROM duckdb_tables()
+WHERE database_name = 'ns' ORDER BY table_name;
+----
+alpha	ns
+beta	ns
+
+query I
+SELECT count(*) FROM ns.main.alpha;
+----
+2
+
+query I
+SELECT sum(id) FROM ns.main.beta;
+----
+60
+
+# A name-resolved INSERT goes through the same open path; before the fix it
+# also failed with "Table with name beta does not exist".
+statement ok
+INSERT INTO ns.main.beta VALUES (40);
+
+query I
+SELECT sum(id) FROM ns.main.beta;
+----
+100
+
+statement ok
+DETACH ns;
+
+# Re-ATTACH and confirm the catalog still discovers the tables.
+statement ok
+ATTACH 's3://${LANCE_S3_BUCKET}/${LANCE_S3_NS_PREFIX}' AS ns2 (TYPE LANCE, READ_ONLY false);
+
+query I
+SELECT count(*) FROM ns2.main.alpha;
+----
+2
+
+statement ok
+DETACH ns2;


### PR DESCRIPTION
Fixes #206. Replaces #207 — the previous PR's head fork lost its fork-network link (private-visibility toggle severed it; GitHub refused to reopen). Re-forked clean and re-pushing the same commits (`c129a9a` + `a395e0c`).

---


## Summary

`open_dataset_in_dir_namespace_inner` builds the `DirectoryNamespace` with the caller-supplied `storage_options`, but the subsequent `DatasetBuilder::from_namespace(...).load()` does not see them: `describe_table` returns `storage_options: None` by design (the directory namespace doesn't vend its own static credentials), and `from_namespace` reads `storage_options` only from that response. `load()` then builds an `ObjectStore` with empty options, falls into AWS bucket-region resolution (`lance-io/src/object_store/providers/aws.rs:217`), and fails on any non-AWS S3-compatible bucket.

End-to-end inside DuckDB: ATTACH succeeds (list_tables uses the namespace's own object store), but per-entry `lance_open_dataset_in_dir_namespace` returns NULL for every table. `LanceDirectoryDefaultGenerator::GetDefaultEntries` silently filters those out, the catalog ends up empty, and every name-resolved op (`SELECT FROM ns.main.X`, `INSERT INTO ns.main.X`, ...) fails with `Table with name X does not exist!`.

Full analysis + standalone Rust reproducer in #206.

## Change

Re-inject the caller's `storage_options` into the builder after `from_namespace`. The caller already has these in hand from `CREATE SECRET ... TYPE LANCE`, so we're reusing them rather than asking the namespace to vend them. `with_storage_options` merges into the existing accessor, so any `StorageOptionsProvider` attached by a future credential vendor is preserved.

```rust
let mut builder =
    DatasetBuilder::from_namespace(Arc::new(namespace), vec![table_name.to_string()]).await?;
if !storage_options.is_empty() {
    builder = builder.with_storage_options(storage_options);
}
if let Some(session) = session {
    builder = builder.with_session(session);
}
builder.load().await
```

## Verification

Standalone Rust reproducer pinned to the same crate versions as `main` (`lance = "=4.0.1"`, `lance-namespace-impls = "=4.0.1"`), same builder chain as the FFI:

```
$ cargo run
list_tables -> ["papers", "scholar_paper", "scholars"]

== bug: from_namespace + load (no with_storage_options)
  papers:        OPEN FAILED: LanceError(IO): Generic S3 error: Bucket 'lance-test' not found,
                 lance-io-4.0.1/src/object_store/providers/aws.rs:217:13

== fix: from_namespace + with_storage_options + load
  papers:        OPEN OK rows=5000
  scholar_paper: OPEN OK rows=15000
  scholars:      OPEN OK rows=500
```

`cargo check` on the patched workspace passes.

## Test

`test/sql/namespace_attach_s3_minio.test` — end-to-end against MinIO, gated by `LANCE_TEST_S3=1` (consistent with the existing `s3_*_minio.test` files). Exercises ATTACH with a Lance secret carrying `ENDPOINT` / `VIRTUAL_HOSTED_STYLE_REQUEST` / `ALLOW_HTTP`, catalog visibility via `duckdb_tables()`, name-resolved `SELECT FROM ns.main.X` and `INSERT INTO ns.main.X` (both broken before the fix), and a DETACH + re-ATTACH cycle.

## Notes

- Patch scope is intentionally narrow — only the directory-namespace dataset-open path. `lance_dir_namespace_drop_table` doesn't go through `from_namespace + load`. The REST-namespace path was already addressed in #203 via `LanceOpenDatasetForTable`.
- The fix could alternatively live in lance core (have `DatasetBuilder::from_namespace` fall back to the namespace builder's own `storage_options` when `describe_table` returns `None`), but that conflicts with the explicit "don't leak namespace's static credentials" intent in `DirectoryNamespace::get_storage_options_for_table`. The FFI side feels like the right place.
- Related: #146 (ABFSS attach in write mode — possibly the same shape for Azure), #203 (REST namespace fix; the description's claim that "directory namespaces remain unaffected" is what this PR contradicts), lance-format/lance#3512 (same `aws.rs:217` surface, different cause).
