### PR TITLE
fix(index): support nested field lifecycle

### DIFF
--- a/rust/ffi/index.rs
+++ b/rust/ffi/index.rs
@@ -19,7 +19,9 @@ use crate::error::{clear_last_error, set_last_error, ErrorCode};
 use crate::runtime;
 
 use super::types::{SchemaHandle, StreamHandle};
-use super::util::{cstr_to_str, dataset_handle, to_c_string, FfiError, FfiResult};
+use super::util::{
+    canonicalize_lance_field_path, cstr_to_str, dataset_handle, to_c_string, FfiError, FfiResult,
+};
 
 #[derive(Debug, Default, Deserialize)]
 #[serde(default, deny_unknown_fields)]
@@ -112,11 +114,12 @@ fn create_index_list_stream_inner(dataset: *mut c_void) -> FfiResult<StreamHandl
 
         let mut cols = Vec::new();
         for &field_id in d.field_ids() {
-            if let Some(field) = dataset.schema().field_by_id(field_id as i32) {
-                cols.push(field.name.clone());
-            } else {
-                cols.push(format!("_field_id_{field_id}"));
-            }
+            cols.push(
+                dataset
+                    .schema()
+                    .field_path(field_id as i32)
+                    .unwrap_or_else(|_| format!("_field_id_{field_id}")),
+            );
         }
         fields.push(cols.join(","));
 
@@ -223,8 +226,8 @@ fn list_scalar_indexed_columns_inner(dataset: *mut c_void) -> FfiResult<Vec<Stri
             continue;
         }
         for &field_id in d.field_ids() {
-            if let Some(field) = schema.field_by_id(field_id as i32) {
-                cols.push(field.name.clone());
+            if let Ok(path) = schema.field_path(field_id as i32) {
+                cols.push(path);
             }
         }
     }
@@ -367,6 +370,8 @@ fn dataset_create_index_inner(
         }
     };
 
+    let canonical_columns = canonicalize_index_columns(handle.dataset.schema(), &columns)?;
+
     let (lance_index_type, params) = build_index_params(&index_type_norm, params_json.as_deref())?;
 
     let mut ds: Dataset = handle.dataset.as_ref().clone();
