### PR TITLE
fix: update ethnum for newer Rust toolchains

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2096,9 +2096,9 @@ dependencies = [
 
 [[package]]
 name = "ethnum"
-version = "1.5.2"
+version = "1.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca81e6b4777c89fd810c25a4be2b1bd93ea034fbe58e6a75216a34c6b82c539b"
+checksum = "40404c3f5f511ec4da6fe866ddf6a717c309fdbb69fbbad7b0f3edab8f2e835f"
 
 [[package]]
 name = "event-listener"


### PR DESCRIPTION
`ethnum` 1.5.2 constructs `TryFromIntError` by transmuting `()`, which no longer compiles after the standard library type changed layout in newer Rust toolchains. Update the lockfile to `ethnum` 1.5.3, which removes that layout assumption and constructs the error through the standard integer conversion API.
