### PR TITLE
chore: update lance dependency to v7.0.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,14 +19,14 @@ panic = "abort"
 [dependencies]
 
 # Lance and Arrow dependencies - using compatible versions
-lance = { version = "6.0.0", default-features = false, features = ["aws", "azure", "gcp", "oss", "huggingface"] }
-lance-arrow = "6.0.0"
-lance-core = "6.0.0"
-lance-index = "6.0.0"
-lance-linalg = "6.0.0"
-lance-namespace = "6.0.0"
-lance-namespace-impls = { version = "6.0.0", features = ["rest"] }
-lance-table = "6.0.0"
+lance = { version = "7.0.0", default-features = false, features = ["aws", "azure", "gcp", "oss", "huggingface"] }
+lance-arrow = "7.0.0"
+lance-core = "7.0.0"
+lance-index = "7.0.0"
+lance-linalg = "7.0.0"
+lance-namespace = "7.0.0"
+lance-namespace-impls = { version = "7.0.0", features = ["rest"] }
+lance-table = "7.0.0"
 
 arrow = { version = "58.0.0", features = ["ffi"] }
 arrow-array = "58.0.0"


### PR DESCRIPTION
## Summary

- Updates the Lance Rust dependency declarations in `Cargo.toml` from `6.0.0` to `7.0.0` for:
  - `lance`
  - `lance-arrow`
  - `lance-core`
  - `lance-index`
  - `lance-linalg`
  - `lance-namespace`
  - `lance-namespace-impls`
  - `lance-table`
- Preserves the existing feature flags and does not add a `[patch.crates-io]` override.
- Triggering Lance tag: [`refs/tags/v7.0.0`](https://github.com/lance-format/lance/tree/refs/tags/v7.0.0)

## Resolver Notes

- The Lance `v7.0.0` tag declares these crates as `7.0.0` and continues to use Arrow `58.0.0` and DataFusion `53.0.0`, so the existing Arrow/DataFusion pins in this repository appear aligned.
- `Cargo.lock` could not be updated because crates.io currently resolves the requested Lance crates only up to `6.0.1`; `cargo update -p lance --precise 7.0.0` fails before lockfile generation with `no matching package named lance found`.
- No git dependency or crates.io patch override was added because this PR is constrained to crates.io stable releases only.

## Checks

- `cargo fmt --all` succeeded.
- `cargo check --manifest-path Cargo.toml` failed during dependency resolution because `lance = 7.0.0` is not available in the crates.io index yet.
- `cargo clippy --manifest-path Cargo.toml --all-targets` failed for the same dependency-resolution reason.