@@ -375,7 +380,7 @@ fn dataset_create_index_inner(
 
     run_with_large_stack(move || {
         match runtime::block_on(async {
-            let cols: [&str; 1] = [columns[0].as_str()];
+            let cols: [&str; 1] = [canonical_columns[0].as_str()];
             let mut builder = ds.create_index_builder(&cols, lance_index_type, params.as_ref());
             if let Some(name) = index_name {
                 builder = builder.name(name);
@@ -614,6 +619,16 @@ fn normalize_index_type(index_type: &str) -> String {
         .trim()
         .to_ascii_uppercase()
         .replace(['-', ' '], "_")
+}
+
+fn canonicalize_index_columns(
+    schema: &lance_core::datatypes::Schema,
+    columns: &[String],
+) -> FfiResult<Vec<String>> {
+    columns
+        .iter()
+        .map(|column| canonicalize_lance_field_path(schema, column, "index column"))
+        .collect()
 }
 
 fn build_index_params(
@@ -871,4 +886,85 @@ fn index_list_schema() -> SchemaHandle {
         Field::new("details", DataType::Utf8, true),
     ]);
     Arc::new(schema)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use arrow_schema::{DataType, Field as ArrowField, Fields, Schema as ArrowSchema};
+
+    fn nested_schema() -> lance_core::datatypes::Schema {
+        let arrow = ArrowSchema::new(vec![
+            ArrowField::new(
+                "left_struct",
+                DataType::Struct(Fields::from(vec![ArrowField::new(
+                    "value",
+                    DataType::Int32,
+                    true,
+                )])),
+                true,
+            ),
+            ArrowField::new(
+                "right_struct",
+                DataType::Struct(Fields::from(vec![ArrowField::new(
+                    "value",
+                    DataType::Int32,
+                    true,
+                )])),
+                true,
+            ),
+            ArrowField::new(
+                "dotted",
+                DataType::Struct(Fields::from(vec![ArrowField::new(
+                    "literal.dot",
+                    DataType::Int32,
+                    true,
+                )])),
+                true,
+            ),
+        ]);
+        let mut schema = lance_core::datatypes::Schema::try_from(&arrow).unwrap();
+        schema.set_field_id(None);
+        schema
+    }
+
+    #[test]
+    fn canonicalizes_nested_index_columns() {
+        let schema = nested_schema();
+
+        assert_eq!(
+            canonicalize_lance_field_path(&schema, "left_struct.value", "index column").unwrap(),
+            "left_struct.value"
+        );
+        assert_eq!(
+            canonicalize_lance_field_path(&schema, "right_struct.value", "index column").unwrap(),
+            "right_struct.value"
+        );
+        assert_eq!(
+            canonicalize_lance_field_path(&schema, "dotted.`literal.dot`", "index column").unwrap(),
+            "dotted.`literal.dot`"
+        );
+    }
+
+    #[test]
+    fn canonicalizes_case_insensitive_index_columns() {
+        let schema = nested_schema();
+
+        assert_eq!(
+            canonicalize_lance_field_path(&schema, "LEFT_STRUCT.VALUE", "index column").unwrap(),
+            "left_struct.value"
+        );
+        assert_eq!(
+            canonicalize_lance_field_path(&schema, "DOTTED.`LITERAL.DOT`", "index column").unwrap(),
+            "dotted.`literal.dot`"
+        );
+    }
+
+    #[test]
+    fn rejects_ambiguous_leaf_without_parent_path() {
+        let schema = nested_schema();
+        let err = canonicalize_lance_field_path(&schema, "value", "index column").unwrap_err();
+
+        assert!(err.message.contains("index column not found"));
+    }
 }

--- a/rust/ffi/schema_evolution.rs
+++ b/rust/ffi/schema_evolution.rs
@@ -18,7 +18,10 @@ use lance_index::scalar::ScalarIndexParams;
 use lance_index::IndexType;
 use serde::{Deserialize, Serialize};
 
-use super::util::{cstr_to_str, optional_cstr_array, to_c_string, FfiError, FfiResult};
+use super::util::{
+    canonicalize_lance_field_path, cstr_to_str, optional_cstr_array, to_c_string, FfiError,
+    FfiResult,
+};
 
 fn parse_batch_size_from_config(dataset: &Dataset) -> Option<u32> {
     dataset
@@ -1047,7 +1050,7 @@ fn dataset_list_indices_inner(dataset: *mut c_void) -> FfiResult<String> {
         let cols = idx
             .fields
             .iter()
-            .filter_map(|id| schema.field_by_id(*id).map(|f| f.name.as_str()))
+            .filter_map(|id| schema.field_path(*id).ok())
             .collect::<Vec<_>>()
             .join(",");
         out.push_str(&cols);
@@ -1086,7 +1089,8 @@ fn dataset_create_scalar_index_inner(
     let index_name = unsafe { cstr_to_str(index_name, "index_name")? };
 
     let mut ds = (*handle.dataset).clone();
-    let cols = [column];
+    let canonical_column = canonicalize_lance_field_path(ds.schema(), column, "index column")?;
+    let cols = [canonical_column.as_str()];
     match runtime::block_on(ds.create_index(
         &cols,
         IndexType::Scalar,

--- a/rust/ffi/util.rs
+++ b/rust/ffi/util.rs
@@ -6,6 +6,7 @@ use arrow::array::RecordBatch;
 use arrow::datatypes::Schema;
 use datafusion_expr::Expr;
 use lance::session::Session;
+use lance_core::datatypes::Schema as LanceSchema;
 
 use crate::error::ErrorCode;
 
@@ -34,6 +35,34 @@ pub(crate) fn to_c_string(s: impl AsRef<str>) -> CString {
         Err(_) => CString::new(s.as_ref().replace('\0', "\\0"))
             .unwrap_or_else(|_| CString::new("invalid string").unwrap()),
     }
+}
+
+pub(crate) fn canonicalize_lance_field_path(
+    schema: &LanceSchema,
+    column: &str,
+    what: &'static str,
+) -> FfiResult<String> {
+    let column = column.trim();
+    if column.is_empty() {
+        return Err(FfiError::new(
+            ErrorCode::InvalidArgument,
+            format!("{what} cannot be empty"),
+        ));
+    }
+
+    let field = schema.field_case_insensitive(column).ok_or_else(|| {
+        FfiError::new(
+            ErrorCode::InvalidArgument,
+            format!("{what} not found: '{column}'"),
+        )
+    })?;
+
+    schema.field_path(field.id).map_err(|err| {
+        FfiError::new(
+            ErrorCode::InvalidArgument,
+            format!("{what} path normalize: {err}"),
+        )
+    })
 }
 
 pub(crate) unsafe fn cstr_to_str<'a>(ptr: *const c_char, what: &'static str) -> FfiResult<&'a str> {

--- a/src/lance_index.cpp
+++ b/src/lance_index.cpp
@@ -21,6 +21,7 @@
 #include "lance_ffi.hpp"
 #include "lance_table_entry.hpp"
 
+#include <algorithm>
 #include <atomic>
 #include <cctype>
 #include <cstring>
@@ -77,6 +78,152 @@ static bool IsIdentChar(char c) {
          c == '.';
 }
 
+static bool LanceFieldPathSegmentNeedsQuoting(const string &segment) {
+  if (segment.empty()) {
+    return true;
+  }
+  for (auto c : segment) {
+    if (std::isalnum(static_cast<unsigned char>(c)) == 0 && c != '_') {
+      return true;
+    }
+  }
+  return false;
+}
+
+static string FormatLanceFieldPath(const vector<string> &segments) {
+  if (segments.empty()) {
+    throw InternalException("field path has no segments");
+  }
+
+  string out;
+  for (idx_t i = 0; i < segments.size(); i++) {
+    if (i > 0) {
+      out.push_back('.');
+    }
+
+    auto &segment = segments[i];
+    if (!LanceFieldPathSegmentNeedsQuoting(segment)) {
+      out += segment;
+      continue;
+    }
+
+    out.push_back('`');
+    for (auto c : segment) {
+      if (c == '`') {
+        out += "``";
+      } else {
+        out.push_back(c);
+      }
+    }
+    out.push_back('`');
+  }
+  return out;
+}
+
+static vector<string>
+StripMatchingColumnQualifier(const vector<string> &column_names,
+                             const vector<string> &table_qualifier) {
+  if (column_names.size() <= 1 || table_qualifier.empty()) {
+    return column_names;
+  }
+
+  auto max_prefix =
+      std::min<idx_t>(column_names.size() - 1, table_qualifier.size());
+  for (idx_t prefix_len = max_prefix; prefix_len > 0; prefix_len--) {
+    auto qualifier_offset = table_qualifier.size() - prefix_len;
+    bool matches = true;
+    for (idx_t i = 0; i < prefix_len; i++) {
+      if (!StringUtil::CIEquals(column_names[i],
+                                table_qualifier[qualifier_offset + i])) {
+        matches = false;
+        break;
+      }
+    }
+    if (matches) {
+      return vector<string>(column_names.begin() + prefix_len,
+                            column_names.end());
+    }
+  }
+
+  return column_names;
+}
+
+static bool TryParseLanceFieldPathSegments(const string &path,
+                                           vector<string> &out_segments) {
+  out_segments.clear();
+  auto s = TrimCopy(path);
+  if (s.empty()) {
+    return false;
+  }
+
+  idx_t i = 0;
+  while (i < s.size()) {
+    string segment;
+    if (s[i] == '`') {
+      i++;
+      bool closed = false;
+      while (i < s.size()) {
+        auto c = s[i];
+        if (c == '`') {
+          if (i + 1 < s.size() && s[i + 1] == '`') {
+            segment.push_back('`');
+            i += 2;
+            continue;
+          }
+          i++;
+          closed = true;
+          break;
+        }
+        segment.push_back(c);
+        i++;
+      }
+      if (!closed) {
+        return false;
+      }
+    } else {
+      auto start = i;
+      while (i < s.size() && s[i] != '.') {
+        if (s[i] == '`') {
+          return false;
+        }
+        i++;
+      }
+      segment = s.substr(start, i - start);
+    }
+
+    if (segment.empty()) {
+      return false;
+    }
+    out_segments.push_back(std::move(segment));
+
+    if (i == s.size()) {
+      return true;
+    }
+    if (s[i] != '.') {
+      return false;
+    }
+    i++;
+    if (i == s.size()) {
+      return false;
+    }
+  }
+
+  return !out_segments.empty();
+}
+
+static string NormalizeTableIndexColumnPath(const string &column,
+                                            const QualifiedName &table_name) {
+  vector<string> segments;
+  if (!TryParseLanceFieldPathSegments(column, segments)) {
+    return column;
+  }
+
+  vector<string> table_qualifier = {table_name.catalog, table_name.schema,
+                                    table_name.name};
+  return FormatLanceFieldPath(
+      StripMatchingColumnQualifier(segments, table_qualifier));
+}
+
 static bool StartsWithQuotedString(const string &sql) {
   return !sql.empty() && sql[0] == '\'';
 }
@@ -117,21 +264,35 @@ static bool TryParseParenList(const string &sql, vector<string> &out_items,
   idx_t i = 1;
   idx_t start = i;
   bool in_str = false;
+  bool in_backtick = false;
   for (; i < s.size(); i++) {
     auto c = s[i];
-    if (c == '\'') {
-      if (in_str) {
+    if (in_str) {
+      if (c == '\'') {
         if (i + 1 < s.size() && s[i + 1] == '\'') {
           i++;
           continue;
         }
         in_str = false;
-      } else {
-        in_str = true;
       }
       continue;
     }
-    if (in_str) {
+    if (in_backtick) {
+      if (c == '`') {
+        if (i + 1 < s.size() && s[i + 1] == '`') {
+          i++;
+          continue;
+        }
+        in_backtick = false;
+      }
+      continue;
+    }
+    if (c == '\'') {
+      in_str = true;
+      continue;
+    }
+    if (c == '`') {
+      in_backtick = true;
       continue;
     }
     if (c == ',') {
@@ -1229,6 +1390,7 @@ public:
       throw IOException("Failed to create Lance index" +
                         LanceFormatErrorSuffix());
     }
+    LanceInvalidateDatasetCacheForTable(client_context, table);
 
     chunk.SetCardinality(0);
     return SourceResultType::FINISHED;
@@ -1246,7 +1408,8 @@ private:
   bool train;
 };
 
-static string GetSingleColumnNameOrThrow(const CreateIndexInfo &info) {
+static string GetSingleColumnNameOrThrow(const CreateIndexInfo &info,
+                                         const TableCatalogEntry &table) {
   if (info.parsed_expressions.size() != 1) {
     throw NotImplementedException(
         "Lance CREATE INDEX currently supports a single column");
@@ -1260,7 +1423,11 @@ static string GetSingleColumnNameOrThrow(const CreateIndexInfo &info) {
   if (col_ref.column_names.empty()) {
     throw InternalException("column ref has no column names");
   }
-  return col_ref.column_names.back();
+  vector<string> table_qualifier = {table.catalog.GetName(),
+                                    table.ParentSchema().name, table.name};
+  auto field_path_segments =
+      StripMatchingColumnQualifier(col_ref.column_names, table_qualifier);
+  return FormatLanceFieldPath(field_path_segments);
 }
 
 static PhysicalOperator &LanceBtreeCreatePlan(PlanIndexInput &input) {
@@ -1273,7 +1440,7 @@ static PhysicalOperator &LanceBtreeCreatePlan(PlanIndexInput &input) {
         "BTREE index type is only supported for Lance tables");
   }
 
-  auto column = GetSingleColumnNameOrThrow(*op.info);
+  auto column = GetSingleColumnNameOrThrow(*op.info, *lance_table);
   auto index_type = NormalizeIndexType(op.info->index_type);
 
   bool replace = false;
@@ -1613,13 +1780,15 @@ LanceIndexPlan(ParserExtensionInfo *, ClientContext &context,
       if (!qname) {
         throw InternalException("CREATE INDEX is missing a target");
       }
+      auto column =
+          NormalizeTableIndexColumnPath(parse_data->columns[0], *qname);
       result.function = LanceCreateIndexTableTableFunction();
       result.parameters = {
           Value(qname->catalog),
           Value(qname->schema),
           Value(qname->name),
           Value(parse_data->index_name),
-          Value(parse_data->columns[0]),
+          Value(std::move(column)),
           Value(parse_data->index_type),
           Value(parse_data->params_json),
           Value::BOOLEAN(parse_data->replace),

--- a/src/lance_scan.cpp
+++ b/src/lance_scan.cpp
@@ -49,6 +49,7 @@
 #include "lance_table_entry.hpp"
 
 #include <atomic>
+#include <cctype>
 #include <cmath>
 #include <cstdint>
 #include <cstring>
@@ -74,6 +75,98 @@
 namespace duckdb {
 
 static TableFunction LanceExecFunction();
+
+static bool LanceFieldPathSegmentNeedsQuoting(const string &segment) {
+  if (segment.empty()) {
+    return true;
+  }
+  for (auto c : segment) {
+    if (std::isalnum(static_cast<unsigned char>(c)) == 0 && c != '_') {
+      return true;
+    }
+  }
+  return false;
+}
+
+static string FormatLanceFieldPath(const vector<string> &segments) {
+  if (segments.empty()) {
+    return "";
+  }
+
+  string out;
+  for (idx_t i = 0; i < segments.size(); i++) {
+    if (i > 0) {
+      out.push_back('.');
+    }
+
+    auto &segment = segments[i];
+    if (!LanceFieldPathSegmentNeedsQuoting(segment)) {
+      out += segment;
+      continue;
+    }
+
+    out.push_back('`');
+    for (auto c : segment) {
+      if (c == '`') {
+        out += "``";
+      } else {
+        out.push_back(c);
+      }
+    }
+    out.push_back('`');
+  }
+  return out;
+}
+
+static bool TryBuildLanceColumnIndexPath(const vector<string> &names,
+                                         const vector<LogicalType> &types,
+                                         const ColumnIndex &col_index,
+                                         string &out_path) {
+  out_path.clear();
+  if (col_index.IsVirtualColumn()) {
+    return false;
+  }
+
+  auto col_id = col_index.GetPrimaryIndex();
+  if (col_id >= names.size() || col_id >= types.size()) {
+    return false;
+  }
+
+  vector<string> segments;
+  segments.push_back(names[col_id]);
+  auto leaf_type = types[col_id];
+
+  std::function<bool(const vector<ColumnIndex> &)> append_children;
+  append_children = [&](const vector<ColumnIndex> &children) -> bool {
+    if (children.empty()) {
+      return true;
+    }
+    if (children.size() != 1) {
+      return false;
+    }
+
+    auto &child = children[0];
+    if (child.IsVirtualColumn()) {
+      return false;
+    }
+    auto child_idx = child.GetPrimaryIndex();
+    if (leaf_type.id() != LogicalTypeId::STRUCT ||
+        child_idx >= StructType::GetChildCount(leaf_type)) {
+      return false;
+    }
+
+    segments.push_back(StructType::GetChildName(leaf_type, child_idx));
+    leaf_type = StructType::GetChildType(leaf_type, child_idx);
+    return append_children(child.GetChildIndexes());
+  };
+
+  if (!append_children(col_index.GetChildIndexes())) {
+    return false;
+  }
+
+  out_path = FormatLanceFieldPath(segments);
+  return !out_path.empty();
+}
 
 static unique_ptr<BaseStatistics>
 LanceScanStatistics(ClientContext &context, const FunctionData *bind_data_p,
@@ -1335,9 +1428,17 @@ LanceScanInitGlobal(ClientContext &context, TableFunctionInitInput &input) {
       for (auto &it : input.filters->filters) {
         auto scan_col_idx = it.first;
         if (scan_col_idx < input.column_ids.size()) {
-          auto col_id = input.column_ids[scan_col_idx];
-          if (col_id < bind_data.names.size()) {
-            filtered_columns.insert(bind_data.names[col_id]);
+          string filtered_path;
+          if (scan_col_idx < input.column_indexes.size() &&
+              TryBuildLanceColumnIndexPath(bind_data.names, bind_data.types,
+                                           input.column_indexes[scan_col_idx],
+                                           filtered_path)) {
+            filtered_columns.insert(std::move(filtered_path));
+          } else {
+            auto col_id = input.column_ids[scan_col_idx];
+            if (col_id < bind_data.names.size()) {
+              filtered_columns.insert(bind_data.names[col_id]);
+            }
           }
         }
       }

--- a/test/sql/index_ddl.test
+++ b/test/sql/index_ddl.test
@@ -218,6 +218,85 @@ SELECT count(*) FROM 'test/.tmp/index_ddl_base.lance' WHERE label % 2 = 1;
 ----
 physical_plan	<REGEX>:[\s\S]*"Lance Pushed Filter Parts": "0"[\s\S]*
 
+# Nested field index lifecycle: creation target, escaped literal-dot path,
+# same-leaf disambiguation, and canonical metadata display.
+statement ok
+COPY (
+  SELECT
+    {'value': i, 'same': i + 10} AS left_struct,
+    {'value': i * 2, 'same': i + 20} AS right_struct,
+    {'literal.dot': i + 100} AS dotted,
+    {'a,b': i + 200, 'a)b': i + 300, 'a`b': i + 400} AS escaped
+  FROM range(8) tbl(i)
+) TO 'test/.tmp/index_ddl_nested.lance' (FORMAT lance, mode 'overwrite');
+
+statement ok
+CREATE INDEX left_value_idx ON 'test/.tmp/index_ddl_nested.lance' (left_struct.value)
+USING BTREE;
+
+statement ok
+CREATE INDEX dotted_literal_idx ON 'test/.tmp/index_ddl_nested.lance' (dotted.`literal.dot`)
+USING BTREE;
+
+statement ok
+CREATE INDEX path_comma_idx ON 'test/.tmp/index_ddl_nested.lance' (escaped.`a,b`)
+USING BTREE;
+
+statement ok
+CREATE INDEX path_paren_idx ON 'test/.tmp/index_ddl_nested.lance' (escaped.`a)b`)
+USING BTREE;
+
+statement ok
+CREATE INDEX path_backtick_idx ON 'test/.tmp/index_ddl_nested.lance' (escaped.`a``b`)
+USING BTREE;
+
+query TTTIT
+SHOW INDEXES ON 'test/.tmp/index_ddl_nested.lance';
+----
+dotted_literal_idx	<REGEX>:.*	dotted.`literal.dot`	8	<REGEX>:.*|NULL
+left_value_idx	<REGEX>:.*	left_struct.value	8	<REGEX>:.*|NULL
+path_backtick_idx	<REGEX>:.*	escaped.`a``b`	8	<REGEX>:.*|NULL
+path_comma_idx	<REGEX>:.*	escaped.`a,b`	8	<REGEX>:.*|NULL
+path_paren_idx	<REGEX>:.*	escaped.`a)b`	8	<REGEX>:.*|NULL
+
+statement ok
+ATTACH 'test/.tmp' AS nested_ns (TYPE LANCE);
+
+query II
+EXPLAIN (FORMAT JSON)
+SELECT count(*) FROM nested_ns.main.index_ddl_nested WHERE right_struct.value = 4;
+----
+physical_plan	<REGEX>:[\s\S]*"Lance Dataset Cache Hit": "false"[\s\S]*
+
+statement ok
+CREATE INDEX right_value_idx ON nested_ns.main.index_ddl_nested (index_ddl_nested.right_struct.value)
+USING BTREE;
+
+query TTTIT
+SHOW INDEXES ON nested_ns.main.index_ddl_nested;
+----
+dotted_literal_idx	<REGEX>:.*	dotted.`literal.dot`	8	<REGEX>:.*|NULL
+left_value_idx	<REGEX>:.*	left_struct.value	8	<REGEX>:.*|NULL
+path_backtick_idx	<REGEX>:.*	escaped.`a``b`	8	<REGEX>:.*|NULL
+path_comma_idx	<REGEX>:.*	escaped.`a,b`	8	<REGEX>:.*|NULL
+path_paren_idx	<REGEX>:.*	escaped.`a)b`	8	<REGEX>:.*|NULL
+right_value_idx	<REGEX>:.*	right_struct.value	8	<REGEX>:.*|NULL
+
+query II
+EXPLAIN (ANALYZE, FORMAT JSON)
+SELECT count(*) FROM nested_ns.main.index_ddl_nested WHERE right_struct.value = 4;
+----
+analyzed_plan	<REGEX>:[\s\S]*"Lance Dataset Cache Hit": "false"[\s\S]*"Lance Scan Mode": "dataset"[\s\S]*
+
+statement error
+CREATE INDEX ambiguous_leaf_idx ON 'test/.tmp/index_ddl_nested.lance' (value)
+USING BTREE;
+----
+IO Error: Failed to create Lance index
+
+statement ok
+DETACH nested_ns;
+
 statement ok
 COPY (SELECT * FROM 'test/data/bigann_tiny/base.lance')
 TO 'test/.tmp/index_ddl_untrained.lance' (FORMAT lance, mode 'overwrite');


### PR DESCRIPTION
## Summary

This PR adds nested field path support across the Lance index lifecycle in DuckDB. It canonicalizes index targets through Lance schema field paths, preserves case-insensitive field resolution, handles escaped literal path segments, and keeps SHOW INDEXES / scanner index selection aligned on canonical nested paths.

The change fixes cases where nested fields with the same leaf name, literal dots, or qualified table references could not be indexed or displayed consistently. It also invalidates the attached-table dataset cache after native CREATE INDEX so follow-up scans can observe the new index metadata.

## Validation

- `uv run make format`
- `cargo fmt --manifest-path Cargo.toml --check`
- `cargo check --manifest-path Cargo.toml`
- `cargo test --manifest-path Cargo.toml ffi::index::tests`
- `GEN=ninja make debug`
- `./build/debug/test/unittest test/sql/index_ddl.test`
- `./build/debug/test/unittest test/sql/scan_index_aware_scanner.test`
