### PR TITLE
feat(optimizer): rewrite ORDER BY <distance> LIMIT k into Lance KNN scan

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,6 +30,8 @@ set(EXTENSION_SOURCES src/lance_extension.cpp src/lance_scan.cpp
                       src/lance_truncate.cpp
                       src/lance_index.cpp
                       src/lance_arrow_compat.cpp
+                      src/lance_knn_scan.cpp
+                      src/lance_knn_optimizer.cpp
                       src/lance_resolver.cpp)
 
 build_static_extension(${TARGET_NAME} ${EXTENSION_SOURCES})

--- a/rust/error.rs
+++ b/rust/error.rs
@@ -67,6 +67,7 @@ pub enum ErrorCode {
     Exec = 52,
     DatasetMerge = 53,
     NamespaceQueryTable = 54,
+    DatasetGetIndexMetric = 55,
 }
 
 struct LastError {

--- a/rust/ffi/index.rs
+++ b/rust/ffi/index.rs
@@ -234,6 +234,208 @@ fn list_scalar_indexed_columns_inner(dataset: *mut c_void) -> FfiResult<Vec<Stri
     Ok(cols)
 }
 
+/// Returns the normalized distance metric ("l2"/"cosine"/"dot") of the first
+/// vector index found on `column`.
+///
+/// On success, writes a heap-allocated C string to `*out_metric` and returns 0.
+/// The caller is responsible for freeing the string via `lance_free_string`.
+///
+/// Returns 1 (and writes null to `*out_metric`) if no vector index covers the
+/// column. Returns -1 on error; the caller should consult
+/// `lance_last_error_code` / `lance_last_error_message`.
+#[no_mangle]
+pub unsafe extern "C" fn lance_dataset_vector_index_metric(
+    dataset: *mut c_void,
+    column: *const c_char,
+    out_metric: *mut *const c_char,
+) -> i32 {
+    if !out_metric.is_null() {
+        // SAFETY: Caller guarantees out_metric points to a writable `*const c_char`
+        // when non-null. We initialise it to null so partial writes are not observed
+        // on the error / not-found paths.
+        unsafe {
+            ptr::write(out_metric, ptr::null());
+        }
+    }
+    match dataset_vector_index_metric_inner(dataset, column, out_metric) {
+        Ok(found) => {
+            clear_last_error();
+            if found {
+                0
+            } else {
+                1
+            }
+        }
+        Err(err) => {
+            set_last_error(err.code, err.message);
+            -1
+        }
+    }
+}
+
+fn dataset_vector_index_metric_inner(
+    dataset: *mut c_void,
+    column: *const c_char,
+    out_metric: *mut *const c_char,
+) -> FfiResult<bool> {
+    if out_metric.is_null() {
+        return Err(FfiError::new(
+            ErrorCode::InvalidArgument,
+            "out_metric is null",
+        ));
+    }
+    let handle = unsafe { dataset_handle(dataset)? };
+    let column = unsafe { cstr_to_str(column, "column")? };
+    if column.is_empty() {
+        return Err(FfiError::new(
+            ErrorCode::InvalidArgument,
+            "column must be non-empty",
+        ));
+    }
+
+    let dataset = handle.dataset.as_ref().clone();
+
+    let descs = match runtime::block_on(async { dataset.describe_indices(None).await }) {
+        Ok(Ok(v)) => v,
+        Ok(Err(err)) => {
+            return Err(FfiError::new(
+                ErrorCode::DatasetDescribeIndices,
+                format!("dataset describe_indices: {err}"),
+            ))
+        }
+        Err(err) => return Err(FfiError::new(ErrorCode::Runtime, format!("runtime: {err}"))),
+    };
+
+    let schema = dataset.schema();
+    for d in descs {
+        let idx_type = d.index_type().to_string();
+        let normalized = normalize_index_type(&idx_type);
+        if !is_vector_index_type(&normalized) {
+            continue;
+        }
+
+        let matches_column = d.field_ids().iter().any(|&field_id| {
+            schema
+                .field_by_id(field_id as i32)
+                .is_some_and(|f| f.name == column)
+        });
+        if !matches_column {
+            continue;
+        }
+
+        let Some(metric_raw) = lookup_vector_index_metric(&dataset, d.as_ref())? else {
+            continue;
+        };
+        let metric = normalize_vector_metric(&metric_raw)?;
+
+        // SAFETY: out_metric was checked non-null above; the caller guarantees it
+        // points to a writable `*const c_char`. The pointer we hand out is created
+        // via `to_c_string(...).into_raw()` and ownership transfers to the caller,
+        // which must release it with `lance_free_string`.
+        unsafe {
+            ptr::write(
+                out_metric,
+                to_c_string(metric).into_raw() as *const c_char,
+            );
+        }
+        return Ok(true);
+    }
+
+    Ok(false)
+}
+
+/// Looks up the raw metric string for a single vector index description.
+///
+/// Prefers `IndexDescription::details()` (which is cheap when a plugin is
+/// registered for the details type), falling back to `Dataset::index_statistics`
+/// (which opens the index) when the details JSON does not expose the metric.
+/// Returns `Ok(None)` when neither source surfaces a metric so the caller can
+/// continue searching across other index descriptions.
+fn lookup_vector_index_metric(
+    dataset: &Dataset,
+    desc: &dyn lance_index::IndexDescription,
+) -> FfiResult<Option<String>> {
+    // Try IndexDescription::details() first. Vector indices currently use an
+    // empty `VectorIndexDetails` proto with no registered plugin, so this almost
+    // always returns Err today; the branch is kept so plugins that later expose
+    // the metric here will be picked up without further changes.
+    if let Ok(details_json) = desc.details() {
+        if let Ok(value) = serde_json::from_str::<serde_json::Value>(&details_json) {
+            if let Some(metric) = value
+                .get("distance_type")
+                .or_else(|| value.get("metric_type"))
+                .and_then(|v| v.as_str())
+            {
+                return Ok(Some(metric.to_string()));
+            }
+        }
+    }
+
+    // Fall back to the richer `index_statistics` JSON which the runtime builds
+    // by opening the index. The IVF statistics carry `metric_type` at the top
+    // level and again inside each entry of the `indices` / `segments` arrays.
+    let stats_json = match runtime::block_on(async { dataset.index_statistics(desc.name()).await })
+    {
+        Ok(Ok(v)) => v,
+        Ok(Err(err)) => {
+            return Err(FfiError::new(
+                ErrorCode::DatasetGetIndexMetric,
+                format!("dataset index_statistics({}): {err}", desc.name()),
+            ));
+        }
+        Err(err) => return Err(FfiError::new(ErrorCode::Runtime, format!("runtime: {err}"))),
+    };
+
+    let stats: serde_json::Value = serde_json::from_str(&stats_json).map_err(|err| {
+        FfiError::new(
+            ErrorCode::DatasetGetIndexMetric,
+            format!("parse index_statistics json: {err}"),
+        )
+    })?;
+
+    let metric = stats
+        .get("metric_type")
+        .and_then(|v| v.as_str())
+        .or_else(|| {
+            stats
+                .get("indices")
+                .and_then(|v| v.as_array())
+                .and_then(|arr| arr.first())
+                .and_then(|obj| obj.get("metric_type"))
+                .and_then(|v| v.as_str())
+        })
+        .or_else(|| {
+            stats
+                .get("segments")
+                .and_then(|v| v.as_array())
+                .and_then(|arr| arr.first())
+                .and_then(|obj| obj.get("metric_type"))
+                .and_then(|v| v.as_str())
+        });
+
+    Ok(metric.map(|s| s.to_string()))
+}
+
+/// Maps a raw distance-type string from Lance into the normalized form expected
+/// by the C++ side: "l2", "cosine", or "dot". Unknown values yield an error
+/// with `ErrorCode::DatasetGetIndexMetric` so the caller can distinguish them
+/// from "no vector index found".
+fn normalize_vector_metric(raw: &str) -> FfiResult<String> {
+    let lower = raw.trim().to_ascii_lowercase();
+    let mapped = match lower.as_str() {
+        "l2" | "euclidean" => "l2",
+        "cosine" => "cosine",
+        "dot" | "innerproduct" | "inner_product" => "dot",
+        other => {
+            return Err(FfiError::new(
+                ErrorCode::DatasetGetIndexMetric,
+                format!("unsupported vector index metric: {other}"),
+            ));
+        }
+    };
+    Ok(mapped.to_string())
+}
+
 fn estimate_rows_indexed(
     dataset_total_rows: u64,
     dataset_frag_ids: &roaring::RoaringBitmap,

--- a/rust/ffi/knn.rs
+++ b/rust/ffi/knn.rs
@@ -23,6 +23,7 @@ pub unsafe extern "C" fn lance_get_knn_schema(
     k: u64,
     nprobes: u64,
     refine_factor: u64,
+    ef: u64,
     prefilter: u8,
     use_index: u8,
 ) -> *mut c_void {
@@ -34,6 +35,7 @@ pub unsafe extern "C" fn lance_get_knn_schema(
         k,
         nprobes,
         refine_factor,
+        ef,
         prefilter,
         use_index,
     ) {
@@ -57,6 +59,7 @@ fn get_knn_schema_inner(
     k: u64,
     nprobes: u64,
     refine_factor: u64,
+    ef: u64,
     prefilter: u8,
     use_index: u8,
 ) -> FfiResult<SchemaHandle> {
@@ -88,6 +91,10 @@ fn get_knn_schema_inner(
         })?;
         scan.refine(refine_factor_u32);
     }
+    if ef != 0 {
+        let ef_usize = nonzero_u64_to_usize(ef, "ef")?;
+        scan.ef(ef_usize);
+    }
     scan.use_index(use_index != 0);
     scan.disable_scoring_autoprojection();
     scan.project(projection.as_ref())
@@ -109,6 +116,7 @@ pub unsafe extern "C" fn lance_create_knn_stream_ir(
     k: u64,
     nprobes: u64,
     refine_factor: u64,
+    ef: u64,
     filter_ir: *const u8,
     filter_ir_len: usize,
     prefilter: u8,
@@ -122,6 +130,7 @@ pub unsafe extern "C" fn lance_create_knn_stream_ir(
         k,
         nprobes,
         refine_factor,
+        ef,
         filter_ir,
         filter_ir_len,
         prefilter,
@@ -147,6 +156,7 @@ fn create_knn_stream_ir_inner(
     k: u64,
     nprobes: u64,
     refine_factor: u64,
+    ef: u64,
     filter_ir: *const u8,
     filter_ir_len: usize,
     prefilter: u8,
@@ -196,6 +206,10 @@ fn create_knn_stream_ir_inner(
         })?;
         scan.refine(refine_factor_u32);
     }
+    if ef != 0 {
+        let ef_usize = nonzero_u64_to_usize(ef, "ef")?;
+        scan.ef(ef_usize);
+    }
     scan.use_index(use_index != 0);
     scan.disable_scoring_autoprojection();
     scan.project(projection.as_ref()).map_err(|err| {
@@ -224,6 +238,7 @@ pub unsafe extern "C" fn lance_explain_knn_scan_ir(
     k: u64,
     nprobes: u64,
     refine_factor: u64,
+    ef: u64,
     filter_ir: *const u8,
     filter_ir_len: usize,
     prefilter: u8,
@@ -238,6 +253,7 @@ pub unsafe extern "C" fn lance_explain_knn_scan_ir(
         k,
         nprobes,
         refine_factor,
+        ef,
         filter_ir,
         filter_ir_len,
         prefilter,
@@ -264,6 +280,7 @@ fn explain_knn_scan_ir_inner(
     k: u64,
     nprobes: u64,
     refine_factor: u64,
+    ef: u64,
     filter_ir: *const u8,
     filter_ir_len: usize,
     prefilter: u8,
@@ -308,6 +325,10 @@ fn explain_knn_scan_ir_inner(
             FfiError::new(ErrorCode::InvalidArgument, "refine_factor must fit in u32")
         })?;
         scan.refine(refine_factor_u32);
+    }
+    if ef != 0 {
+        let ef_usize = nonzero_u64_to_usize(ef, "ef")?;
+        scan.ef(ef_usize);
     }
     scan.use_index(use_index != 0);
     scan.disable_scoring_autoprojection();

--- a/src/include/lance_dataset_cache.hpp
+++ b/src/include/lance_dataset_cache.hpp
@@ -2,9 +2,22 @@
 
 #include "duckdb.hpp"
 
+#include <mutex>
+#include <unordered_map>
+
 namespace duckdb {
 
 class LanceTableEntry;
+
+// Outcome of a vector-index metric lookup. Cached on LanceDatasetCacheEntry
+// so the per-plan KNN optimizer does not pay the index_statistics open cost
+// on repeated queries against the same (cached) dataset.
+struct LanceVectorIndexMetricLookup {
+  // 0 = ok, 1 = no index, -1 = error.
+  int status = 0;
+  string metric;
+  string error_message;
+};
 
 class LanceDatasetCacheEntry {
 public:
@@ -14,9 +27,19 @@ public:
   void *Handle() const { return dataset; }
   const string &DisplayUri() const { return display_uri; }
 
+  // Returns the metric lookup for `column`, calling into Lance only on the
+  // first request per column. Subsequent calls return the cached value.
+  // Cache invalidation happens automatically: writes invalidate the dataset
+  // cache entry, which discards this cache along with the handle.
+  LanceVectorIndexMetricLookup
+  GetOrLookupVectorIndexMetric(const string &column);
+
 private:
   void *dataset = nullptr;
   string display_uri;
+
+  std::mutex vector_metric_mutex;
+  std::unordered_map<string, LanceVectorIndexMetricLookup> vector_metric_cache;
 };
 
 shared_ptr<LanceDatasetCacheEntry>

--- a/src/include/lance_ffi.hpp
+++ b/src/include/lance_ffi.hpp
@@ -249,11 +249,11 @@ const char *lance_explain_dataset_scan_ir(void *dataset, const char **columns,
 void *lance_get_knn_schema(void *dataset, const char *vector_column,
                            const float *query_values, size_t query_len,
                            uint64_t k, uint64_t nprobes, uint64_t refine_factor,
-                           uint8_t prefilter, uint8_t use_index);
+                           uint64_t ef, uint8_t prefilter, uint8_t use_index);
 void *lance_create_knn_stream_ir(void *dataset, const char *vector_column,
                                  const float *query_values, size_t query_len,
                                  uint64_t k, uint64_t nprobes,
-                                 uint64_t refine_factor,
+                                 uint64_t refine_factor, uint64_t ef,
                                  const uint8_t *filter_ir, size_t filter_ir_len,
                                  uint8_t prefilter, uint8_t use_index);
 
@@ -261,7 +261,7 @@ const char *lance_explain_knn_scan_ir(void *dataset, const char *vector_column,
                                       const float *query_values,
                                       size_t query_len, uint64_t k,
                                       uint64_t nprobes, uint64_t refine_factor,
-                                      const uint8_t *filter_ir,
+                                      uint64_t ef, const uint8_t *filter_ir,
                                       size_t filter_ir_len, uint8_t prefilter,
                                       uint8_t use_index, uint8_t verbose);
 
@@ -338,6 +338,14 @@ void *lance_create_index_list_stream(void *dataset);
 char **lance_dataset_list_scalar_indexed_columns(void *dataset,
                                                  size_t *out_len);
 void lance_free_scalar_indexed_columns(char **ptr, size_t len);
+
+// Returns 0 if a vector index is found on `column`, writing the normalized
+// metric
+// ("l2"/"cosine"/"dot") to *out_metric (caller must free via
+// lance_free_string). Returns 1 if no vector index covers this column. Returns
+// -1 on error (use lance_last_error_*).
+int32_t lance_dataset_vector_index_metric(void *dataset, const char *column,
+                                          const char **out_metric);
 
 void lance_free_batch(void *batch);
 int32_t lance_batch_to_arrow(void *batch, ArrowArray *out_array,

--- a/src/include/lance_knn_optimizer.hpp
+++ b/src/include/lance_knn_optimizer.hpp
@@ -1,0 +1,19 @@
+#pragma once
+
+namespace duckdb {
+
+class DBConfig;
+
+// Registers the KNN rewrite optimizer extension. The pass converts a
+// LOGICAL_TOP_N (ORDER BY array_distance(vec, const_query) LIMIT k) sitting
+// over a Lance scan (with an optional pushable LOGICAL_FILTER in between)
+// into a single LOGICAL_GET against the internal __lance_knn_scan table
+// function, so the request is served by Lance's vector index instead of by
+// a full table scan + DuckDB in-memory sort.
+//
+// All fallback conditions (missing index, metric mismatch, OFFSET, DESC,
+// multi-order-by, non-constant query vector, non-pushable WHERE, ...) keep
+// the plan unchanged — the original semantics always remain correct.
+void RegisterLanceKNNOptimizer(DBConfig &config);
+
+} // namespace duckdb

--- a/src/include/lance_knn_scan.hpp
+++ b/src/include/lance_knn_scan.hpp
@@ -1,0 +1,66 @@
+#pragma once
+
+#include "lance_dataset_cache.hpp"
+
+#include "duckdb.hpp"
+#include "duckdb/common/arrow/arrow_wrapper.hpp"
+#include "duckdb/function/table/arrow.hpp"
+#include "duckdb/function/table_function.hpp"
+
+#include <cstdint>
+
+namespace duckdb {
+
+class ExtensionLoader;
+class TableCatalogEntry;
+
+// Bind data for the internal __lance_knn_scan table function. The
+// optimizer constructs this directly via the rewrite pass; the rebuild
+// path (prepared statements / EXPLAIN ANALYZE replanning) reconstructs
+// the same shape from the function's BLOB parameters.
+struct LanceKnnScanBindData : public TableFunctionData {
+  string file_path;
+  string vector_column;
+  vector<float> query;
+  uint64_t k = 0;
+  // Distance metric inferred from the rewritten distance function:
+  // "l2" / "cosine" / "dot". Lance itself reads the metric from the
+  // selected index; this string is informational (EXPLAIN clarity and
+  // optimizer / index-metric consistency checks).
+  string metric;
+  uint64_t nprobes = 0;
+  uint64_t refine_factor = 0;
+  uint64_t ef = 0;
+  bool prefilter = true;
+  bool use_index = true;
+
+  // Encoded Lance Filter IR (LFT1) bytes, possibly empty.
+  string filter_ir_msg;
+
+  // Dataset handle is always accessed through dataset_entry->Handle().
+  // We intentionally do not cache the raw pointer separately — keeping
+  // two fields in sync (and making sure neither outlives the other) was a
+  // foot-gun: a future copy-then-move of bind_data would leave the raw
+  // pointer dangling while dataset_entry was nulled out. shared_ptr ref-
+  // count is the single source of truth for dataset lifetime.
+  shared_ptr<LanceDatasetCacheEntry> dataset_entry;
+  bool dataset_cache_hit = false;
+
+  // Lance-side scan schema (matches the bound LogicalGet return types).
+  ArrowSchemaWrapper schema_root;
+  ArrowTableSchema arrow_table;
+  vector<string> names;
+  vector<LogicalType> types;
+};
+
+TableFunction LanceKnnScanFunction();
+void RegisterLanceKNNScan(ExtensionLoader &loader);
+
+// Populates the bind_data's arrow_table / schema_root / names / types by
+// asking Lance for the KNN scan schema. The optimizer-built rewrite path
+// uses this to bootstrap the bind data it just constructed (the normal
+// Bind callback does the same thing internally on re-bind).
+void LanceKnnScanPopulateSchema(ClientContext &context,
+                                LanceKnnScanBindData &bind_data);
+
+} // namespace duckdb

--- a/src/lance_dataset_cache.cpp
+++ b/src/lance_dataset_cache.cpp
@@ -75,6 +75,70 @@ LanceDatasetCacheEntry::~LanceDatasetCacheEntry() {
   }
 }
 
+LanceVectorIndexMetricLookup
+LanceDatasetCacheEntry::GetOrLookupVectorIndexMetric(const string &column) {
+  {
+    std::lock_guard<std::mutex> guard(vector_metric_mutex);
+    auto it = vector_metric_cache.find(column);
+    if (it != vector_metric_cache.end()) {
+      return it->second;
+    }
+  }
+
+  // FFI call runs without the mutex held to avoid blocking concurrent lookups
+  // on other columns. The window between releasing the read and inserting the
+  // result allows a duplicate call; that is harmless (same result) and rare.
+  LanceVectorIndexMetricLookup result;
+  const char *metric_ptr = nullptr;
+  auto rc =
+      lance_dataset_vector_index_metric(dataset, column.c_str(), &metric_ptr);
+  result.status = rc;
+  if (rc == 0) {
+    if (metric_ptr) {
+      result.metric.assign(metric_ptr);
+      lance_free_string(metric_ptr);
+    } else {
+      // Treat null metric as a soft error: do not cache, so a later call
+      // gets another chance to surface the real reason.
+      result.status = -1;
+      result.error_message = "vector index metric was null";
+      return result;
+    }
+  } else if (rc == -1) {
+    result.error_message = LanceConsumeLastError();
+    if (result.error_message.empty()) {
+      result.error_message = "unknown error";
+    }
+    // Error paths are intentionally not cached: a transient error should be
+    // retried on the next call, otherwise a single failure poisons the cache
+    // for the lifetime of the dataset entry.
+    return result;
+  } else if (rc == 1) {
+    // No vector index on this column. Same-context CREATE INDEX in
+    // lance_index.cpp invalidates the entire dataset cache entry, so this
+    // negative result would normally be discarded with the entry — but
+    // caching it would still leave a foot-gun for any future index DDL path
+    // that forgets to invalidate. Symmetric with the error path: only
+    // cache positive results.
+    return result;
+  }
+
+  {
+    std::lock_guard<std::mutex> guard(vector_metric_mutex);
+    auto insertion = vector_metric_cache.emplace(column, result);
+    // On a benign-race collision the existing entry wins. Both racers ran the
+    // same FFI against the same dataset handle, so the metric must match —
+    // catch the day a Lance bug surfaces a non-deterministic metric.
+    // Release-build behavior if the assertion would fire is still safe: the
+    // first-writer-wins semantics mean both callers proceed with a
+    // consistent (if surprising) metric, and the optimizer's downstream
+    // mismatch check in lance_knn_scan rebind will catch any divergence.
+    D_ASSERT(insertion.second ||
+             insertion.first->second.metric == result.metric);
+    return insertion.first->second;
+  }
+}
+
 static shared_ptr<LanceDatasetCacheState>
 GetOrCreateLanceDatasetCacheState(ClientContext &context) {
   return context.registered_state->GetOrCreate<LanceDatasetCacheState>(

--- a/src/lance_extension.cpp
+++ b/src/lance_extension.cpp
@@ -22,6 +22,8 @@ void RegisterLanceStorage(DBConfig &config);
 void RegisterLanceTruncate(DBConfig &config, ExtensionLoader &loader);
 void RegisterLanceIndex(DBConfig &config, ExtensionLoader &loader);
 void RegisterLanceScanOptimizer(DBConfig &config);
+void RegisterLanceKNNScan(ExtensionLoader &loader);
+void RegisterLanceKNNOptimizer(DBConfig &config);
 
 static void LoadInternal(ExtensionLoader &loader) {
   // Register internal scan table functions.
@@ -29,6 +31,7 @@ static void LoadInternal(ExtensionLoader &loader) {
   RegisterLanceSearch(loader);
   RegisterLanceWrite(loader);
   RegisterLanceMaintenance(loader);
+  RegisterLanceKNNScan(loader);
 }
 
 void LanceExtension::Load(ExtensionLoader &loader) {
@@ -42,7 +45,47 @@ void LanceExtension::Load(ExtensionLoader &loader) {
                             "Enable deferred materialization for heavy columns "
                             "when filter pushdown fails",
                             LogicalType::BOOLEAN, Value::BOOLEAN(true));
+  config.AddExtensionOption(
+      "lance_knn_nprobes",
+      "Default nprobes passed to Lance KNN scans rewritten by the optimizer "
+      "(0 = Lance default)",
+      LogicalType::BIGINT, Value::BIGINT(0));
+  config.AddExtensionOption(
+      "lance_knn_refine_factor",
+      "Default refine_factor passed to Lance KNN scans rewritten by the "
+      "optimizer (0 = no refinement)",
+      LogicalType::BIGINT, Value::BIGINT(0));
+  config.AddExtensionOption(
+      "lance_knn_ef_search",
+      "HNSW search-time candidate-pool size (ef_search) passed to Lance KNN "
+      "scans rewritten by the optimizer. Larger values trade latency for "
+      "recall; 0 = Lance default (k + k/2). Distinct from hnsw_ef_construction "
+      "which only affects index build.",
+      LogicalType::BIGINT, Value::BIGINT(0));
+  config.AddExtensionOption(
+      "lance_knn_prefilter",
+      "Whether the optimizer-rewritten Lance KNN scans should pre-filter "
+      "(true) or leave filtered queries on DuckDB's original TopN plan "
+      "(false). Explicit lance_vector_search(prefilter=false) remains "
+      "available for post-filtered KNN search.",
+      LogicalType::BOOLEAN, Value::BOOLEAN(true));
+  config.AddExtensionOption(
+      "lance_knn_use_index",
+      "Kill switch for the Lance KNN optimizer — when false the optimizer "
+      "leaves ORDER BY <distance> LIMIT k plans alone and DuckDB executes "
+      "them via a full Lance scan + in-memory top-k",
+      LogicalType::BOOLEAN, Value::BOOLEAN(true));
+  config.AddExtensionOption(
+      "lance_knn_max_k",
+      "Upper bound on the LIMIT value the Lance KNN optimizer will rewrite. "
+      "Plans with LIMIT above this value are left to DuckDB so a runaway "
+      "query does not pin an arbitrarily large k inside the index scan. "
+      "Setting to 0 falls back to the built-in default (10000); the "
+      "optimizer also clamps any configured value to a hard ceiling of "
+      "1000000 to keep a typo'd setting from blowing up memory",
+      LogicalType::BIGINT, Value::BIGINT(10000));
   RegisterLanceScanOptimizer(config);
+  RegisterLanceKNNOptimizer(config);
   RegisterLanceStorage(config);
   RegisterLanceReplacement(config);
   RegisterLanceTruncate(config, loader);

--- a/src/lance_knn_optimizer.cpp
+++ b/src/lance_knn_optimizer.cpp
@@ -1,0 +1,594 @@
+#include "lance_knn_optimizer.hpp"
+
+#include "duckdb.hpp"
+#include "duckdb/common/types.hpp"
+#include "duckdb/common/types/value.hpp"
+#include "duckdb/main/client_context.hpp"
+#include "duckdb/main/config.hpp"
+#include "duckdb/optimizer/optimizer_extension.hpp"
+#include "duckdb/planner/expression/bound_cast_expression.hpp"
+#include "duckdb/planner/expression/bound_columnref_expression.hpp"
+#include "duckdb/planner/expression/bound_constant_expression.hpp"
+#include "duckdb/planner/expression/bound_function_expression.hpp"
+#include "duckdb/planner/operator/logical_filter.hpp"
+#include "duckdb/planner/operator/logical_get.hpp"
+#include "duckdb/planner/operator/logical_projection.hpp"
+#include "duckdb/planner/operator/logical_top_n.hpp"
+
+#include "lance_common.hpp"
+#include "lance_dataset_cache.hpp"
+#include "lance_ffi.hpp"
+#include "lance_filter_ir.hpp"
+#include "lance_knn_scan.hpp"
+#include "lance_scan_bind_data.hpp"
+
+#include <cstring>
+#include <unordered_set>
+
+namespace duckdb {
+
+namespace {
+
+// Hard ceiling — even if the user sets lance_knn_max_k higher, we refuse to
+// rewrite past this. Keeps a typo'd setting from pinning many GB of state
+// inside Lance.
+constexpr idx_t LANCE_KNN_ABSOLUTE_MAX_K = 1000000;
+
+constexpr const char *LANCE_KNN_NPROBES_SETTING = "lance_knn_nprobes";
+constexpr const char *LANCE_KNN_REFINE_FACTOR_SETTING =
+    "lance_knn_refine_factor";
+constexpr const char *LANCE_KNN_EF_SEARCH_SETTING = "lance_knn_ef_search";
+constexpr const char *LANCE_KNN_PREFILTER_SETTING = "lance_knn_prefilter";
+constexpr const char *LANCE_KNN_USE_INDEX_SETTING = "lance_knn_use_index";
+constexpr const char *LANCE_KNN_MAX_K_SETTING = "lance_knn_max_k";
+constexpr uint64_t LANCE_KNN_MAX_K_DEFAULT = 10000;
+
+// Mirrors the helper in lance_scan.cpp — kept local to avoid coupling the
+// optimizer header to the scan internals.
+bool IsLanceScanTableFunction(const TableFunction &fn) {
+  return fn.name == "__lance_scan" || fn.name == "__lance_table_scan" ||
+         fn.name == "__lance_namespace_scan";
+}
+
+uint64_t GetKNNOptionUInt64(ClientContext &context, const char *name,
+                            uint64_t fallback) {
+  Value val;
+  if (!context.TryGetCurrentSetting(name, val) || val.IsNull()) {
+    return fallback;
+  }
+  auto v = val.DefaultCastAs(LogicalType::BIGINT).GetValue<int64_t>();
+  if (v <= 0) {
+    return 0;
+  }
+  return NumericCast<uint64_t>(v);
+}
+
+bool GetKNNOptionBool(ClientContext &context, const char *name, bool fallback) {
+  Value val;
+  if (!context.TryGetCurrentSetting(name, val) || val.IsNull()) {
+    return fallback;
+  }
+  return val.DefaultCastAs(LogicalType::BOOLEAN).GetValue<bool>();
+}
+
+// Maps the DuckDB distance function name to the metric tag Lance uses.
+// Returns false for any unsupported / unrecognised distance function so the
+// caller can fall back to the original plan.
+//
+// All three supported scalar distances are symmetric in the value they
+// produce — L2 and cosine are obviously so, and negative inner product
+// satisfies -(a·b) = -(b·a). The caller can therefore accept either
+// argument order without altering semantics.
+bool DistanceFunctionToMetric(const string &fn_name, string &out_metric) {
+  if (fn_name == "array_distance" || fn_name == "list_distance") {
+    out_metric = "l2";
+    return true;
+  }
+  if (fn_name == "array_cosine_distance" || fn_name == "list_cosine_distance") {
+    out_metric = "cosine";
+    return true;
+  }
+  if (fn_name == "array_negative_inner_product" ||
+      fn_name == "list_negative_inner_product") {
+    out_metric = "dot";
+    return true;
+  }
+  return false;
+}
+
+// Extracts query floats from a BoundConstantExpression. Accepts both
+// FLOAT[N] (ARRAY) and FLOAT[] (LIST) constants — DuckDB binds the literal
+// to one or the other depending on the distance function's signature
+// (array_distance prefers ARRAY, list_distance prefers LIST). Returns false
+// if the constant is not a float sequence, since the Lance KNN FFI takes a
+// `const float *` and we are not willing to silently insert a cast.
+bool TryExtractQueryVector(const Expression &expr, vector<float> &out) {
+  if (expr.GetExpressionClass() != ExpressionClass::BOUND_CONSTANT) {
+    return false;
+  }
+  auto &constant = expr.Cast<BoundConstantExpression>();
+  if (constant.value.IsNull()) {
+    return false;
+  }
+  auto &type = constant.value.type();
+  const vector<Value> *children_ptr = nullptr;
+  if (type.id() == LogicalTypeId::ARRAY) {
+    if (ArrayType::GetChildType(type).id() != LogicalTypeId::FLOAT) {
+      return false;
+    }
+    children_ptr = &ArrayValue::GetChildren(constant.value);
+  } else if (type.id() == LogicalTypeId::LIST) {
+    if (ListType::GetChildType(type).id() != LogicalTypeId::FLOAT) {
+      return false;
+    }
+    children_ptr = &ListValue::GetChildren(constant.value);
+  } else {
+    return false;
+  }
+  out.clear();
+  out.reserve(children_ptr->size());
+  for (auto &child : *children_ptr) {
+    if (child.IsNull()) {
+      return false;
+    }
+    out.push_back(child.GetValue<float>());
+  }
+  return true;
+}
+
+// Walks past any BOUND_CAST nodes and returns the underlying expression.
+// Cast chains are common for ORDER BY expressions (DuckDB inserts an explicit
+// cast to align with the projection output type).
+const Expression *PeelCasts(const Expression *expr) {
+  while (expr && expr->GetExpressionClass() == ExpressionClass::BOUND_CAST) {
+    auto &cast = expr->Cast<BoundCastExpression>();
+    expr = cast.child.get();
+  }
+  return expr;
+}
+
+// Resolve a column ref pointing at the projection to the underlying
+// expression in the projection's select list, peeling casts as we go. If the
+// column ref does not bind to `proj.table_index` we leave `expr` untouched.
+const Expression *ResolveThroughProjection(const Expression *expr,
+                                           const LogicalProjection *proj) {
+  expr = PeelCasts(expr);
+  if (!expr || !proj) {
+    return expr;
+  }
+  if (expr->GetExpressionClass() != ExpressionClass::BOUND_COLUMN_REF) {
+    return expr;
+  }
+  auto &ref = expr->Cast<BoundColumnRefExpression>();
+  if (ref.binding.table_index != proj->table_index) {
+    return expr;
+  }
+  if (ref.binding.column_index >= proj->expressions.size()) {
+    return expr;
+  }
+  return PeelCasts(proj->expressions[ref.binding.column_index].get());
+}
+
+bool TryResolveVectorColumn(const Expression &expr, const LogicalGet &get,
+                            string &out_name) {
+  if (expr.GetExpressionClass() != ExpressionClass::BOUND_COLUMN_REF) {
+    return false;
+  }
+  auto &ref = expr.Cast<BoundColumnRefExpression>();
+  if (ref.binding.table_index != get.table_index) {
+    return false;
+  }
+  auto &col_ids = get.GetColumnIds();
+  if (ref.binding.column_index >= col_ids.size()) {
+    return false;
+  }
+  auto col_id = col_ids[ref.binding.column_index].GetPrimaryIndex();
+  if (col_id >= get.names.size()) {
+    return false;
+  }
+  if (ref.return_type.id() != LogicalTypeId::ARRAY) {
+    return false;
+  }
+  // FLOAT[N] (Float32) is the only element type currently exercised end-to-
+  // end through the KNN FFI: lance_create_knn_stream_ir takes a const
+  // float * query and Lance's KNN executor expects the column to match.
+  //
+  // Other Arrow array element types fall through to a silent fallback:
+  //   - DOUBLE[N] (Float64): Lance can store this, but routing it through
+  //     the Float32 FFI requires a query-vector cast (loses precision) or
+  //     a new Float64 FFI variant. Until that's wired we leave such
+  //     columns on the DuckDB scan path — correct, just unindexed.
+  //   - HALF_FLOAT[N] (Float16): LanceCoerceArrowSchemaForDuckDB converts
+  //     these to FLOAT[N] before DuckDB sees them, so a DuckDB-visible
+  //     HALF_FLOAT array shouldn't reach this point.
+  //   - INTEGER / other numeric element types are not vector embeddings.
+  //
+  // If you change the supported types here, also update the rebind path
+  // in lance_knn_scan.cpp and add a dataset fixture + test.
+  auto &child_type = ArrayType::GetChildType(ref.return_type);
+  if (child_type.id() != LogicalTypeId::FLOAT) {
+    return false;
+  }
+  out_name = get.names[col_id];
+  return true;
+}
+
+// Inspects the distance function call, finds the (column, query) sides, and
+// returns the metric tag. Returns false if the call shape does not satisfy
+// the rewrite preconditions.
+struct DistanceCallInfo {
+  string metric;
+  string vector_column;
+  vector<float> query;
+};
+
+bool TryDescribeDistanceCall(const Expression &expr, const LogicalGet &get,
+                             DistanceCallInfo &out) {
+  if (expr.GetExpressionClass() != ExpressionClass::BOUND_FUNCTION) {
+    return false;
+  }
+  auto &func = expr.Cast<BoundFunctionExpression>();
+  if (func.children.size() != 2) {
+    return false;
+  }
+  string metric;
+  if (!DistanceFunctionToMetric(func.function.name, metric)) {
+    return false;
+  }
+
+  auto *lhs = PeelCasts(func.children[0].get());
+  auto *rhs = PeelCasts(func.children[1].get());
+  if (!lhs || !rhs) {
+    return false;
+  }
+
+  vector<float> query;
+  string vector_column;
+  if (TryExtractQueryVector(*rhs, query) &&
+      TryResolveVectorColumn(*lhs, get, vector_column)) {
+    out.metric = std::move(metric);
+    out.vector_column = std::move(vector_column);
+    out.query = std::move(query);
+    return true;
+  }
+  if (TryExtractQueryVector(*lhs, query) &&
+      TryResolveVectorColumn(*rhs, get, vector_column)) {
+    out.metric = std::move(metric);
+    out.vector_column = std::move(vector_column);
+    out.query = std::move(query);
+    return true;
+  }
+  return false;
+}
+
+// Wraps the metric-lookup FFI via the dataset cache entry. Returns true when
+// a vector index exists *and* its metric matches the requested one. On any
+// error or mismatch we set `out_reason` (helpful for debugging) and return
+// false. The cache entry memoizes the lookup result for the lifetime of the
+// dataset entry, avoiding the index_statistics open on every plan.
+bool VectorIndexMetricMatches(LanceDatasetCacheEntry &entry,
+                              const string &column,
+                              const string &requested_metric,
+                              string &out_reason) {
+  auto lookup = entry.GetOrLookupVectorIndexMetric(column);
+  if (lookup.status == 1) {
+    out_reason = "no vector index on column " + column;
+    return false;
+  }
+  if (lookup.status != 0) {
+    out_reason = "vector index metric lookup failed: " + lookup.error_message;
+    return false;
+  }
+  if (lookup.metric != requested_metric) {
+    out_reason = "vector index metric '" + lookup.metric +
+                 "' does not match requested '" + requested_metric + "'";
+    return false;
+  }
+  return true;
+}
+
+unique_ptr<LogicalOperator> RewriteKNNNode(ClientContext &context,
+                                           unique_ptr<LogicalOperator> op) {
+  if (op->type != LogicalOperatorType::LOGICAL_TOP_N ||
+      op->children.size() != 1 || !op->children[0]) {
+    return op;
+  }
+  // The use_index session var is a kill switch for the rewrite as a whole:
+  // when off, we leave the plan alone and let DuckDB's TopN drive a normal
+  // Lance scan.
+  if (!GetKNNOptionBool(context, LANCE_KNN_USE_INDEX_SETTING, true)) {
+    return op;
+  }
+  auto &top_n = op->Cast<LogicalTopN>();
+
+  // --- TopN shape checks ----------------------------------------------------
+  if (top_n.orders.size() != 1) {
+    return op;
+  }
+  auto &order = top_n.orders[0];
+  if (order.type != OrderType::ASCENDING) {
+    return op;
+  }
+  if (top_n.offset != 0) {
+    return op;
+  }
+  // DuckDB-pin: top_n.limit / top_n.offset are plain idx_t in the vendored
+  // submodule. Newer DuckDB wraps both in BoundLimitNode; switch the access
+  // pattern if the submodule bump fails to compile here.
+  auto configured_max_k = GetKNNOptionUInt64(context, LANCE_KNN_MAX_K_SETTING,
+                                             LANCE_KNN_MAX_K_DEFAULT);
+  auto effective_max_k =
+      configured_max_k == 0 ? LANCE_KNN_MAX_K_DEFAULT : configured_max_k;
+  if (effective_max_k > LANCE_KNN_ABSOLUTE_MAX_K) {
+    effective_max_k = LANCE_KNN_ABSOLUTE_MAX_K;
+  }
+  if (top_n.limit == 0 || top_n.limit > effective_max_k) {
+    return op;
+  }
+  if (!order.expression) {
+    return op;
+  }
+
+  // --- Plan-shape walk: TopN → Projection → [Filter →] GET ------------------
+  if (top_n.children[0]->type != LogicalOperatorType::LOGICAL_PROJECTION) {
+    return op;
+  }
+  auto &projection = top_n.children[0]->Cast<LogicalProjection>();
+  if (projection.children.size() != 1 || !projection.children[0]) {
+    return op;
+  }
+
+  LogicalFilter *filter_node = nullptr;
+  LogicalOperator *get_owner = projection.children[0].get();
+  if (get_owner->type == LogicalOperatorType::LOGICAL_FILTER) {
+    filter_node = &get_owner->Cast<LogicalFilter>();
+    if (filter_node->children.size() != 1 || !filter_node->children[0]) {
+      return op;
+    }
+    get_owner = filter_node->children[0].get();
+  }
+  if (!get_owner || get_owner->type != LogicalOperatorType::LOGICAL_GET) {
+    return op;
+  }
+  auto &get = get_owner->Cast<LogicalGet>();
+  if (!IsLanceScanTableFunction(get.function) || !get.bind_data) {
+    return op;
+  }
+  auto &scan_bind = get.bind_data->Cast<LanceScanBindData>();
+  if (!scan_bind.dataset) {
+    return op;
+  }
+  auto prefilter = GetKNNOptionBool(context, LANCE_KNN_PREFILTER_SETTING, true);
+
+  // A scan that already has pushed down LIMIT/OFFSET or take-rowids must not
+  // be re-wrapped: that earlier pushdown drives an entirely different scan
+  // path. Treating this as a fallback is strictly safe.
+  if (scan_bind.limit_offset_pushed_down || !scan_bind.take_row_ids.empty()) {
+    return op;
+  }
+
+  // If filters are present, prefilter=false would make Lance take the global
+  // KNN result first and apply the filter afterwards. SQL's WHERE semantics
+  // require filtering before ORDER BY/LIMIT, so leave the original TopN plan
+  // in place for this explicitly non-prefiltered mode.
+  auto has_filter_source = filter_node ||
+                           !scan_bind.lance_pushed_filter_ir_parts.empty() ||
+                           !get.table_filters.filters.empty();
+  if (!prefilter && has_filter_source) {
+    return op;
+  }
+
+  // --- Distance call extraction --------------------------------------------
+  auto *resolved =
+      ResolveThroughProjection(order.expression.get(), &projection);
+  if (!resolved) {
+    return op;
+  }
+  DistanceCallInfo info;
+  if (!TryDescribeDistanceCall(*resolved, get, info)) {
+    return op;
+  }
+
+  // --- Vector index existence + metric agreement ---------------------------
+  string reason;
+  if (!scan_bind.dataset_entry ||
+      !VectorIndexMetricMatches(*scan_bind.dataset_entry, info.vector_column,
+                                info.metric, reason)) {
+    return op;
+  }
+
+  // --- Filter IR assembly --------------------------------------------------
+  //
+  // Three sources feed into the merged IR:
+  //   (a) filter_node->expressions               — predicates still live on
+  //                                                 the LogicalFilter
+  //   (b) scan_bind.lance_pushed_filter_ir_parts — IR fragments injected by
+  //                                                 sibling passes (e.g.
+  //                                                 LanceLikePushdown)
+  //   (c) ProbeLanceTableFilterIR(get, ...)      — table_filters folded out
+  //                                                 of the LogicalFilter by
+  //                                                 ColumnLifetimeAnalyzer
+  //
+  // (a) and (b) are *not* disjoint today: LIKE pushdown writes into (b) but
+  // leaves the expression in (a) as a DuckDB-side defense in depth. Encoding
+  // both would push the same predicate to Lance twice. We dedupe by the
+  // serialized IR bytes — the encoder is deterministic for a given
+  // (expression, schema), so byte equality implies semantic equality.
+  vector<string> filter_parts;
+  unordered_set<string> seen_parts;
+  auto add_part = [&](string part) {
+    if (seen_parts.insert(part).second) {
+      filter_parts.push_back(std::move(part));
+    }
+  };
+
+  if (filter_node) {
+    for (auto &expr : filter_node->expressions) {
+      if (!expr || expr->HasParameter() || expr->IsVolatile() ||
+          expr->CanThrow()) {
+        return op;
+      }
+      string part;
+      if (!TryBuildLanceExprFilterIR(get, scan_bind.names, scan_bind.types,
+                                     false, *expr, part)) {
+        return op;
+      }
+      add_part(std::move(part));
+    }
+  }
+
+  for (auto &part : scan_bind.lance_pushed_filter_ir_parts) {
+    add_part(part);
+  }
+
+  // table_filters source: probe returns parts only if every filter is
+  // encodable — anything else means there is a residual DuckDB filter the
+  // KNN scan would silently drop, so we fall back instead.
+  auto probe = ProbeLanceTableFilterIR(get, scan_bind.names, scan_bind.types);
+  if (!probe.all_filters_pushed) {
+    return op;
+  }
+  // Bail if any table_filter targets the rowid column — rowid filters are
+  // not part of the KNN IR contract and we'd lose semantics if we erased
+  // them silently.
+  auto &col_ids = get.GetColumnIds();
+  for (auto &entry : get.table_filters.filters) {
+    if (entry.first >= col_ids.size()) {
+      return op;
+    }
+    auto col_id = col_ids[entry.first].GetPrimaryIndex();
+    if (col_id == COLUMN_IDENTIFIER_ROW_ID) {
+      return op;
+    }
+  }
+  for (auto &part : probe.parts) {
+    add_part(std::move(part));
+  }
+
+  string filter_ir_msg;
+  if (!filter_parts.empty()) {
+    if (!TryEncodeLanceFilterIRMessage(filter_parts, filter_ir_msg)) {
+      return op;
+    }
+  }
+
+  // --- Build the replacement LogicalGet around __lance_knn_scan ------------
+  auto knn_bind = make_uniq<LanceKnnScanBindData>();
+  knn_bind->file_path = scan_bind.file_path;
+  knn_bind->vector_column = info.vector_column;
+  knn_bind->query = std::move(info.query);
+  knn_bind->k = NumericCast<uint64_t>(top_n.limit);
+  knn_bind->metric = info.metric;
+  knn_bind->nprobes = GetKNNOptionUInt64(context, LANCE_KNN_NPROBES_SETTING, 0);
+  knn_bind->refine_factor =
+      GetKNNOptionUInt64(context, LANCE_KNN_REFINE_FACTOR_SETTING, 0);
+  knn_bind->ef = GetKNNOptionUInt64(context, LANCE_KNN_EF_SEARCH_SETTING, 0);
+  knn_bind->prefilter = prefilter;
+  knn_bind->use_index =
+      GetKNNOptionBool(context, LANCE_KNN_USE_INDEX_SETTING, true);
+  knn_bind->filter_ir_msg = filter_ir_msg;
+  knn_bind->dataset_entry = scan_bind.dataset_entry;
+  knn_bind->dataset_cache_hit = scan_bind.dataset_cache_hit;
+  // Populate arrow_table / schema_root / names / types from the live Lance
+  // KNN schema. The execution path reads bind_data.arrow_table.GetColumns()
+  // during ArrowToDuckDB conversion, so we cannot skip this step.
+  LanceKnnScanPopulateSchema(context, *knn_bind);
+
+  // The KNN scan schema prepends synthetic columns (_distance, _rowid) ahead
+  // of the user's columns, so the upstream column_ids (which index into the
+  // original Lance scan schema) must be remapped by name.
+  vector<ColumnIndex> remapped_column_ids;
+  remapped_column_ids.reserve(get.GetColumnIds().size());
+  for (auto &col_id : get.GetColumnIds()) {
+    auto p_orig = col_id.GetPrimaryIndex();
+    if (p_orig == COLUMN_IDENTIFIER_ROW_ID) {
+      // Rowid semantics differ on the KNN path; safer to fall back.
+      return op;
+    }
+    if (p_orig >= scan_bind.names.size()) {
+      return op;
+    }
+    auto &original_name = scan_bind.names[p_orig];
+    idx_t p_new = DConstants::INVALID_INDEX;
+    for (idx_t i = 0; i < knn_bind->names.size(); i++) {
+      if (knn_bind->names[i] == original_name) {
+        p_new = i;
+        break;
+      }
+    }
+    if (p_new == DConstants::INVALID_INDEX) {
+      return op;
+    }
+    remapped_column_ids.emplace_back(p_new);
+  }
+
+  auto returned_types = knn_bind->types;
+  auto returned_names = knn_bind->names;
+
+  auto knn_get = make_uniq<LogicalGet>(
+      get.table_index, LanceKnnScanFunction(), std::move(knn_bind),
+      std::move(returned_types), std::move(returned_names));
+  knn_get->SetColumnIds(std::move(remapped_column_ids));
+  knn_get->projection_ids = get.projection_ids;
+  knn_get->SetEstimatedCardinality(top_n.limit);
+
+  // Parameters for re-bind (prepared statement / EXPLAIN ANALYZE replan).
+  // Layout must match LanceKnnScanFunction()'s 11-parameter signature.
+  auto &bind_data_ref = knn_get->bind_data->Cast<LanceKnnScanBindData>();
+  knn_get->parameters.reserve(11);
+  knn_get->parameters.emplace_back(Value(bind_data_ref.file_path));
+  knn_get->parameters.emplace_back(Value(bind_data_ref.vector_column));
+  string query_blob;
+  query_blob.resize(bind_data_ref.query.size() * sizeof(float));
+  if (!bind_data_ref.query.empty()) {
+    memcpy(&query_blob[0], bind_data_ref.query.data(), query_blob.size());
+  }
+  knn_get->parameters.emplace_back(Value::BLOB_RAW(query_blob));
+  knn_get->parameters.emplace_back(
+      Value::BIGINT(NumericCast<int64_t>(bind_data_ref.k)));
+  knn_get->parameters.emplace_back(Value(bind_data_ref.metric));
+  knn_get->parameters.emplace_back(
+      Value::BLOB_RAW(bind_data_ref.filter_ir_msg));
+  knn_get->parameters.emplace_back(
+      Value::BIGINT(NumericCast<int64_t>(bind_data_ref.nprobes)));
+  knn_get->parameters.emplace_back(
+      Value::BIGINT(NumericCast<int64_t>(bind_data_ref.refine_factor)));
+  knn_get->parameters.emplace_back(Value::BOOLEAN(bind_data_ref.prefilter));
+  knn_get->parameters.emplace_back(Value::BOOLEAN(bind_data_ref.use_index));
+  knn_get->parameters.emplace_back(
+      Value::BIGINT(NumericCast<int64_t>(bind_data_ref.ef)));
+
+  // --- Splice the new GET in place: drop TopN and Filter -------------------
+  projection.children[0] = std::move(knn_get);
+  projection.SetEstimatedCardinality(top_n.limit);
+  // TODO: the surviving projection still computes array_distance(vec, q) on
+  // every output row. DuckDB's projection pruner does not eliminate it after
+  // our rewrite. Cost is only k rows of one distance call so we tolerate it,
+  // but a follow-up could rewrite the projection to read _distance straight
+  // from the KNN scan output (the first column it returns).
+  auto new_root = std::move(top_n.children[0]);
+  return new_root;
+}
+
+unique_ptr<LogicalOperator>
+LanceKNNScanRewrite(ClientContext &context, unique_ptr<LogicalOperator> op) {
+  for (auto &child : op->children) {
+    child = LanceKNNScanRewrite(context, std::move(child));
+  }
+  return RewriteKNNNode(context, std::move(op));
+}
+
+void LanceKNNScanRewriteOptimizer(OptimizerExtensionInput &input,
+                                  unique_ptr<LogicalOperator> &plan) {
+  plan = LanceKNNScanRewrite(input.context, std::move(plan));
+}
+
+} // namespace
+
+void RegisterLanceKNNOptimizer(DBConfig &config) {
+  OptimizerExtension ext;
+  ext.optimize_function = LanceKNNScanRewriteOptimizer;
+  OptimizerExtension::Register(config, std::move(ext));
+}
+
+} // namespace duckdb

--- a/src/lance_knn_scan.cpp
+++ b/src/lance_knn_scan.cpp
@@ -1,0 +1,510 @@
+#include "lance_knn_scan.hpp"
+
+#include "duckdb.hpp"
+#include "duckdb/common/exception.hpp"
+#include "duckdb/function/table/arrow.hpp"
+#include "duckdb/main/extension/extension_loader.hpp"
+
+#include "lance_arrow_compat.hpp"
+#include "lance_common.hpp"
+#include "lance_dataset_cache.hpp"
+#include "lance_ffi.hpp"
+
+#include <atomic>
+#include <cstring>
+#include <mutex>
+
+namespace duckdb {
+
+namespace {
+
+struct LanceKnnScanGlobalState : public GlobalTableFunctionState {
+  std::atomic<idx_t> lines_read{0};
+  std::atomic<idx_t> record_batches{0};
+  std::atomic<idx_t> record_batch_rows{0};
+
+  vector<idx_t> projection_ids;
+  vector<LogicalType> scanned_types;
+
+  std::atomic<bool> explain_computed{false};
+  string explain_plan;
+  string explain_error;
+  std::mutex explain_mutex;
+
+  idx_t MaxThreads() const override { return 1; }
+  bool CanRemoveFilterColumns() const { return !projection_ids.empty(); }
+};
+
+struct LanceKnnScanLocalState : public ArrowScanLocalState {
+  LanceKnnScanLocalState(unique_ptr<ArrowArrayWrapper> current_chunk,
+                         ClientContext &context)
+      : ArrowScanLocalState(std::move(current_chunk), context) {}
+
+  void *stream = nullptr;
+  LanceKnnScanGlobalState *global_state = nullptr;
+
+  ~LanceKnnScanLocalState() override {
+    if (stream) {
+      lance_close_stream(stream);
+    }
+  }
+};
+
+void PopulateSchemaFromKnn(ClientContext &context,
+                           LanceKnnScanBindData &bind_data) {
+  auto *schema_handle = lance_get_knn_schema(
+      bind_data.dataset_entry->Handle(), bind_data.vector_column.c_str(),
+      bind_data.query.data(), bind_data.query.size(), bind_data.k,
+      bind_data.nprobes, bind_data.refine_factor, bind_data.ef,
+      bind_data.prefilter ? 1 : 0, bind_data.use_index ? 1 : 0);
+  if (!schema_handle) {
+    throw IOException("Failed to get Lance KNN schema: " + bind_data.file_path +
+                      LanceFormatErrorSuffix());
+  }
+  memset(&bind_data.schema_root.arrow_schema, 0,
+         sizeof(bind_data.schema_root.arrow_schema));
+  if (lance_schema_to_arrow(schema_handle,
+                            &bind_data.schema_root.arrow_schema) != 0) {
+    lance_free_schema(schema_handle);
+    throw IOException(
+        "Failed to export Lance KNN schema to Arrow C Data Interface" +
+        LanceFormatErrorSuffix());
+  }
+  lance_free_schema(schema_handle);
+  LanceCoerceArrowSchemaForDuckDB(&bind_data.schema_root.arrow_schema);
+  ArrowTableFunction::PopulateArrowTableSchema(
+      context, bind_data.arrow_table, bind_data.schema_root.arrow_schema);
+  bind_data.names = bind_data.arrow_table.GetNames();
+  bind_data.types = bind_data.arrow_table.GetTypes();
+}
+
+// Upper bound on the rebound query vector blob. 1 MiB / 4 = 262 144 floats,
+// far above any real embedding dimension; meant to keep a typo'd or hostile
+// __lance_knn_scan(..., <huge blob>, ...) call from allocating eagerly.
+constexpr idx_t LANCE_KNN_REBIND_MAX_QUERY_BYTES = 1ULL << 20;
+
+// Symmetric cap on the rebound Filter IR blob. The optimizer-built path
+// produces filter IR proportional to the WHERE clause complexity (a few
+// hundred bytes is typical, a few KB is generous); 1 MiB is well above
+// anything a normal predicate could encode and prevents a hostile call
+// from passing __lance_knn_scan an arbitrarily large blob that Lance
+// would then have to parse.
+constexpr idx_t LANCE_KNN_REBIND_MAX_FILTER_IR_BYTES = 1ULL << 20;
+
+unique_ptr<FunctionData> LanceKnnScanBind(ClientContext &context,
+                                          TableFunctionBindInput &input,
+                                          vector<LogicalType> &return_types,
+                                          vector<string> &names) {
+  // The optimizer-built path attaches bind_data via the LogicalGet
+  // directly; that bind_data is used at execution time. This Bind callback
+  // is only invoked when DuckDB rebinds (prepared statement re-bind,
+  // EXPLAIN ANALYZE replanning). We reconstruct from the BLOB parameters.
+  if (input.inputs.size() < 11) {
+    throw InvalidInputException(
+        "__lance_knn_scan requires 11 parameters (internal function)");
+  }
+
+  auto result = make_uniq<LanceKnnScanBindData>();
+  result->file_path = input.inputs[0].GetValue<string>();
+  result->vector_column = input.inputs[1].GetValue<string>();
+
+  auto query_blob = input.inputs[2].GetValueUnsafe<string_t>();
+  auto query_bytes = query_blob.GetString();
+  if (query_bytes.size() % sizeof(float) != 0) {
+    throw InvalidInputException(
+        "__lance_knn_scan query blob must be a multiple of 4 bytes");
+  }
+  if (query_bytes.size() > LANCE_KNN_REBIND_MAX_QUERY_BYTES) {
+    throw InvalidInputException(
+        "__lance_knn_scan query blob is too large (" +
+        to_string(query_bytes.size()) + " bytes, max " +
+        to_string(LANCE_KNN_REBIND_MAX_QUERY_BYTES) +
+        "); this is an internal function — use lance_vector_search instead");
+  }
+  auto query_len = query_bytes.size() / sizeof(float);
+  result->query.resize(query_len);
+  if (query_len > 0) {
+    memcpy(result->query.data(), query_bytes.data(), query_bytes.size());
+  }
+
+  auto k_val = input.inputs[3].GetValue<int64_t>();
+  if (k_val <= 0) {
+    throw InvalidInputException("__lance_knn_scan requires k > 0");
+  }
+  result->k = NumericCast<uint64_t>(k_val);
+
+  // input.inputs[4] is the metric tag (informational; semantics are
+  // already baked into the chosen Lance index — we pass it through for
+  // EXPLAIN clarity but Lance itself reads metric from the index).
+  result->metric = input.inputs[4].GetValue<string>();
+
+  auto filter_blob = input.inputs[5].GetValueUnsafe<string_t>();
+  if (filter_blob.GetSize() > LANCE_KNN_REBIND_MAX_FILTER_IR_BYTES) {
+    throw InvalidInputException(
+        "__lance_knn_scan filter IR blob is too large (" +
+        to_string(filter_blob.GetSize()) + " bytes, max " +
+        to_string(LANCE_KNN_REBIND_MAX_FILTER_IR_BYTES) +
+        "); this is an internal function — use lance_vector_search instead");
+  }
+  result->filter_ir_msg.assign(filter_blob.GetData(), filter_blob.GetSize());
+
+  auto nprobes_val = input.inputs[6].GetValue<int64_t>();
+  result->nprobes = nprobes_val > 0 ? NumericCast<uint64_t>(nprobes_val) : 0;
+  auto refine_val = input.inputs[7].GetValue<int64_t>();
+  result->refine_factor =
+      refine_val > 0 ? NumericCast<uint64_t>(refine_val) : 0;
+  result->prefilter = input.inputs[8].GetValue<bool>();
+  result->use_index = input.inputs[9].GetValue<bool>();
+  auto ef_val = input.inputs[10].GetValue<int64_t>();
+  result->ef = ef_val > 0 ? NumericCast<uint64_t>(ef_val) : 0;
+
+  result->dataset_entry = LanceGetOrOpenDatasetEntry(
+      context, result->file_path, &result->dataset_cache_hit);
+  if (!result->dataset_entry) {
+    throw IOException("Failed to open Lance dataset: " + result->file_path +
+                      LanceFormatErrorSuffix());
+  }
+
+  // Re-verify the vector index still exists with the expected metric. This
+  // catches PREPARE / EXECUTE windows where the index was dropped or
+  // recreated with a different metric — without this check the user would
+  // hit an opaque "Failed to create Lance KNN stream" downstream.
+  //
+  // Limitation: GetOrLookupVectorIndexMetric is backed by the per-entry
+  // cache populated at PREPARE time. Same-context DDL invalidates the
+  // dataset cache entry (and thus this cache) precisely, so the check
+  // catches it. Cross-context drops (another connection / process) leave
+  // the cache stale; this rebind will still let the query proceed and
+  // Lance itself surfaces the error a moment later. Strictly better than
+  // the pre-fix path, just not perfect.
+  if (result->use_index && !result->metric.empty()) {
+    auto lookup = result->dataset_entry->GetOrLookupVectorIndexMetric(
+        result->vector_column);
+    if (lookup.status == 1) {
+      throw IOException(
+          "Lance vector index for column '" + result->vector_column +
+          "' no longer exists on dataset " + result->file_path +
+          "; re-prepare the statement so the optimizer can re-plan" +
+          LanceFormatErrorSuffix());
+    }
+    if (lookup.status != 0) {
+      throw IOException("Lance vector index metric lookup failed: " +
+                        lookup.error_message + LanceFormatErrorSuffix());
+    }
+    if (lookup.metric != result->metric) {
+      throw IOException("Lance vector index metric for column '" +
+                        result->vector_column + "' changed from '" +
+                        result->metric + "' to '" + lookup.metric +
+                        "' since the statement was prepared; re-prepare it" +
+                        LanceFormatErrorSuffix());
+    }
+  }
+
+  PopulateSchemaFromKnn(context, *result);
+  names = result->names;
+  return_types = result->types;
+  return std::move(result);
+}
+
+unique_ptr<GlobalTableFunctionState>
+LanceKnnScanInitGlobal(ClientContext &, TableFunctionInitInput &input) {
+  auto &bind_data = input.bind_data->Cast<LanceKnnScanBindData>();
+  auto state =
+      make_uniq_base<GlobalTableFunctionState, LanceKnnScanGlobalState>();
+  auto &global = state->Cast<LanceKnnScanGlobalState>();
+
+  global.projection_ids = input.projection_ids;
+  if (!input.projection_ids.empty()) {
+    global.scanned_types.reserve(input.column_ids.size());
+    for (auto col_id : input.column_ids) {
+      if (col_id >= bind_data.types.size()) {
+        throw IOException("Invalid column id in projection");
+      }
+      global.scanned_types.push_back(bind_data.types[col_id]);
+    }
+  }
+  return state;
+}
+
+unique_ptr<LocalTableFunctionState>
+LanceKnnScanLocalInit(ExecutionContext &context, TableFunctionInitInput &input,
+                      GlobalTableFunctionState *global_state) {
+  auto &bind_data = input.bind_data->Cast<LanceKnnScanBindData>();
+  auto &global = global_state->Cast<LanceKnnScanGlobalState>();
+
+  auto chunk = make_uniq<ArrowArrayWrapper>();
+  auto result =
+      make_uniq<LanceKnnScanLocalState>(std::move(chunk), context.client);
+  result->column_ids = input.column_ids;
+  result->filters = input.filters.get();
+  result->global_state = &global;
+  if (global.CanRemoveFilterColumns()) {
+    result->all_columns.Initialize(context.client, global.scanned_types);
+  }
+
+  const uint8_t *filter_ir =
+      bind_data.filter_ir_msg.empty()
+          ? nullptr
+          : reinterpret_cast<const uint8_t *>(bind_data.filter_ir_msg.data());
+  auto filter_ir_len = bind_data.filter_ir_msg.size();
+  result->stream = lance_create_knn_stream_ir(
+      bind_data.dataset_entry->Handle(), bind_data.vector_column.c_str(),
+      bind_data.query.data(), bind_data.query.size(), bind_data.k,
+      bind_data.nprobes, bind_data.refine_factor, bind_data.ef, filter_ir,
+      filter_ir_len, bind_data.prefilter ? 1 : 0, bind_data.use_index ? 1 : 0);
+  if (!result->stream) {
+    throw IOException("Failed to create Lance KNN stream" +
+                      LanceFormatErrorSuffix());
+  }
+  return std::move(result);
+}
+
+bool LanceKnnScanLoadNextBatch(LanceKnnScanLocalState &local_state) {
+  if (!local_state.stream) {
+    return false;
+  }
+
+  void *batch = nullptr;
+  auto rc = lance_stream_next(local_state.stream, &batch);
+  if (rc == 1) {
+    lance_close_stream(local_state.stream);
+    local_state.stream = nullptr;
+    return false;
+  }
+  if (rc != 0) {
+    throw IOException("Failed to read next Lance RecordBatch" +
+                      LanceFormatErrorSuffix());
+  }
+
+  auto new_chunk = make_shared_ptr<ArrowArrayWrapper>();
+  memset(&new_chunk->arrow_array, 0, sizeof(new_chunk->arrow_array));
+  ArrowSchema tmp_schema;
+  memset(&tmp_schema, 0, sizeof(tmp_schema));
+
+  if (lance_batch_to_arrow(batch, &new_chunk->arrow_array, &tmp_schema) != 0) {
+    lance_free_batch(batch);
+    throw IOException(
+        "Failed to export Lance RecordBatch to Arrow C Data Interface" +
+        LanceFormatErrorSuffix());
+  }
+  lance_free_batch(batch);
+  LanceCoerceArrowArrayForDuckDB(&tmp_schema, &new_chunk->arrow_array);
+
+  if (local_state.global_state) {
+    local_state.global_state->record_batches.fetch_add(1);
+    auto rows = NumericCast<idx_t>(new_chunk->arrow_array.length);
+    local_state.global_state->record_batch_rows.fetch_add(rows);
+  }
+
+  if (tmp_schema.release) {
+    tmp_schema.release(&tmp_schema);
+  }
+
+  local_state.chunk = std::move(new_chunk);
+  local_state.Reset();
+  return true;
+}
+
+void LanceKnnScanFunc(ClientContext &, TableFunctionInput &data,
+                      DataChunk &output) {
+  // LocalInit always provides a local_state; assert in debug so a future
+  // refactor that breaks the contract is caught loudly.
+  D_ASSERT(data.local_state);
+  if (!data.local_state) {
+    return;
+  }
+
+  auto &bind_data = data.bind_data->Cast<LanceKnnScanBindData>();
+  auto &global_state = data.global_state->Cast<LanceKnnScanGlobalState>();
+  auto &local_state = data.local_state->Cast<LanceKnnScanLocalState>();
+
+  while (true) {
+    if (local_state.chunk_offset >=
+        NumericCast<idx_t>(local_state.chunk->arrow_array.length)) {
+      if (!LanceKnnScanLoadNextBatch(local_state)) {
+        return;
+      }
+    }
+
+    auto remaining = NumericCast<idx_t>(local_state.chunk->arrow_array.length) -
+                     local_state.chunk_offset;
+    auto output_size = MinValue<idx_t>(STANDARD_VECTOR_SIZE, remaining);
+    global_state.lines_read.fetch_add(output_size);
+
+    if (global_state.CanRemoveFilterColumns()) {
+      local_state.all_columns.Reset();
+      local_state.all_columns.SetCardinality(output_size);
+      ArrowTableFunction::ArrowToDuckDB(local_state,
+                                        bind_data.arrow_table.GetColumns(),
+                                        local_state.all_columns, false);
+      local_state.chunk_offset += output_size;
+      output.ReferenceColumns(local_state.all_columns,
+                              global_state.projection_ids);
+      output.SetCardinality(local_state.all_columns);
+    } else {
+      output.SetCardinality(output_size);
+      ArrowTableFunction::ArrowToDuckDB(
+          local_state, bind_data.arrow_table.GetColumns(), output, false);
+      local_state.chunk_offset += output_size;
+    }
+
+    if (output.size() == 0) {
+      continue;
+    }
+    output.Verify();
+    return;
+  }
+}
+
+bool TryLanceExplainKnnScan(const LanceKnnScanBindData &bind_data,
+                            string &out_plan, string &out_error) {
+  out_plan.clear();
+  out_error.clear();
+  if (!bind_data.dataset_entry) {
+    out_error = "dataset is null";
+    return false;
+  }
+  const uint8_t *filter_ptr =
+      bind_data.filter_ir_msg.empty()
+          ? nullptr
+          : reinterpret_cast<const uint8_t *>(bind_data.filter_ir_msg.data());
+  auto filter_len = bind_data.filter_ir_msg.size();
+
+  auto *plan_ptr = lance_explain_knn_scan_ir(
+      bind_data.dataset_entry->Handle(), bind_data.vector_column.c_str(),
+      bind_data.query.data(), bind_data.query.size(), bind_data.k,
+      bind_data.nprobes, bind_data.refine_factor, bind_data.ef, filter_ptr,
+      filter_len, bind_data.prefilter ? 1 : 0, bind_data.use_index ? 1 : 0, 0);
+  if (!plan_ptr) {
+    out_error = LanceConsumeLastError();
+    if (out_error.empty()) {
+      out_error = "unknown error";
+    }
+    return false;
+  }
+  out_plan = plan_ptr;
+  lance_free_string(plan_ptr);
+  return true;
+}
+
+InsertionOrderPreservingMap<string>
+LanceKnnScanToString(TableFunctionToStringInput &input) {
+  InsertionOrderPreservingMap<string> result;
+  auto &bind_data = input.bind_data->Cast<LanceKnnScanBindData>();
+
+  result["Lance Path"] = bind_data.file_path;
+  result["Lance Vector Column"] = bind_data.vector_column;
+  result["Lance K"] = to_string(bind_data.k);
+  result["Lance Metric"] = bind_data.metric;
+  result["Lance Nprobes"] = to_string(bind_data.nprobes);
+  result["Lance Refine Factor"] = to_string(bind_data.refine_factor);
+  result["Lance Ef Search"] = to_string(bind_data.ef);
+  result["Lance Query Dim"] = to_string(bind_data.query.size());
+  result["Lance Prefilter"] = bind_data.prefilter ? "true" : "false";
+  result["Lance Use Index"] = bind_data.use_index ? "true" : "false";
+  result["Lance Dataset Cache Hit"] =
+      bind_data.dataset_cache_hit ? "true" : "false";
+  result["Lance Filter IR Bytes (Bind)"] =
+      to_string(bind_data.filter_ir_msg.size());
+
+  string plan;
+  string error;
+  if (TryLanceExplainKnnScan(bind_data, plan, error)) {
+    result["Lance Plan (Bind)"] = plan;
+  } else if (!error.empty()) {
+    result["Lance Plan Error (Bind)"] = error;
+  }
+  return result;
+}
+
+InsertionOrderPreservingMap<string>
+LanceKnnScanDynamicToString(TableFunctionDynamicToStringInput &input) {
+  InsertionOrderPreservingMap<string> result;
+  auto &bind_data = input.bind_data->Cast<LanceKnnScanBindData>();
+  auto &global_state = input.global_state->Cast<LanceKnnScanGlobalState>();
+
+  result["Lance Path"] = bind_data.file_path;
+  result["Lance Vector Column"] = bind_data.vector_column;
+  result["Lance K"] = to_string(bind_data.k);
+  result["Lance Metric"] = bind_data.metric;
+  result["Lance Nprobes"] = to_string(bind_data.nprobes);
+  result["Lance Refine Factor"] = to_string(bind_data.refine_factor);
+  result["Lance Ef Search"] = to_string(bind_data.ef);
+  result["Lance Query Dim"] = to_string(bind_data.query.size());
+  result["Lance Prefilter"] = bind_data.prefilter ? "true" : "false";
+  result["Lance Use Index"] = bind_data.use_index ? "true" : "false";
+  result["Lance Dataset Cache Hit"] =
+      bind_data.dataset_cache_hit ? "true" : "false";
+  result["Lance Filter IR Bytes"] = to_string(bind_data.filter_ir_msg.size());
+
+  result["Lance Record Batches"] =
+      to_string(global_state.record_batches.load());
+  result["Lance Record Batch Rows"] =
+      to_string(global_state.record_batch_rows.load());
+  result["Lance Rows Out"] = to_string(global_state.lines_read.load());
+
+  // Double-checked lazy init for the explain plan. Memory ordering chain:
+  //   writer: explain_plan = ... ; mutex.unlock() ;
+  //           explain_computed.store(true, release)
+  //   reader: explain_computed.load(acquire) sees true →
+  //           subsequent reads of explain_plan happen-after the writer's
+  //           assignment.
+  // Inner load can be relaxed since the mutex itself provides
+  // synchronization for the slow path. Do not weaken the outer load to
+  // relaxed — the fast path skips the mutex and relies on this acquire to
+  // publish the plan string.
+  if (!global_state.explain_computed.load(std::memory_order_acquire)) {
+    std::lock_guard<std::mutex> guard(global_state.explain_mutex);
+    if (!global_state.explain_computed.load(std::memory_order_relaxed)) {
+      string plan;
+      string error;
+      auto ok = TryLanceExplainKnnScan(bind_data, plan, error);
+      if (ok) {
+        global_state.explain_plan = std::move(plan);
+      } else {
+        global_state.explain_error = std::move(error);
+      }
+      global_state.explain_computed.store(true, std::memory_order_release);
+    }
+  }
+  if (!global_state.explain_plan.empty()) {
+    result["Lance Plan"] = global_state.explain_plan;
+  } else if (!global_state.explain_error.empty()) {
+    result["Lance Plan Error"] = global_state.explain_error;
+  }
+  return result;
+}
+
+} // namespace
+
+void LanceKnnScanPopulateSchema(ClientContext &context,
+                                LanceKnnScanBindData &bind_data) {
+  PopulateSchemaFromKnn(context, bind_data);
+}
+
+TableFunction LanceKnnScanFunction() {
+  TableFunction function(
+      "__lance_knn_scan",
+      {LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::BLOB,
+       LogicalType::BIGINT, LogicalType::VARCHAR, LogicalType::BLOB,
+       LogicalType::BIGINT, LogicalType::BIGINT, LogicalType::BOOLEAN,
+       LogicalType::BOOLEAN, LogicalType::BIGINT},
+      LanceKnnScanFunc, LanceKnnScanBind, LanceKnnScanInitGlobal,
+      LanceKnnScanLocalInit);
+  function.projection_pushdown = true;
+  // filter_pushdown is intentionally disabled: the KNN optimizer absorbs
+  // every WHERE predicate it can encode into filter_ir_msg at plan time, so
+  // there is nothing left for DuckDB to push down at execution. If a future
+  // post-optimization pass ever re-introduces a filter above the KNN scan,
+  // it will run in DuckDB row-by-row — promote filter_pushdown then.
+  function.filter_pushdown = false;
+  function.to_string = LanceKnnScanToString;
+  function.dynamic_to_string = LanceKnnScanDynamicToString;
+  return function;
+}
+
+void RegisterLanceKNNScan(ExtensionLoader &loader) {
+  loader.RegisterFunction(LanceKnnScanFunction());
+}
+
+} // namespace duckdb

--- a/src/lance_search.cpp
+++ b/src/lance_search.cpp
@@ -69,7 +69,7 @@ static bool TryLanceExplainKnn(void *dataset, const string &vector_column,
 
   auto *plan_ptr = lance_explain_knn_scan_ir(
       dataset, vector_column.c_str(), query.data(), query.size(), k, nprobes,
-      refine_factor, filter_ptr, NumericCast<size_t>(filter_len),
+      refine_factor, /*ef=*/0, filter_ptr, NumericCast<size_t>(filter_len),
       prefilter ? 1 : 0, use_index ? 1 : 0, verbose ? 1 : 0);
   if (!plan_ptr) {
     out_error = LanceConsumeLastError();
@@ -575,7 +575,7 @@ LanceSearchVectorBind(ClientContext &context, TableFunctionBindInput &input,
   auto *schema_handle = lance_get_knn_schema(
       result->dataset, result->vector_column.c_str(), result->query.data(),
       result->query.size(), result->k, result->nprobes, result->refine_factor,
-      result->prefilter ? 1 : 0, result->use_index ? 1 : 0);
+      /*ef=*/0, result->prefilter ? 1 : 0, result->use_index ? 1 : 0);
   if (!schema_handle) {
     throw IOException("Failed to get Lance KNN schema: " + result->file_path +
                       LanceFormatErrorSuffix());
@@ -709,8 +709,8 @@ LanceKnnLocalInit(ExecutionContext &context, TableFunctionInitInput &input,
   result->stream = lance_create_knn_stream_ir(
       bind_data.dataset, bind_data.vector_column.c_str(),
       bind_data.query.data(), bind_data.query.size(), bind_data.k,
-      bind_data.nprobes, bind_data.refine_factor, filter_ir, filter_ir_len,
-      bind_data.prefilter ? 1 : 0, bind_data.use_index ? 1 : 0);
+      bind_data.nprobes, bind_data.refine_factor, /*ef=*/0, filter_ir,
+      filter_ir_len, bind_data.prefilter ? 1 : 0, bind_data.use_index ? 1 : 0);
   if (!result->stream && filter_ir && !bind_data.prefilter) {
     // Best-effort: if filter pushdown failed, retry without it and rely on
     // DuckDB-side filter execution for correctness.
@@ -720,7 +720,7 @@ LanceKnnLocalInit(ExecutionContext &context, TableFunctionInitInput &input,
     result->stream = lance_create_knn_stream_ir(
         bind_data.dataset, bind_data.vector_column.c_str(),
         bind_data.query.data(), bind_data.query.size(), bind_data.k,
-        bind_data.nprobes, bind_data.refine_factor, nullptr, 0,
+        bind_data.nprobes, bind_data.refine_factor, /*ef=*/0, nullptr, 0,
         bind_data.prefilter ? 1 : 0, bind_data.use_index ? 1 : 0);
   }
   if (!result->stream) {

--- a/test/sql/optimizer_knn_basic.test
+++ b/test/sql/optimizer_knn_basic.test
@@ -1,0 +1,508 @@
+# name: test/sql/optimizer_knn_basic.test
+# description: KNN optimizer rewrites ORDER BY <distance> LIMIT k into __LANCE_KNN_SCAN
+# group: [sql]
+
+require lance
+
+# ===================================================================
+# Setup: L2 dataset (FLOAT[16] vectors) with an IVF_FLAT/L2 index
+# ===================================================================
+
+statement ok
+COPY (SELECT * FROM 'test/data/bigann_tiny/base.lance')
+TO 'test/.tmp/knn_opt_l2.lance' (FORMAT lance, mode 'overwrite');
+
+statement ok
+CREATE INDEX vec_idx ON 'test/.tmp/knn_opt_l2.lance' (vec)
+USING IVF_FLAT WITH (num_partitions=1, metric_type='l2');
+
+# ===================================================================
+# Basic L2 rewrite: EXPLAIN shows __LANCE_KNN_SCAN and l2 metric
+# ===================================================================
+
+query II
+EXPLAIN (FORMAT JSON)
+SELECT id
+FROM 'test/.tmp/knn_opt_l2.lance'
+ORDER BY array_distance(vec, [
+  0.32245764, 0.2814153, 0.08346437, 0.28065863,
+  0.2566661, -0.47035545, -0.9935358, 0.09578487,
+  0.000604047, -0.37332273, 0.12592472, -0.3458825,
+  -0.2536356, -0.3673502, -0.68120277, 0.41665298
+]::FLOAT[16])
+LIMIT 5;
+----
+physical_plan	<REGEX>:[\s\S]*__LANCE_KNN_SCAN[\s\S]*"Lance Metric": "l2"[\s\S]*
+
+# After rewrite the LOGICAL_TOP_N has been dropped (KNN scan is the top-k source)
+query II
+EXPLAIN (FORMAT JSON)
+SELECT id
+FROM 'test/.tmp/knn_opt_l2.lance'
+ORDER BY array_distance(vec, [
+  0.32245764, 0.2814153, 0.08346437, 0.28065863,
+  0.2566661, -0.47035545, -0.9935358, 0.09578487,
+  0.000604047, -0.37332273, 0.12592472, -0.3458825,
+  -0.2536356, -0.3673502, -0.68120277, 0.41665298
+]::FLOAT[16])
+LIMIT 5;
+----
+physical_plan	<!REGEX>:.*TOP_N.*
+
+# ===================================================================
+# Correctness: rewritten query returns the same ids as lance_vector_search
+# ===================================================================
+
+# Symmetric difference must be empty: every id from one side appears on the other
+query I
+SELECT count(*) FROM (
+  (SELECT id FROM 'test/.tmp/knn_opt_l2.lance'
+   ORDER BY array_distance(vec, [
+     0.32245764, 0.2814153, 0.08346437, 0.28065863,
+     0.2566661, -0.47035545, -0.9935358, 0.09578487,
+     0.000604047, -0.37332273, 0.12592472, -0.3458825,
+     -0.2536356, -0.3673502, -0.68120277, 0.41665298
+   ]::FLOAT[16])
+   LIMIT 5)
+  EXCEPT
+  (SELECT id FROM lance_vector_search(
+    'test/.tmp/knn_opt_l2.lance', 'vec',
+    [
+      0.32245764, 0.2814153, 0.08346437, 0.28065863,
+      0.2566661, -0.47035545, -0.9935358, 0.09578487,
+      0.000604047, -0.37332273, 0.12592472, -0.3458825,
+      -0.2536356, -0.3673502, -0.68120277, 0.41665298
+    ]::FLOAT[16],
+    k = 5))
+);
+----
+0
+
+query I
+SELECT count(*) FROM (
+  (SELECT id FROM lance_vector_search(
+    'test/.tmp/knn_opt_l2.lance', 'vec',
+    [
+      0.32245764, 0.2814153, 0.08346437, 0.28065863,
+      0.2566661, -0.47035545, -0.9935358, 0.09578487,
+      0.000604047, -0.37332273, 0.12592472, -0.3458825,
+      -0.2536356, -0.3673502, -0.68120277, 0.41665298
+    ]::FLOAT[16],
+    k = 5))
+  EXCEPT
+  (SELECT id FROM 'test/.tmp/knn_opt_l2.lance'
+   ORDER BY array_distance(vec, [
+     0.32245764, 0.2814153, 0.08346437, 0.28065863,
+     0.2566661, -0.47035545, -0.9935358, 0.09578487,
+     0.000604047, -0.37332273, 0.12592472, -0.3458825,
+     -0.2536356, -0.3673502, -0.68120277, 0.41665298
+   ]::FLOAT[16])
+   LIMIT 5)
+);
+----
+0
+
+# Sanity: the rewritten query returns exactly k rows
+query I
+SELECT count(*) FROM (
+  SELECT id FROM 'test/.tmp/knn_opt_l2.lance'
+  ORDER BY array_distance(vec, [
+    0.32245764, 0.2814153, 0.08346437, 0.28065863,
+    0.2566661, -0.47035545, -0.9935358, 0.09578487,
+    0.000604047, -0.37332273, 0.12592472, -0.3458825,
+    -0.2536356, -0.3673502, -0.68120277, 0.41665298
+  ]::FLOAT[16])
+  LIMIT 5
+);
+----
+5
+
+# ===================================================================
+# Args order: constant on the left (L2 is symmetric)
+# ===================================================================
+
+query II
+EXPLAIN (FORMAT JSON)
+SELECT id
+FROM 'test/.tmp/knn_opt_l2.lance'
+ORDER BY array_distance(
+  [
+    0.32245764, 0.2814153, 0.08346437, 0.28065863,
+    0.2566661, -0.47035545, -0.9935358, 0.09578487,
+    0.000604047, -0.37332273, 0.12592472, -0.3458825,
+    -0.2536356, -0.3673502, -0.68120277, 0.41665298
+  ]::FLOAT[16],
+  vec
+)
+LIMIT 5;
+----
+physical_plan	<REGEX>:[\s\S]*__LANCE_KNN_SCAN[\s\S]*"Lance Metric": "l2"[\s\S]*
+
+# ===================================================================
+# k from LIMIT shows up in EXPLAIN
+# ===================================================================
+
+query II
+EXPLAIN (FORMAT JSON)
+SELECT id
+FROM 'test/.tmp/knn_opt_l2.lance'
+ORDER BY array_distance(vec, [
+  0.32245764, 0.2814153, 0.08346437, 0.28065863,
+  0.2566661, -0.47035545, -0.9935358, 0.09578487,
+  0.000604047, -0.37332273, 0.12592472, -0.3458825,
+  -0.2536356, -0.3673502, -0.68120277, 0.41665298
+]::FLOAT[16])
+LIMIT 7;
+----
+physical_plan	<REGEX>:[\s\S]*__LANCE_KNN_SCAN[\s\S]*"Lance K": "7"[\s\S]*
+
+# ===================================================================
+# Session var injection: lance_knn_nprobes flows into EXPLAIN
+# ===================================================================
+
+statement ok
+SET lance_knn_nprobes = 32;
+
+query II
+EXPLAIN (FORMAT JSON)
+SELECT id
+FROM 'test/.tmp/knn_opt_l2.lance'
+ORDER BY array_distance(vec, [
+  0.32245764, 0.2814153, 0.08346437, 0.28065863,
+  0.2566661, -0.47035545, -0.9935358, 0.09578487,
+  0.000604047, -0.37332273, 0.12592472, -0.3458825,
+  -0.2536356, -0.3673502, -0.68120277, 0.41665298
+]::FLOAT[16])
+LIMIT 5;
+----
+physical_plan	<REGEX>:[\s\S]*__LANCE_KNN_SCAN[\s\S]*"Lance Nprobes": "32"[\s\S]*
+
+# Reset back to default so the next sub-test does not inherit nprobes=32.
+statement ok
+RESET lance_knn_nprobes;
+
+# ===================================================================
+# Cosine variant
+# ===================================================================
+
+statement ok
+COPY (SELECT * FROM 'test/data/bigann_tiny/base.lance')
+TO 'test/.tmp/knn_opt_cosine.lance' (FORMAT lance, mode 'overwrite');
+
+statement ok
+CREATE INDEX vec_idx ON 'test/.tmp/knn_opt_cosine.lance' (vec)
+USING IVF_FLAT WITH (num_partitions=1, metric_type='cosine');
+
+query II
+EXPLAIN (FORMAT JSON)
+SELECT id
+FROM 'test/.tmp/knn_opt_cosine.lance'
+ORDER BY array_cosine_distance(vec, [
+  0.32245764, 0.2814153, 0.08346437, 0.28065863,
+  0.2566661, -0.47035545, -0.9935358, 0.09578487,
+  0.000604047, -0.37332273, 0.12592472, -0.3458825,
+  -0.2536356, -0.3673502, -0.68120277, 0.41665298
+]::FLOAT[16])
+LIMIT 5;
+----
+physical_plan	<REGEX>:[\s\S]*__LANCE_KNN_SCAN[\s\S]*"Lance Metric": "cosine"[\s\S]*
+
+# Correctness: rewrite returns the same set as lance_vector_search
+query I
+SELECT count(*) FROM (
+  (SELECT id FROM 'test/.tmp/knn_opt_cosine.lance'
+   ORDER BY array_cosine_distance(vec, [
+     0.32245764, 0.2814153, 0.08346437, 0.28065863,
+     0.2566661, -0.47035545, -0.9935358, 0.09578487,
+     0.000604047, -0.37332273, 0.12592472, -0.3458825,
+     -0.2536356, -0.3673502, -0.68120277, 0.41665298
+   ]::FLOAT[16])
+   LIMIT 5)
+  EXCEPT
+  (SELECT id FROM lance_vector_search(
+    'test/.tmp/knn_opt_cosine.lance', 'vec',
+    [
+      0.32245764, 0.2814153, 0.08346437, 0.28065863,
+      0.2566661, -0.47035545, -0.9935358, 0.09578487,
+      0.000604047, -0.37332273, 0.12592472, -0.3458825,
+      -0.2536356, -0.3673502, -0.68120277, 0.41665298
+    ]::FLOAT[16],
+    k = 5))
+);
+----
+0
+
+# ===================================================================
+# Dot variant (array_negative_inner_product -> metric=dot)
+# ===================================================================
+
+statement ok
+COPY (SELECT * FROM 'test/data/bigann_tiny/base.lance')
+TO 'test/.tmp/knn_opt_dot.lance' (FORMAT lance, mode 'overwrite');
+
+statement ok
+CREATE INDEX vec_idx ON 'test/.tmp/knn_opt_dot.lance' (vec)
+USING IVF_FLAT WITH (num_partitions=1, metric_type='dot');
+
+query II
+EXPLAIN (FORMAT JSON)
+SELECT id
+FROM 'test/.tmp/knn_opt_dot.lance'
+ORDER BY array_negative_inner_product(vec, [
+  0.32245764, 0.2814153, 0.08346437, 0.28065863,
+  0.2566661, -0.47035545, -0.9935358, 0.09578487,
+  0.000604047, -0.37332273, 0.12592472, -0.3458825,
+  -0.2536356, -0.3673502, -0.68120277, 0.41665298
+]::FLOAT[16])
+LIMIT 5;
+----
+physical_plan	<REGEX>:[\s\S]*__LANCE_KNN_SCAN[\s\S]*"Lance Metric": "dot"[\s\S]*
+
+# Sanity: rewritten dot query returns k rows
+query I
+SELECT count(*) FROM (
+  SELECT id FROM 'test/.tmp/knn_opt_dot.lance'
+  ORDER BY array_negative_inner_product(vec, [
+    0.32245764, 0.2814153, 0.08346437, 0.28065863,
+    0.2566661, -0.47035545, -0.9935358, 0.09578487,
+    0.000604047, -0.37332273, 0.12592472, -0.3458825,
+    -0.2536356, -0.3673502, -0.68120277, 0.41665298
+  ]::FLOAT[16])
+  LIMIT 5
+);
+----
+5
+
+# Correctness: rewritten dot query returns the same id set as
+# lance_vector_search. The dot metric is the asymmetric branch in the
+# DistanceFunctionToMetric mapping, so this catches sign / argument-order
+# regressions that the count-only sanity above would miss.
+query I
+SELECT count(*) FROM (
+  (SELECT id FROM 'test/.tmp/knn_opt_dot.lance'
+   ORDER BY array_negative_inner_product(vec, [
+     0.32245764, 0.2814153, 0.08346437, 0.28065863,
+     0.2566661, -0.47035545, -0.9935358, 0.09578487,
+     0.000604047, -0.37332273, 0.12592472, -0.3458825,
+     -0.2536356, -0.3673502, -0.68120277, 0.41665298
+   ]::FLOAT[16])
+   LIMIT 5)
+  EXCEPT
+  (SELECT id FROM lance_vector_search(
+    'test/.tmp/knn_opt_dot.lance', 'vec',
+    [
+      0.32245764, 0.2814153, 0.08346437, 0.28065863,
+      0.2566661, -0.47035545, -0.9935358, 0.09578487,
+      0.000604047, -0.37332273, 0.12592472, -0.3458825,
+      -0.2536356, -0.3673502, -0.68120277, 0.41665298
+    ]::FLOAT[16],
+    k = 5))
+);
+----
+0
+
+# Reverse direction
+query I
+SELECT count(*) FROM (
+  (SELECT id FROM lance_vector_search(
+    'test/.tmp/knn_opt_dot.lance', 'vec',
+    [
+      0.32245764, 0.2814153, 0.08346437, 0.28065863,
+      0.2566661, -0.47035545, -0.9935358, 0.09578487,
+      0.000604047, -0.37332273, 0.12592472, -0.3458825,
+      -0.2536356, -0.3673502, -0.68120277, 0.41665298
+    ]::FLOAT[16],
+    k = 5))
+  EXCEPT
+  (SELECT id FROM 'test/.tmp/knn_opt_dot.lance'
+   ORDER BY array_negative_inner_product(vec, [
+     0.32245764, 0.2814153, 0.08346437, 0.28065863,
+     0.2566661, -0.47035545, -0.9935358, 0.09578487,
+     0.000604047, -0.37332273, 0.12592472, -0.3458825,
+     -0.2536356, -0.3673502, -0.68120277, 0.41665298
+   ]::FLOAT[16])
+   LIMIT 5)
+);
+----
+0
+
+# ===================================================================
+# Multi-column projection: exercises the column_ids remap path
+# (KNN schema prepends _distance/_rowid, so every requested column needs
+# its index remapped by name)
+# ===================================================================
+
+query II
+EXPLAIN (FORMAT JSON)
+SELECT id, label, bucket
+FROM 'test/.tmp/knn_opt_l2.lance'
+ORDER BY array_distance(vec, [
+  0.32245764, 0.2814153, 0.08346437, 0.28065863,
+  0.2566661, -0.47035545, -0.9935358, 0.09578487,
+  0.000604047, -0.37332273, 0.12592472, -0.3458825,
+  -0.2536356, -0.3673502, -0.68120277, 0.41665298
+]::FLOAT[16])
+LIMIT 5;
+----
+physical_plan	<REGEX>:[\s\S]*__LANCE_KNN_SCAN[\s\S]*
+
+# Correctness with multi-column projection: ids must match lance_vector_search
+query I
+SELECT count(*) FROM (
+  (SELECT id FROM 'test/.tmp/knn_opt_l2.lance'
+   ORDER BY array_distance(vec, [
+     0.32245764, 0.2814153, 0.08346437, 0.28065863,
+     0.2566661, -0.47035545, -0.9935358, 0.09578487,
+     0.000604047, -0.37332273, 0.12592472, -0.3458825,
+     -0.2536356, -0.3673502, -0.68120277, 0.41665298
+   ]::FLOAT[16])
+   LIMIT 5)
+  EXCEPT
+  (SELECT id FROM (
+    SELECT id, label, bucket FROM 'test/.tmp/knn_opt_l2.lance'
+    ORDER BY array_distance(vec, [
+      0.32245764, 0.2814153, 0.08346437, 0.28065863,
+      0.2566661, -0.47035545, -0.9935358, 0.09578487,
+      0.000604047, -0.37332273, 0.12592472, -0.3458825,
+      -0.2536356, -0.3673502, -0.68120277, 0.41665298
+    ]::FLOAT[16])
+    LIMIT 5
+  ))
+);
+----
+0
+
+# Sanity: per-row scalar columns are populated, not garbage
+query II
+SELECT count(label), count(bucket) FROM (
+  SELECT id, label, bucket FROM 'test/.tmp/knn_opt_l2.lance'
+  ORDER BY array_distance(vec, [
+    0.32245764, 0.2814153, 0.08346437, 0.28065863,
+    0.2566661, -0.47035545, -0.9935358, 0.09578487,
+    0.000604047, -0.37332273, 0.12592472, -0.3458825,
+    -0.2536356, -0.3673502, -0.68120277, 0.41665298
+  ]::FLOAT[16])
+  LIMIT 5
+);
+----
+5	5
+
+# SELECT * including the indexed vec column itself (remap of vec to its
+# new index in the KNN schema)
+query I
+SELECT count(*) FROM (
+  SELECT * FROM 'test/.tmp/knn_opt_l2.lance'
+  ORDER BY array_distance(vec, [
+    0.32245764, 0.2814153, 0.08346437, 0.28065863,
+    0.2566661, -0.47035545, -0.9935358, 0.09578487,
+    0.000604047, -0.37332273, 0.12592472, -0.3458825,
+    -0.2536356, -0.3673502, -0.68120277, 0.41665298
+  ]::FLOAT[16])
+  LIMIT 5
+);
+----
+5
+
+# Vec column itself comes back as FLOAT[16] of length 16
+query I
+SELECT array_length(vec) FROM (
+  SELECT * FROM 'test/.tmp/knn_opt_l2.lance'
+  ORDER BY array_distance(vec, [
+    0.32245764, 0.2814153, 0.08346437, 0.28065863,
+    0.2566661, -0.47035545, -0.9935358, 0.09578487,
+    0.000604047, -0.37332273, 0.12592472, -0.3458825,
+    -0.2536356, -0.3673502, -0.68120277, 0.41665298
+  ]::FLOAT[16])
+  LIMIT 1
+);
+----
+16
+
+# ===================================================================
+# list_distance variant: aliased to L2; should rewrite the same way
+# ===================================================================
+
+query II
+EXPLAIN (FORMAT JSON)
+SELECT id
+FROM 'test/.tmp/knn_opt_l2.lance'
+ORDER BY list_distance(vec, [
+  0.32245764, 0.2814153, 0.08346437, 0.28065863,
+  0.2566661, -0.47035545, -0.9935358, 0.09578487,
+  0.000604047, -0.37332273, 0.12592472, -0.3458825,
+  -0.2536356, -0.3673502, -0.68120277, 0.41665298
+]::FLOAT[16])
+LIMIT 5;
+----
+physical_plan	<REGEX>:[\s\S]*__LANCE_KNN_SCAN[\s\S]*"Lance Metric": "l2"[\s\S]*
+
+# ===================================================================
+# Session var: lance_knn_refine_factor flows into EXPLAIN
+# ===================================================================
+
+statement ok
+SET lance_knn_refine_factor = 4;
+
+query II
+EXPLAIN (FORMAT JSON)
+SELECT id
+FROM 'test/.tmp/knn_opt_l2.lance'
+ORDER BY array_distance(vec, [
+  0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+  0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0
+]::FLOAT[16])
+LIMIT 5;
+----
+physical_plan	<REGEX>:[\s\S]*__LANCE_KNN_SCAN[\s\S]*"Lance Refine Factor": "4"[\s\S]*
+
+# Reset back to default so the next sub-test does not inherit refine_factor=4.
+statement ok
+RESET lance_knn_refine_factor;
+
+# ===================================================================
+# EXPLAIN ANALYZE exercises the dynamic to_string path. The tree view
+# renders the operator generically as TABLE_SCAN, so we match on the
+# Lance-specific extra_info that only the dynamic_to_string callback
+# emits (Lance Rows Out, Lance Record Batches, Lance Plan).
+# ===================================================================
+
+query II
+EXPLAIN ANALYZE
+SELECT id
+FROM 'test/.tmp/knn_opt_l2.lance'
+ORDER BY array_distance(vec, [
+  0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+  0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0
+]::FLOAT[16])
+LIMIT 5;
+----
+analyzed_plan	<REGEX>:[\s\S]*Lance Rows Out[\s\S]*Lance Plan[\s\S]*
+
+# ===================================================================
+# Prepared statement: rebind path runs without error and returns k rows
+# ===================================================================
+
+statement ok
+PREPARE knn_q AS
+  SELECT id FROM 'test/.tmp/knn_opt_l2.lance'
+  ORDER BY array_distance(vec, [
+    0.32245764, 0.2814153, 0.08346437, 0.28065863,
+    0.2566661, -0.47035545, -0.9935358, 0.09578487,
+    0.000604047, -0.37332273, 0.12592472, -0.3458825,
+    -0.2536356, -0.3673502, -0.68120277, 0.41665298
+  ]::FLOAT[16])
+  LIMIT 5;
+
+# Execute the prepared statement; the rebind path runs without error.
+# (DuckDB does not allow EXECUTE as a subquery or in CREATE TABLE AS, so we
+# cannot count rows here directly; the inline query above already proves
+# count = 5 for the same SQL.)
+statement ok
+EXECUTE knn_q;
+
+# Re-execute exercises any cached / re-bound plan a second time
+statement ok
+EXECUTE knn_q;
+
+statement ok
+DEALLOCATE knn_q;

--- a/test/sql/optimizer_knn_fallback.test
+++ b/test/sql/optimizer_knn_fallback.test
@@ -1,0 +1,464 @@
+# name: test/sql/optimizer_knn_fallback.test
+# description: Cases where the KNN optimizer must NOT rewrite (original plan kept)
+# group: [sql]
+
+require lance
+
+# ===================================================================
+# Setup: indexed L2 dataset (FLOAT[16]) for most cases;
+# also an UNINDEXED copy for the "no vector index" case.
+# ===================================================================
+
+statement ok
+COPY (SELECT * FROM 'test/data/bigann_tiny/base.lance')
+TO 'test/.tmp/knn_fb_l2.lance' (FORMAT lance, mode 'overwrite');
+
+statement ok
+CREATE INDEX vec_idx ON 'test/.tmp/knn_fb_l2.lance' (vec)
+USING IVF_FLAT WITH (num_partitions=1, metric_type='l2');
+
+statement ok
+COPY (SELECT * FROM 'test/data/bigann_tiny/base.lance')
+TO 'test/.tmp/knn_fb_noindex.lance' (FORMAT lance, mode 'overwrite');
+
+# ===================================================================
+# Fallback: ORDER BY ... DESC -> no rewrite
+# ===================================================================
+
+query II
+EXPLAIN (FORMAT JSON)
+SELECT id
+FROM 'test/.tmp/knn_fb_l2.lance'
+ORDER BY array_distance(vec, [
+  0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+  0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0
+]::FLOAT[16]) DESC
+LIMIT 5;
+----
+physical_plan	<!REGEX>:.*__LANCE_KNN_SCAN.*
+
+query II
+EXPLAIN (FORMAT JSON)
+SELECT id
+FROM 'test/.tmp/knn_fb_l2.lance'
+ORDER BY array_distance(vec, [
+  0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+  0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0
+]::FLOAT[16]) DESC
+LIMIT 5;
+----
+physical_plan	<REGEX>:[\s\S]*TOP_N[\s\S]*
+
+# Original plan still executes
+query I
+SELECT count(*) FROM (
+  SELECT id FROM 'test/.tmp/knn_fb_l2.lance'
+  ORDER BY array_distance(vec, [
+    0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+    0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0
+  ]::FLOAT[16]) DESC
+  LIMIT 5
+);
+----
+5
+
+# ===================================================================
+# Fallback: OFFSET > 0 -> no rewrite
+# ===================================================================
+
+query II
+EXPLAIN (FORMAT JSON)
+SELECT id
+FROM 'test/.tmp/knn_fb_l2.lance'
+ORDER BY array_distance(vec, [
+  0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+  0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0
+]::FLOAT[16])
+LIMIT 5 OFFSET 10;
+----
+physical_plan	<!REGEX>:.*__LANCE_KNN_SCAN.*
+
+query I
+SELECT count(*) FROM (
+  SELECT id FROM 'test/.tmp/knn_fb_l2.lance'
+  ORDER BY array_distance(vec, [
+    0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+    0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0
+  ]::FLOAT[16])
+  LIMIT 5 OFFSET 10
+);
+----
+5
+
+# ===================================================================
+# Fallback: multiple ORDER BY keys -> no rewrite
+# ===================================================================
+
+query II
+EXPLAIN (FORMAT JSON)
+SELECT id
+FROM 'test/.tmp/knn_fb_l2.lance'
+ORDER BY array_distance(vec, [
+  0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+  0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0
+]::FLOAT[16]), id
+LIMIT 5;
+----
+physical_plan	<!REGEX>:.*__LANCE_KNN_SCAN.*
+
+query II
+EXPLAIN (FORMAT JSON)
+SELECT id
+FROM 'test/.tmp/knn_fb_l2.lance'
+ORDER BY array_distance(vec, [
+  0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+  0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0
+]::FLOAT[16]), id
+LIMIT 5;
+----
+physical_plan	<REGEX>:[\s\S]*TOP_N[\s\S]*
+
+query I
+SELECT count(*) FROM (
+  SELECT id FROM 'test/.tmp/knn_fb_l2.lance'
+  ORDER BY array_distance(vec, [
+    0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+    0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0
+  ]::FLOAT[16]), id
+  LIMIT 5
+);
+----
+5
+
+# ===================================================================
+# Fallback: distance has no constant query (both args are column refs)
+# ===================================================================
+
+query II
+EXPLAIN (FORMAT JSON)
+SELECT id
+FROM 'test/.tmp/knn_fb_l2.lance'
+ORDER BY array_distance(vec, vec)
+LIMIT 5;
+----
+physical_plan	<!REGEX>:.*__LANCE_KNN_SCAN.*
+
+query I
+SELECT count(*) FROM (
+  SELECT id FROM 'test/.tmp/knn_fb_l2.lance'
+  ORDER BY array_distance(vec, vec)
+  LIMIT 5
+);
+----
+5
+
+# ===================================================================
+# Fallback: k literal too large (> 10000)
+# ===================================================================
+
+query II
+EXPLAIN (FORMAT JSON)
+SELECT id
+FROM 'test/.tmp/knn_fb_l2.lance'
+ORDER BY array_distance(vec, [
+  0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+  0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0
+]::FLOAT[16])
+LIMIT 100000;
+----
+physical_plan	<!REGEX>:.*__LANCE_KNN_SCAN.*
+
+query I
+SELECT count(*) > 0 FROM (
+  SELECT id FROM 'test/.tmp/knn_fb_l2.lance'
+  ORDER BY array_distance(vec, [
+    0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+    0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0
+  ]::FLOAT[16])
+  LIMIT 100000
+);
+----
+true
+
+# ===================================================================
+# Fallback: no vector index on the column
+# ===================================================================
+
+query II
+EXPLAIN (FORMAT JSON)
+SELECT id
+FROM 'test/.tmp/knn_fb_noindex.lance'
+ORDER BY array_distance(vec, [
+  0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+  0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0
+]::FLOAT[16])
+LIMIT 5;
+----
+physical_plan	<!REGEX>:.*__LANCE_KNN_SCAN.*
+
+query I
+SELECT count(*) FROM (
+  SELECT id FROM 'test/.tmp/knn_fb_noindex.lance'
+  ORDER BY array_distance(vec, [
+    0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+    0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0
+  ]::FLOAT[16])
+  LIMIT 5
+);
+----
+5
+
+# After the fallback above, the metric cache must NOT have negative-cached
+# the "no index" answer: a subsequent CREATE INDEX in the same session
+# should make the next plan pick up the index and rewrite. CREATE INDEX
+# invalidates the dataset cache entry today, but we also rely on the
+# metric cache only storing positive lookups so any future index DDL path
+# that forgets to invalidate still recovers on the next plan.
+statement ok
+CREATE INDEX vec_idx_late ON 'test/.tmp/knn_fb_noindex.lance' (vec)
+USING IVF_FLAT WITH (num_partitions=1, metric_type='l2');
+
+query II
+EXPLAIN (FORMAT JSON)
+SELECT id
+FROM 'test/.tmp/knn_fb_noindex.lance'
+ORDER BY array_distance(vec, [
+  0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+  0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0
+]::FLOAT[16])
+LIMIT 5;
+----
+physical_plan	<REGEX>:[\s\S]*__LANCE_KNN_SCAN[\s\S]*
+
+# ===================================================================
+# Fallback: metric mismatch (L2 index, cosine query)
+# Original plan kept; DuckDB still computes the correct result.
+# ===================================================================
+
+query II
+EXPLAIN (FORMAT JSON)
+SELECT id
+FROM 'test/.tmp/knn_fb_l2.lance'
+ORDER BY array_cosine_distance(vec, [
+  0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+  0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0
+]::FLOAT[16])
+LIMIT 5;
+----
+physical_plan	<!REGEX>:.*__LANCE_KNN_SCAN.*
+
+query I
+SELECT count(*) FROM (
+  SELECT id FROM 'test/.tmp/knn_fb_l2.lance'
+  ORDER BY array_cosine_distance(vec, [
+    1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0,
+    1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0
+  ]::FLOAT[16])
+  LIMIT 5
+);
+----
+5
+
+# ===================================================================
+# Fallback: session var disables the rewrite
+# ===================================================================
+
+statement ok
+SET lance_knn_use_index = false;
+
+query II
+EXPLAIN (FORMAT JSON)
+SELECT id
+FROM 'test/.tmp/knn_fb_l2.lance'
+ORDER BY array_distance(vec, [
+  0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+  0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0
+]::FLOAT[16])
+LIMIT 5;
+----
+physical_plan	<!REGEX>:.*__LANCE_KNN_SCAN.*
+
+query I
+SELECT count(*) FROM (
+  SELECT id FROM 'test/.tmp/knn_fb_l2.lance'
+  ORDER BY array_distance(vec, [
+    0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+    0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0
+  ]::FLOAT[16])
+  LIMIT 5
+);
+----
+5
+
+# The kill switch is also the exact SQL fallback: it must return the
+# same ids as a materialized full-scan distance + DuckDB TopN plan.
+query I
+SELECT count(*) FROM (
+  (SELECT id FROM 'test/.tmp/knn_fb_l2.lance'
+   ORDER BY array_distance(vec, [
+     0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+     0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0
+   ]::FLOAT[16])
+   LIMIT 5)
+  EXCEPT
+  (SELECT id FROM (
+     SELECT id, array_distance(vec, [
+       0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+       0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0
+     ]::FLOAT[16]) AS dist
+     FROM 'test/.tmp/knn_fb_l2.lance'
+   ) baseline
+   ORDER BY dist
+   LIMIT 5)
+);
+----
+0
+
+query I
+SELECT count(*) FROM (
+  (SELECT id FROM (
+     SELECT id, array_distance(vec, [
+       0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+       0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0
+     ]::FLOAT[16]) AS dist
+     FROM 'test/.tmp/knn_fb_l2.lance'
+   ) baseline
+   ORDER BY dist
+   LIMIT 5)
+  EXCEPT
+  (SELECT id FROM 'test/.tmp/knn_fb_l2.lance'
+   ORDER BY array_distance(vec, [
+     0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+     0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0
+   ]::FLOAT[16])
+   LIMIT 5)
+);
+----
+0
+
+statement ok
+SET lance_knn_use_index = true;
+
+# ===================================================================
+# Fallback: WHERE contains a non-deterministic expression
+# (random() cannot be encoded as Filter IR -> no rewrite)
+# ===================================================================
+
+query II
+EXPLAIN (FORMAT JSON)
+SELECT id
+FROM 'test/.tmp/knn_fb_l2.lance'
+WHERE random() < 0.5
+ORDER BY array_distance(vec, [
+  0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+  0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0
+]::FLOAT[16])
+LIMIT 5;
+----
+physical_plan	<!REGEX>:.*__LANCE_KNN_SCAN.*
+
+# Sanity: query executes (the row count is non-deterministic since random()
+# may filter everything; just assert that it does not error and returns <= k rows)
+query I
+SELECT count(*) <= 5 FROM (
+  SELECT id FROM 'test/.tmp/knn_fb_l2.lance'
+  WHERE random() < 0.5
+  ORDER BY array_distance(vec, [
+    0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+    0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0
+  ]::FLOAT[16])
+  LIMIT 5
+);
+----
+true
+
+# ===================================================================
+# Fallback: ORDER BY is not a supported distance function
+# (length(text) over the search_test_data fixture)
+# ===================================================================
+
+query II
+EXPLAIN (FORMAT JSON)
+SELECT id
+FROM 'test/data/search_test_data.lance'
+ORDER BY length(text)
+LIMIT 5;
+----
+physical_plan	<!REGEX>:.*__LANCE_KNN_SCAN.*
+
+query I
+SELECT count(*) FROM (
+  SELECT id FROM 'test/data/search_test_data.lance'
+  ORDER BY length(text)
+  LIMIT 5
+);
+----
+5
+
+# ===================================================================
+# Session var: lance_knn_max_k lowers the rewrite ceiling.
+#
+# Test scope note: we only assert the lowering path and the "0 = default"
+# fallback, not "raising the ceiling unlocks larger LIMIT" or "hard
+# ceiling clamps to 1M". Those branches would need a LIMIT large enough
+# to *not* also trip DuckDB's own switch from LogicalTopN to
+# STREAMING_LIMIT + ORDER_BY (which happens once LIMIT exceeds the
+# estimated input cardinality, ~2048 here). With a tiny test dataset
+# any "raise max_k to 100000, LIMIT 50000" assertion would actually be
+# testing that DuckDB-side switch, not our path. The hard-ceiling
+# clamp is exercised by code review and the absolute_max_k constant.
+# ===================================================================
+
+# Lowering below the literal LIMIT forces fallback even though the
+# default ceiling would have allowed the rewrite.
+statement ok
+SET lance_knn_max_k = 3;
+
+query II
+EXPLAIN (FORMAT JSON)
+SELECT id
+FROM 'test/.tmp/knn_fb_l2.lance'
+ORDER BY array_distance(vec, [
+  0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+  0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0
+]::FLOAT[16])
+LIMIT 5;
+----
+physical_plan	<!REGEX>:.*__LANCE_KNN_SCAN.*
+
+# Sanity: the query still returns correct row count via the DuckDB
+# fallback path.
+query I
+SELECT count(*) FROM (
+  SELECT id FROM 'test/.tmp/knn_fb_l2.lance'
+  ORDER BY array_distance(vec, [
+    0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+    0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0
+  ]::FLOAT[16])
+  LIMIT 5
+);
+----
+5
+
+statement ok
+RESET lance_knn_max_k;
+
+# Setting to 0 falls back to the documented default (10000): LIMIT 5
+# still rewrites because 5 <= 10000.
+statement ok
+SET lance_knn_max_k = 0;
+
+query II
+EXPLAIN (FORMAT JSON)
+SELECT id
+FROM 'test/.tmp/knn_fb_l2.lance'
+ORDER BY array_distance(vec, [
+  0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+  0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0
+]::FLOAT[16])
+LIMIT 5;
+----
+physical_plan	<REGEX>:[\s\S]*__LANCE_KNN_SCAN[\s\S]*
+
+statement ok
+RESET lance_knn_max_k;

--- a/test/sql/optimizer_knn_filter.test
+++ b/test/sql/optimizer_knn_filter.test
@@ -1,0 +1,431 @@
+# name: test/sql/optimizer_knn_filter.test
+# description: KNN optimizer also pushes WHERE predicates into __LANCE_KNN_SCAN
+# group: [sql]
+
+require lance
+
+# ===================================================================
+# Setup: dataset with FLOAT[16] vec + scalar `category` column + L2 index
+# ===================================================================
+
+statement ok
+COPY (
+  SELECT id, vec, (id % 4)::INTEGER AS category
+  FROM 'test/data/bigann_tiny/base.lance'
+) TO 'test/.tmp/knn_opt_filter.lance' (FORMAT lance, mode 'overwrite');
+
+statement ok
+CREATE INDEX vec_idx ON 'test/.tmp/knn_opt_filter.lance' (vec)
+USING IVF_FLAT WITH (num_partitions=1, metric_type='l2');
+
+# ===================================================================
+# Basic WHERE pushdown: filter bytes are non-zero, no separate FILTER/TOP_N
+# ===================================================================
+
+query II
+EXPLAIN (FORMAT JSON)
+SELECT id
+FROM 'test/.tmp/knn_opt_filter.lance'
+WHERE category = 1
+ORDER BY array_distance(vec, [
+  0.32245764, 0.2814153, 0.08346437, 0.28065863,
+  0.2566661, -0.47035545, -0.9935358, 0.09578487,
+  0.000604047, -0.37332273, 0.12592472, -0.3458825,
+  -0.2536356, -0.3673502, -0.68120277, 0.41665298
+]::FLOAT[16])
+LIMIT 5;
+----
+physical_plan	<REGEX>:[\s\S]*__LANCE_KNN_SCAN[\s\S]*"Lance Filter IR Bytes \(Bind\)": "[1-9][0-9]*"[\s\S]*
+
+# Filter and Top-N were folded into the KNN scan
+query II
+EXPLAIN (FORMAT JSON)
+SELECT id
+FROM 'test/.tmp/knn_opt_filter.lance'
+WHERE category = 1
+ORDER BY array_distance(vec, [
+  0.32245764, 0.2814153, 0.08346437, 0.28065863,
+  0.2566661, -0.47035545, -0.9935358, 0.09578487,
+  0.000604047, -0.37332273, 0.12592472, -0.3458825,
+  -0.2536356, -0.3673502, -0.68120277, 0.41665298
+]::FLOAT[16])
+LIMIT 5;
+----
+physical_plan	<!REGEX>:.*LOGICAL_FILTER.*
+
+query II
+EXPLAIN (FORMAT JSON)
+SELECT id
+FROM 'test/.tmp/knn_opt_filter.lance'
+WHERE category = 1
+ORDER BY array_distance(vec, [
+  0.32245764, 0.2814153, 0.08346437, 0.28065863,
+  0.2566661, -0.47035545, -0.9935358, 0.09578487,
+  0.000604047, -0.37332273, 0.12592472, -0.3458825,
+  -0.2536356, -0.3673502, -0.68120277, 0.41665298
+]::FLOAT[16])
+LIMIT 5;
+----
+physical_plan	<!REGEX>:.*TOP_N.*
+
+# ===================================================================
+# Correctness: rewritten WHERE+ORDER BY returns the same ids as
+# lance_vector_search(prefilter=true) with the WHERE applied to the result
+# ===================================================================
+
+query I
+SELECT count(*) FROM (
+  (SELECT id FROM 'test/.tmp/knn_opt_filter.lance'
+   WHERE category = 1
+   ORDER BY array_distance(vec, [
+     0.32245764, 0.2814153, 0.08346437, 0.28065863,
+     0.2566661, -0.47035545, -0.9935358, 0.09578487,
+     0.000604047, -0.37332273, 0.12592472, -0.3458825,
+     -0.2536356, -0.3673502, -0.68120277, 0.41665298
+   ]::FLOAT[16])
+   LIMIT 5)
+  EXCEPT
+  (SELECT id FROM lance_vector_search(
+     'test/.tmp/knn_opt_filter.lance', 'vec',
+     [
+       0.32245764, 0.2814153, 0.08346437, 0.28065863,
+       0.2566661, -0.47035545, -0.9935358, 0.09578487,
+       0.000604047, -0.37332273, 0.12592472, -0.3458825,
+       -0.2536356, -0.3673502, -0.68120277, 0.41665298
+     ]::FLOAT[16],
+     k = 5,
+     prefilter = true
+   )
+   WHERE category = 1)
+);
+----
+0
+
+# Reverse direction
+query I
+SELECT count(*) FROM (
+  (SELECT id FROM lance_vector_search(
+     'test/.tmp/knn_opt_filter.lance', 'vec',
+     [
+       0.32245764, 0.2814153, 0.08346437, 0.28065863,
+       0.2566661, -0.47035545, -0.9935358, 0.09578487,
+       0.000604047, -0.37332273, 0.12592472, -0.3458825,
+       -0.2536356, -0.3673502, -0.68120277, 0.41665298
+     ]::FLOAT[16],
+     k = 5,
+     prefilter = true
+   )
+   WHERE category = 1)
+  EXCEPT
+  (SELECT id FROM 'test/.tmp/knn_opt_filter.lance'
+   WHERE category = 1
+   ORDER BY array_distance(vec, [
+     0.32245764, 0.2814153, 0.08346437, 0.28065863,
+     0.2566661, -0.47035545, -0.9935358, 0.09578487,
+     0.000604047, -0.37332273, 0.12592472, -0.3458825,
+     -0.2536356, -0.3673502, -0.68120277, 0.41665298
+   ]::FLOAT[16])
+   LIMIT 5)
+);
+----
+0
+
+# ===================================================================
+# Multi-predicate WHERE: AND of category IN (...) and id > 100
+# ===================================================================
+
+query II
+EXPLAIN (FORMAT JSON)
+SELECT id
+FROM 'test/.tmp/knn_opt_filter.lance'
+WHERE category IN (0, 1, 2) AND id > 100
+ORDER BY array_distance(vec, [
+  0.32245764, 0.2814153, 0.08346437, 0.28065863,
+  0.2566661, -0.47035545, -0.9935358, 0.09578487,
+  0.000604047, -0.37332273, 0.12592472, -0.3458825,
+  -0.2536356, -0.3673502, -0.68120277, 0.41665298
+]::FLOAT[16])
+LIMIT 10;
+----
+physical_plan	<REGEX>:[\s\S]*__LANCE_KNN_SCAN[\s\S]*"Lance Filter IR Bytes \(Bind\)": "[1-9][0-9]*"[\s\S]*
+
+query I
+SELECT count(*) FROM (
+  (SELECT id FROM 'test/.tmp/knn_opt_filter.lance'
+   WHERE category IN (0, 1, 2) AND id > 100
+   ORDER BY array_distance(vec, [
+     0.32245764, 0.2814153, 0.08346437, 0.28065863,
+     0.2566661, -0.47035545, -0.9935358, 0.09578487,
+     0.000604047, -0.37332273, 0.12592472, -0.3458825,
+     -0.2536356, -0.3673502, -0.68120277, 0.41665298
+   ]::FLOAT[16])
+   LIMIT 10)
+  EXCEPT
+  (SELECT id FROM lance_vector_search(
+     'test/.tmp/knn_opt_filter.lance', 'vec',
+     [
+       0.32245764, 0.2814153, 0.08346437, 0.28065863,
+       0.2566661, -0.47035545, -0.9935358, 0.09578487,
+       0.000604047, -0.37332273, 0.12592472, -0.3458825,
+       -0.2536356, -0.3673502, -0.68120277, 0.41665298
+     ]::FLOAT[16],
+     k = 10,
+     prefilter = true
+   )
+   WHERE category IN (0, 1, 2) AND id > 100)
+);
+----
+0
+
+# Sanity: the result actually returns rows
+query I
+SELECT count(*) FROM (
+  SELECT id FROM 'test/.tmp/knn_opt_filter.lance'
+  WHERE category IN (0, 1, 2) AND id > 100
+  ORDER BY array_distance(vec, [
+    0.32245764, 0.2814153, 0.08346437, 0.28065863,
+    0.2566661, -0.47035545, -0.9935358, 0.09578487,
+    0.000604047, -0.37332273, 0.12592472, -0.3458825,
+    -0.2536356, -0.3673502, -0.68120277, 0.41665298
+  ]::FLOAT[16])
+  LIMIT 10
+);
+----
+10
+
+# ===================================================================
+# Prefilter session var: when off and WHERE is present, do not rewrite.
+#
+# A transparent optimizer rule must not turn WHERE-before-TopN SQL into
+# post-filtered global KNN. Explicit lance_vector_search(prefilter=false)
+# remains available for that search mode, but ordinary SQL falls back.
+# ===================================================================
+
+statement ok
+SET lance_knn_prefilter = false;
+
+query II
+EXPLAIN (FORMAT JSON)
+SELECT id
+FROM 'test/.tmp/knn_opt_filter.lance'
+WHERE category = 1
+ORDER BY array_distance(vec, [
+  0.32245764, 0.2814153, 0.08346437, 0.28065863,
+  0.2566661, -0.47035545, -0.9935358, 0.09578487,
+  0.000604047, -0.37332273, 0.12592472, -0.3458825,
+  -0.2536356, -0.3673502, -0.68120277, 0.41665298
+]::FLOAT[16])
+LIMIT 5;
+----
+physical_plan	<!REGEX>:.*__LANCE_KNN_SCAN.*
+
+query I
+SELECT count(*) FROM (
+  SELECT id FROM 'test/.tmp/knn_opt_filter.lance'
+  WHERE category = 1
+  ORDER BY array_distance(vec, [
+    0.32245764, 0.2814153, 0.08346437, 0.28065863,
+    0.2566661, -0.47035545, -0.9935358, 0.09578487,
+    0.000604047, -0.37332273, 0.12592472, -0.3458825,
+    -0.2536356, -0.3673502, -0.68120277, 0.41665298
+  ]::FLOAT[16])
+  LIMIT 5
+);
+----
+5
+
+statement ok
+RESET lance_knn_prefilter;
+
+# ===================================================================
+# Selective filter: prefilter=true rewrites, prefilter=false falls back.
+# The filter `category = 1 AND id < 20` matches exactly 5 rows out of
+# 2048; asking for k=10 must return those 5 rows under SQL semantics.
+# ===================================================================
+
+# prefilter=true: KNN scan applies the filter inside the index lookup
+query I
+SELECT count(*) FROM (
+  SELECT id FROM 'test/.tmp/knn_opt_filter.lance'
+  WHERE category = 1 AND id < 20
+  ORDER BY array_distance(vec, [
+    0.32245764, 0.2814153, 0.08346437, 0.28065863,
+    0.2566661, -0.47035545, -0.9935358, 0.09578487,
+    0.000604047, -0.37332273, 0.12592472, -0.3458825,
+    -0.2536356, -0.3673502, -0.68120277, 0.41665298
+  ]::FLOAT[16])
+  LIMIT 10
+);
+----
+5
+
+# Same SQL must agree with lance_vector_search(prefilter=true)
+query I
+SELECT count(*) FROM (
+  (SELECT id FROM 'test/.tmp/knn_opt_filter.lance'
+   WHERE category = 1 AND id < 20
+   ORDER BY array_distance(vec, [
+     0.32245764, 0.2814153, 0.08346437, 0.28065863,
+     0.2566661, -0.47035545, -0.9935358, 0.09578487,
+     0.000604047, -0.37332273, 0.12592472, -0.3458825,
+     -0.2536356, -0.3673502, -0.68120277, 0.41665298
+   ]::FLOAT[16])
+   LIMIT 10)
+  EXCEPT
+  (SELECT id FROM lance_vector_search(
+     'test/.tmp/knn_opt_filter.lance', 'vec',
+     [
+       0.32245764, 0.2814153, 0.08346437, 0.28065863,
+       0.2566661, -0.47035545, -0.9935358, 0.09578487,
+       0.000604047, -0.37332273, 0.12592472, -0.3458825,
+       -0.2536356, -0.3673502, -0.68120277, 0.41665298
+     ]::FLOAT[16],
+     k = 10,
+     prefilter = true
+   )
+   WHERE category = 1 AND id < 20)
+);
+----
+0
+
+# Now switch prefilter off. Because a WHERE clause is present, the
+# optimizer leaves the original DuckDB TopN plan intact.
+statement ok
+SET lance_knn_prefilter = false;
+
+query II
+EXPLAIN (FORMAT JSON)
+SELECT id
+FROM 'test/.tmp/knn_opt_filter.lance'
+WHERE category = 1 AND id < 20
+ORDER BY array_distance(vec, [
+  0.32245764, 0.2814153, 0.08346437, 0.28065863,
+  0.2566661, -0.47035545, -0.9935358, 0.09578487,
+  0.000604047, -0.37332273, 0.12592472, -0.3458825,
+  -0.2536356, -0.3673502, -0.68120277, 0.41665298
+]::FLOAT[16])
+LIMIT 10;
+----
+physical_plan	<!REGEX>:.*__LANCE_KNN_SCAN.*
+
+query I
+SELECT count(*) FROM (
+  SELECT id FROM 'test/.tmp/knn_opt_filter.lance'
+  WHERE category = 1 AND id < 20
+  ORDER BY array_distance(vec, [
+    0.32245764, 0.2814153, 0.08346437, 0.28065863,
+    0.2566661, -0.47035545, -0.9935358, 0.09578487,
+    0.000604047, -0.37332273, 0.12592472, -0.3458825,
+    -0.2536356, -0.3673502, -0.68120277, 0.41665298
+  ]::FLOAT[16])
+  LIMIT 10
+);
+----
+5
+
+statement ok
+RESET lance_knn_prefilter;
+
+# ===================================================================
+# LIKE WHERE: verifies LanceLikePushdownOptimizer collaboration
+# (Filter parts can land in either the LogicalFilter we walk, or in
+# scan_bind.lance_pushed_filter_ir_parts after the LIKE pass — both
+# paths must merge into a single non-empty IR.)
+# ===================================================================
+
+statement ok
+COPY (
+  SELECT id, vec, ('group_' || (id % 4)::VARCHAR) AS name
+  FROM 'test/data/bigann_tiny/base.lance'
+) TO 'test/.tmp/knn_opt_like.lance' (FORMAT lance, mode 'overwrite');
+
+statement ok
+CREATE INDEX vec_idx ON 'test/.tmp/knn_opt_like.lance' (vec)
+USING IVF_FLAT WITH (num_partitions=1, metric_type='l2');
+
+query II
+EXPLAIN (FORMAT JSON)
+SELECT id
+FROM 'test/.tmp/knn_opt_like.lance'
+WHERE name LIKE 'group_1'
+ORDER BY array_distance(vec, [
+  0.32245764, 0.2814153, 0.08346437, 0.28065863,
+  0.2566661, -0.47035545, -0.9935358, 0.09578487,
+  0.000604047, -0.37332273, 0.12592472, -0.3458825,
+  -0.2536356, -0.3673502, -0.68120277, 0.41665298
+]::FLOAT[16])
+LIMIT 5;
+----
+physical_plan	<REGEX>:[\s\S]*__LANCE_KNN_SCAN[\s\S]*"Lance Filter IR Bytes \(Bind\)": "[1-9][0-9]*"[\s\S]*
+
+# Correctness vs lance_vector_search(prefilter=true) wrapped in the same LIKE
+query I
+SELECT count(*) FROM (
+  (SELECT id FROM 'test/.tmp/knn_opt_like.lance'
+   WHERE name LIKE 'group_1'
+   ORDER BY array_distance(vec, [
+     0.32245764, 0.2814153, 0.08346437, 0.28065863,
+     0.2566661, -0.47035545, -0.9935358, 0.09578487,
+     0.000604047, -0.37332273, 0.12592472, -0.3458825,
+     -0.2536356, -0.3673502, -0.68120277, 0.41665298
+   ]::FLOAT[16])
+   LIMIT 5)
+  EXCEPT
+  (SELECT id FROM lance_vector_search(
+     'test/.tmp/knn_opt_like.lance', 'vec',
+     [
+       0.32245764, 0.2814153, 0.08346437, 0.28065863,
+       0.2566661, -0.47035545, -0.9935358, 0.09578487,
+       0.000604047, -0.37332273, 0.12592472, -0.3458825,
+       -0.2536356, -0.3673502, -0.68120277, 0.41665298
+     ]::FLOAT[16],
+     k = 5,
+     prefilter = true
+   )
+   WHERE name LIKE 'group_1')
+);
+----
+0
+
+# Sanity: LIKE narrows to exactly the matching group and returns rows
+query I
+SELECT count(*) FROM (
+  SELECT id FROM 'test/.tmp/knn_opt_like.lance'
+  WHERE name LIKE 'group_1'
+  ORDER BY array_distance(vec, [
+    0.32245764, 0.2814153, 0.08346437, 0.28065863,
+    0.2566661, -0.47035545, -0.9935358, 0.09578487,
+    0.000604047, -0.37332273, 0.12592472, -0.3458825,
+    -0.2536356, -0.3673502, -0.68120277, 0.41665298
+  ]::FLOAT[16])
+  LIMIT 5
+);
+----
+5
+
+# ===================================================================
+# IR dedup: LIKE pushdown writes the LIKE fragment into
+# scan_bind.lance_pushed_filter_ir_parts AND leaves the LIKE
+# expression on the LogicalFilter as defense-in-depth. The KNN
+# optimizer must dedup the merged IR or Lance receives the same
+# predicate twice. A single-fragment LIKE encodes to ~136 bytes on
+# the current wire format; doubled it would be ~270+. We pin a
+# 100-199 byte window so the dedup regression is loud — if a future
+# encoder change drifts the single-fragment size, update the bound
+# but keep the upper-side gap from the doubled case.
+# ===================================================================
+
+query II
+EXPLAIN (FORMAT JSON)
+SELECT id
+FROM 'test/.tmp/knn_opt_like.lance'
+WHERE name LIKE 'group_1'
+ORDER BY array_distance(vec, [
+  0.32245764, 0.2814153, 0.08346437, 0.28065863,
+  0.2566661, -0.47035545, -0.9935358, 0.09578487,
+  0.000604047, -0.37332273, 0.12592472, -0.3458825,
+  -0.2536356, -0.3673502, -0.68120277, 0.41665298
+]::FLOAT[16])
+LIMIT 5;
+----
+physical_plan	<REGEX>:[\s\S]*"Lance Filter IR Bytes \(Bind\)": "1[0-9][0-9]"[\s\S]*


### PR DESCRIPTION
  ## Summary

  Standard SQL `SELECT ... ORDER BY array_distance(vec, q) LIMIT k` previously fell through DuckDB's `LogicalTopN` over a full Lance scan and silently ignored any IVF / HNSW
  index on the column — the only way to use the index was to switch to the bespoke `lance_vector_search` table function.

  This PR adds an `OptimizerExtension` that rewrites the standard pattern into an index-backed plan with no user-visible change.

  ## Design

  The optimizer matches:

  LogicalTopN(limit=k, offset=0, ASC dist)
    └── LogicalProjection(... dist_func(vec, const_query) ...)
          └── [LogicalFilter ...]                 // optional
                └── LogicalGet(__lance_scan | __lance_table_scan | __lance_namespace_scan)

  and replaces the underlying `LogicalGet` with a new internal `__lance_knn_scan`, collapsing `TopN` and any pushable `Filter` into a single GET. A covering `WHERE` clause is
  encoded as Lance Filter IR so Lance pre-filters inside the index lookup.

  ### Distance functions

  | SQL function | Metric |
  |---|---|
  | `array_distance` / `list_distance` | `l2` |
  | `array_cosine_distance` / `list_cosine_distance` | `cosine` |
  | `array_negative_inner_product` / `list_negative_inner_product` | `dot` |

  `l2` and `cosine` are commutative; for `dot`, exactly one side must be a constant `FLOAT[N]` and the other a column reference.

  ### Metric consistency

  A new FFI `lance_dataset_vector_index_metric` returns the index's metric for a column, cached per-column on `LanceDatasetCacheEntry` (positive lookups only, so transient
  errors don't poison the entry and late `CREATE INDEX` is picked up on the next plan). The optimizer falls back if the column has no vector index or the metric doesn't match
  the distance function.

  ### Session variables

  | Variable | Default | Purpose |
  |---|---|---|
  | `lance_knn_nprobes` | `0` (Lance default) | IVF probe count |
  | `lance_knn_refine_factor` | `0` | PQ refine factor |
  | `lance_knn_prefilter` | `true` | Apply filter before / after the scan |
  | `lance_knn_use_index` | `true` | Kill switch — `false` disables the rewrite |
  | `lance_knn_max_k` | `10000` (hard ceiling 1,000,000) | Caps `k` to bound index scan cost |

  ### Fallback

  13 conditions keep the original plan unchanged (DESC, `OFFSET`, multi-ORDER-BY, non-constant query vector, unpushable `WHERE`, missing index, metric mismatch, `k > max_k`,
  etc.). Correctness is unchanged in every fallback case.

  ## Hardening

  - **Filter IR dedup** — `LogicalFilter`, LIKE pushdown, and `table_filters` can each contribute IR fragments; byte-equal fragments are deduplicated so LIKE + KNN don't push
  the same predicate twice.
  - **Rebind verification** — The `__lance_knn_scan` rebind path (prepared statement / `EXPLAIN ANALYZE` replan) re-verifies the index and metric. A clear "re-prepare" error
  replaces an opaque downstream failure when an index is dropped across contexts.
  - **1 MiB blob cap** — Rebound query / filter IR blobs are capped at 1 MiB; a typo'd internal call cannot trigger an eager multi-GB allocation.

  ## Test plan

  - [x] `test/sql/optimizer_knn_basic.test` — rewrite shape; bidirectional `EXCEPT` against `lance_vector_search` for all three metrics
  - [x] `test/sql/optimizer_knn_filter.test` — `WHERE` pushdown, `prefilter=true` vs `false` row-count gap, IR-dedup byte window, LIKE + KNN interaction
  - [x] `test/sql/optimizer_knn_fallback.test` — every fallback condition, `lance_knn_max_k` lowering + `0 = default` branch, late `CREATE INDEX` proving the metric cache only
   stores positive lookups
  - [x] Full regression `GEN=ninja make test`: **4203 assertions / 53 cases pass**