### PR TITLE
Fix/rest namespace multilevel

### DIFF
--- a/rust/ffi/namespace.rs
+++ b/rust/ffi/namespace.rs
@@ -193,13 +193,16 @@ fn describe_table_info_inner(
         api_key.as_deref(),
         headers_tsv.as_deref(),
     )
-    .delimiter(delimiter)
+    .delimiter(delimiter.clone())
     .build();
 
     let (location, storage_options_tsv) = runtime::block_on(async move {
         record_namespace_describe();
         let mut req = DescribeTableRequest::new();
-        req.id = Some(vec![table_id.to_string()]);
+        // FIX: a qualified table id (e.g. "catalog.schema.table") must be sent as
+        // its multi-segment namespace path, not a single segment. Split on the
+        // delimiter so the server sees the full 3-level id instead of "got: 1".
+        req.id = Some(table_id.split(delimiter.as_str()).map(|s| s.to_string()).collect());
         req.with_table_uri = Some(true);
         let resp = namespace.describe_table(req).await.map_err(|err| {
             FfiError::new(
@@ -300,12 +303,14 @@ fn create_empty_table_inner(
         api_key.as_deref(),
         headers_tsv.as_deref(),
     )
-    .delimiter(delimiter)
+    .delimiter(delimiter.clone())
     .build();
 
+    let table_id_segments: Vec<String> =
+        table_id.split(delimiter.as_str()).map(|s| s.to_string()).collect();
     let (location, storage_options_tsv) = runtime::block_on(async move {
         let mut req = DeclareTableRequest::new();
-        req.id = Some(vec![table_id.to_string()]);
+        req.id = Some(table_id_segments);
         let resp = namespace.declare_table(req).await.map_err(|err| {
             FfiError::new(
                 ErrorCode::NamespaceCreateEmptyTable,
@@ -405,12 +410,14 @@ fn drop_table_inner(
         api_key.as_deref(),
         headers_tsv.as_deref(),
     )
-    .delimiter(delimiter)
+    .delimiter(delimiter.clone())
     .build();
 
+    let table_id_segments: Vec<String> =
+        table_id.split(delimiter.as_str()).map(|s| s.to_string()).collect();
     runtime::block_on(async move {
         let mut req = DropTableRequest::new();
-        req.id = Some(vec![table_id.to_string()]);
+        req.id = Some(table_id_segments);
         match namespace.drop_table(req).await {
             Ok(_) => Ok(()),
             Err(LanceError::NotFound { .. }) => Ok(()),
@@ -475,12 +482,13 @@ fn describe_table_with_schema_inner(
         api_key.as_deref(),
         headers_tsv.as_deref(),
     )
-    .delimiter(delimiter)
+    .delimiter(delimiter.clone())
     .build();
 
     let schema_json = runtime::block_on(async move {
         let mut req = DescribeTableRequest::new();
-        req.id = Some(vec![table_id.to_string()]);
+        // FIX: split the qualified id into its namespace segments (see describe_table_info_inner).
+        req.id = Some(table_id.split(delimiter.as_str()).map(|s| s.to_string()).collect());
         req.with_table_uri = Some(true);
         req.load_detailed_metadata = Some(true);
         let resp = namespace.describe_table(req).await.map_err(|err| {
@@ -574,14 +582,18 @@ fn open_dataset_in_namespace_inner(
         api_key.as_deref(),
         headers_tsv.as_deref(),
     )
-    .delimiter(delimiter)
+    .delimiter(delimiter.clone())
     .build();
     let session = unsafe { optional_session_handle(session)? };
+    // FIX: split the qualified id into namespace segments so the crate's internal
+    // describe (DatasetBuilder::from_namespace) gets the full 3-level id, not 1.
+    let table_id_segments: Vec<String> =
+        table_id.split(delimiter.as_str()).map(|s| s.to_string()).collect();
 
     let (dataset, table_uri) = runtime::block_on(async move {
         record_namespace_describe();
         let mut builder =
-            DatasetBuilder::from_namespace(Arc::new(namespace), vec![table_id.to_string()])
+            DatasetBuilder::from_namespace(Arc::new(namespace), table_id_segments)
                 .await
                 .map_err(|err| {
                     FfiError::new(

--- a/src/lance_storage.cpp
+++ b/src/lance_storage.cpp
@@ -411,6 +411,25 @@ public:
   unique_ptr<CatalogEntry>
   CreateDefaultEntry(ClientContext &context,
                      const string &entry_name) override {
+    // Only resolve names that are real tables in this namespace. DuckDB probes
+    // the active catalog for system names (e.g. duckdb_tables when SHOW TABLES
+    // runs under `USE <lance_catalog>`); without this guard we'd try to open
+    // those as Lance datasets and throw, aborting the statement. Returning
+    // nullptr (not found) lets resolution fall through to the system catalog.
+    {
+      auto known = GetDefaultEntries();
+      bool found = false;
+      for (auto &k : known) {
+        if (k == entry_name) {
+          found = true;
+          break;
+        }
+      }
+      if (!found) {
+        return nullptr;
+      }
+    }
+
     unordered_map<string, Value> overrides;
     if (!bearer_token_override.empty()) {
       overrides["bearer_token"] = Value(bearer_token_override);
@@ -464,9 +483,18 @@ public:
     // Slow fallback: open dataset from S3.
     for (auto &table_id : candidates) {
       string table_uri;
-      auto *dataset = LanceOpenDatasetInNamespace(
-          context, endpoint, table_id, resolved_bearer, resolved_api_key,
-          delimiter, headers_tsv, table_uri);
+      void *dataset = nullptr;
+      try {
+        dataset = LanceOpenDatasetInNamespace(
+            context, endpoint, table_id, resolved_bearer, resolved_api_key,
+            delimiter, headers_tsv, table_uri);
+      } catch (...) {
+        // Unresolvable candidate (e.g. a DuckDB system name like
+        // duckdb_tables that SHOW TABLES resolves against the active catalog,
+        // or an invalid 1-segment id) — skip it instead of aborting the
+        // whole statement.
+        continue;
+      }
       if (!dataset) {
         continue;
       }


### PR DESCRIPTION
   
Closes: #226 
                                                                                                                               
> Problem:   
                                                                                                                 
On the current release, reading a Lance table from a multi-level REST namespace (e.g. Apache Gravitino, where a table is     catalog.schema.table) fails  SELECT, DESCRIBE, and SHOW TABLES all error:                                                   
                                                                                                                               
```
 namespace describe_table: Expected at 3-level namespace but got: 1                                                           
  lance-namespace-impls-6.0.0/src/rest.rs:560      
```                                                                          
                                                                                                                               
**Before** (official v1.5.4)

<img width="2062" height="1420" alt="image" src="https://github.com/user-attachments/assets/fba99deb-395f-4c5c-a474-20a051a7e0c1" />


> Root cause:    

                                                                                                              
rust/ffi/namespace.rs sends the whole qualified id as a single namespace segment (req.id = Some(vec![table_id])), so the   server receives a 1-level id and rejects it. The delimiter was in scope but never used to split the id.  

> Fix:  

                                                                                                                                                                                                                                                  
Split table_id on the configured delimiter so a qualified id is sent as its real multi-level path. Applied at all 5          
id-assembly sites: describe_table (location + schema), open_dataset_in_namespace (DatasetBuilder::from_namespace),           
declare_table, drop_table.                                                                                                   
                                                                                                                               
  - req.id = Some(vec![table_id.to_string()]);                                                                                 
  + req.id = Some(table_id.split(delimiter.as_str()).map(|s| s.to_string()).collect());                                        
                                                                                                                               
**After** (patched build, same Gravitino namespace):  SHOW ALL TABLES lists tables, SELECT * FROM             
lance_ns.main.users returns rows.
  
<img width="2062" height="1542" alt="image" src="https://github.com/user-attachments/assets/f665eb1f-0971-4330-a4cb-02b1a39de2e8" />


> No regressions:   

                                                                                                            
                                                                                                                               
For single-segment ids (the existing single-namespace flow, e.g. the LanceDB-Cloud example in docs/rest.md), the split is a  
no-op: "users".split(".") → ["users"], identical to today. Only previously-broken multi-level ids change  from error to     
correct.                                                                                                                     
                                                                                                                               

> Repro:      

                                                                                                                  
```
                                                                                                                               
ATTACH 'lance_lakehouse.lance_smoke' AS lance_ns (TYPE LANCE, ENDPOINT '<lance-rest>/lance', DELIMITER '.');                 
SELECT * FROM lance_ns.main.users;   -- before: "Expected 3-level … got: 1";  after: rows                                    
SHOW ALL TABLES;                     -- after: lists the namespace's tables         
```                                         
                                                                                                                               
(Second commit, flagged for review): fail-soft catalog resolution so SHOW TABLES under USE <lance_catalog> doesn't abort  when DuckDB probes the active catalog for its own duckdb_tables system table returns not-found instead of throwing.      
                                                                                                                            