### PR TITLE
feat(scan): push REST namespace scans through query_table

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -137,6 +137,7 @@ set(RUST_FFI_DEPENDS
     ${CMAKE_CURRENT_LIST_DIR}/rust/ffi/knn.rs
     ${CMAKE_CURRENT_LIST_DIR}/rust/ffi/mod.rs
     ${CMAKE_CURRENT_LIST_DIR}/rust/ffi/projection.rs
+    ${CMAKE_CURRENT_LIST_DIR}/rust/ffi/query_table.rs
     ${CMAKE_CURRENT_LIST_DIR}/rust/ffi/scan.rs
 	    ${CMAKE_CURRENT_LIST_DIR}/rust/ffi/search.rs
 	    ${CMAKE_CURRENT_LIST_DIR}/rust/ffi/stream.rs

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,6 +44,7 @@ if(APPLE)
   endif()
   set(PLATFORM_LIBS
       "-framework CoreFoundation"
+      "-framework IOKit"
       "-framework SystemConfiguration"
       "-framework Security")
 elseif(UNIX)

--- a/docs/rest.md
+++ b/docs/rest.md
@@ -9,6 +9,7 @@ A Lance REST Namespace provides a centralized catalog for managing Lance tables.
 - Listing tables in a namespace
 - Creating and dropping tables
 - Describing tables (getting location and storage credentials)
+- Querying tables through the `query_table` API
 - Credential vending for accessing underlying storage (S3, GCS, Azure, etc.)
 
 ## Prerequisites
@@ -102,6 +103,13 @@ INSERT INTO users VALUES
 ```
 
 ### 5. Query Data
+
+For tables attached through a REST Namespace, `SELECT` is executed through the
+Lance Namespace `query_table` API. DuckDB pushes the required projection,
+supported `WHERE` predicates, and `LIMIT`/`OFFSET` pairs into the request and
+reads the Arrow IPC response. Reads therefore do not require DuckDB to open the
+underlying object-store location directly. Unsupported predicates remain in
+DuckDB, and an `OFFSET` without a `LIMIT` is also evaluated by DuckDB.
 
 ```sql
 -- Select all rows

--- a/docs/sql.md
+++ b/docs/sql.md
@@ -169,6 +169,11 @@ SELECT count(*) FROM ns.main.some_table;
 DETACH ns;
 ```
 
+Scans of REST namespace tables use the Lance Namespace `query_table` API.
+Projection, supported filters, and `LIMIT`/`OFFSET` pairs are pushed into the
+request; unsupported filters and standalone `OFFSET` operations remain in
+DuckDB. Directory namespace scans continue to read the Lance dataset directly.
+
 ## Write datasets
 
 ### `COPY ... TO ... (FORMAT lance, ...)`

--- a/rust/ffi/query_table.rs
+++ b/rust/ffi/query_table.rs
@@ -5,6 +5,9 @@ use std::ptr;
 
 use arrow::array::RecordBatch;
 use arrow::ipc::reader::{FileReader, StreamReader};
+use datafusion_expr::Expr;
+use datafusion_sql::unparser::dialect::CustomDialectBuilder;
+use datafusion_sql::unparser::Unparser;
 use lance_namespace::models::{
     QueryTableRequest, QueryTableRequestColumns, QueryTableRequestFullTextQuery,
     QueryTableRequestVector, StringFtsQuery,
@@ -16,13 +19,13 @@ use crate::error::{clear_last_error, set_last_error, ErrorCode};
 use crate::runtime;
 
 use super::types::StreamHandle;
-use super::util::{cstr_to_str, slice_from_ptr, FfiError, FfiResult};
+use super::util::{cstr_to_str, parse_optional_filter_ir, slice_from_ptr, FfiError, FfiResult};
 
 const NAMESPACE_KIND_DIRECTORY: u8 = 0;
 const NAMESPACE_KIND_REST: u8 = 1;
 
 #[repr(C)]
-pub struct LanceNamespaceSearchConfig {
+pub struct LanceNamespaceQueryConfig {
     namespace_kind: u8,
     root: *const c_char,
     option_keys: *const *const c_char,
@@ -71,7 +74,7 @@ enum NamespaceBackend {
     },
 }
 
-struct ParsedConfig {
+struct ParsedNamespaceQueryConfig {
     backend: NamespaceBackend,
     table_id: String,
     columns: Vec<String>,
@@ -159,21 +162,23 @@ fn parse_headers_tsv(headers_tsv: Option<&str>) -> Vec<(String, String)> {
         .unwrap_or_default()
 }
 
-unsafe fn parse_config(config: *const LanceNamespaceSearchConfig) -> FfiResult<ParsedConfig> {
+unsafe fn parse_config(
+    config: *const LanceNamespaceQueryConfig,
+) -> FfiResult<ParsedNamespaceQueryConfig> {
     if config.is_null() {
         return Err(FfiError::new(
             ErrorCode::InvalidArgument,
-            "namespace search config is null",
+            "namespace query config is null",
         ));
     }
     let config = unsafe { &*config };
     let table_id = unsafe { cstr_to_str(config.table_id, "table_id")? }.to_string();
     let columns = unsafe { parse_string_array(config.columns, config.columns_len, "columns")? };
     let filter = unsafe { optional_cstr_to_string(config.filter, "filter")? };
-    let k = if config.k == 0 || config.k > i32::MAX as u64 {
+    let k = if config.k > i32::MAX as u64 {
         return Err(FfiError::new(
             ErrorCode::InvalidArgument,
-            "k must be in the range 1..=i32::MAX",
+            "k must fit in i32",
         ));
     } else {
         config.k as i32
@@ -215,7 +220,7 @@ unsafe fn parse_config(config: *const LanceNamespaceSearchConfig) -> FfiResult<P
         }
     };
 
-    Ok(ParsedConfig {
+    Ok(ParsedNamespaceQueryConfig {
         backend,
         table_id,
         columns,
@@ -225,8 +230,18 @@ unsafe fn parse_config(config: *const LanceNamespaceSearchConfig) -> FfiResult<P
     })
 }
 
-fn apply_base_request(config: &ParsedConfig, request: &mut QueryTableRequest) {
-    request.id = Some(vec![config.table_id.clone()]);
+fn apply_base_request(config: &ParsedNamespaceQueryConfig, request: &mut QueryTableRequest) {
+    request.id = Some(match &config.backend {
+        NamespaceBackend::Rest { delimiter, .. } => {
+            let delimiter = delimiter.as_deref().unwrap_or("$");
+            config
+                .table_id
+                .split(delimiter)
+                .map(str::to_string)
+                .collect()
+        }
+        NamespaceBackend::Directory { .. } => vec![config.table_id.clone()],
+    });
     request.prefilter = Some(config.prefilter);
     if !config.columns.is_empty() {
         let mut columns = QueryTableRequestColumns::new();
@@ -239,7 +254,7 @@ fn apply_base_request(config: &ParsedConfig, request: &mut QueryTableRequest) {
 }
 
 async fn execute_query_table(
-    config: ParsedConfig,
+    config: ParsedNamespaceQueryConfig,
     request: QueryTableRequest,
 ) -> FfiResult<Vec<u8>> {
     match config.backend {
@@ -330,16 +345,167 @@ fn ipc_bytes_to_batches(bytes: Vec<u8>) -> FfiResult<Vec<RecordBatch>> {
     }
 }
 
-fn execute_to_stream(config: ParsedConfig, request: QueryTableRequest) -> FfiResult<StreamHandle> {
+fn execute_to_stream(
+    config: ParsedNamespaceQueryConfig,
+    request: QueryTableRequest,
+) -> FfiResult<StreamHandle> {
     let bytes = runtime::block_on(execute_query_table(config, request))
         .map_err(|err| FfiError::new(ErrorCode::Runtime, format!("runtime: {err}")))??;
     let batches = ipc_bytes_to_batches(bytes)?;
     Ok(StreamHandle::Batches(batches.into_iter()))
 }
 
+fn filter_expr_to_sql(expr: &Expr) -> FfiResult<String> {
+    let dialect = CustomDialectBuilder::new()
+        .with_identifier_quote_style('`')
+        .build();
+    Unparser::new(&dialect)
+        .expr_to_sql(expr)
+        .map(|sql| sql.to_string())
+        .map_err(|err| {
+            FfiError::new(
+                ErrorCode::NamespaceQueryTable,
+                format!("unparse namespace scan filter: {err}"),
+            )
+        })
+}
+
+fn build_namespace_scan_request(
+    config: &ParsedNamespaceQueryConfig,
+    filter_expr: Option<&Expr>,
+    limit: i64,
+    offset: i64,
+    with_row_id: bool,
+) -> FfiResult<QueryTableRequest> {
+    if limit < -1 {
+        return Err(FfiError::new(
+            ErrorCode::InvalidArgument,
+            "namespace scan limit must be >= -1",
+        ));
+    }
+    if offset < 0 {
+        return Err(FfiError::new(
+            ErrorCode::InvalidArgument,
+            "namespace scan offset must be non-negative",
+        ));
+    }
+    if limit == -1 && offset != 0 {
+        return Err(FfiError::new(
+            ErrorCode::InvalidArgument,
+            "namespace query_table cannot apply OFFSET without LIMIT",
+        ));
+    }
+
+    let k = if limit == -1 {
+        0
+    } else {
+        i32::try_from(limit).map_err(|_| {
+            FfiError::new(
+                ErrorCode::InvalidArgument,
+                "namespace scan limit must fit in i32",
+            )
+        })?
+    };
+    let offset = i32::try_from(offset).map_err(|_| {
+        FfiError::new(
+            ErrorCode::InvalidArgument,
+            "namespace scan offset must fit in i32",
+        )
+    })?;
+
+    let mut request = QueryTableRequest::new(k, QueryTableRequestVector::new());
+    apply_base_request(config, &mut request);
+    request.prefilter = None;
+    if offset != 0 {
+        request.offset = Some(offset);
+    }
+    if with_row_id {
+        request.with_row_id = Some(true);
+        let mut clear_columns = false;
+        if let Some(columns) = request.columns.as_mut() {
+            if let Some(column_names) = columns.column_names.as_mut() {
+                column_names.retain(|name| name != "_rowid");
+                clear_columns = column_names.is_empty();
+            }
+        }
+        if clear_columns {
+            request.columns = None;
+        }
+    }
+
+    if let Some(filter_expr) = filter_expr {
+        let filter_sql = filter_expr_to_sql(filter_expr)?;
+        request.filter = Some(match request.filter.take() {
+            Some(existing) => format!("({existing}) AND ({filter_sql})"),
+            None => filter_sql,
+        });
+    }
+    Ok(request)
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn lance_create_namespace_scan_stream_ir(
+    config: *const LanceNamespaceQueryConfig,
+    filter_ir: *const u8,
+    filter_ir_len: usize,
+    limit: i64,
+    offset: i64,
+    with_row_id: u8,
+) -> *mut c_void {
+    match unsafe {
+        create_namespace_scan_stream_ir_inner(
+            config,
+            filter_ir,
+            filter_ir_len,
+            limit,
+            offset,
+            with_row_id,
+        )
+    } {
+        Ok(stream) => {
+            clear_last_error();
+            Box::into_raw(Box::new(stream)) as *mut c_void
+        }
+        Err(err) => {
+            set_last_error(err.code, err.message);
+            ptr::null_mut()
+        }
+    }
+}
+
+unsafe fn create_namespace_scan_stream_ir_inner(
+    config: *const LanceNamespaceQueryConfig,
+    filter_ir: *const u8,
+    filter_ir_len: usize,
+    limit: i64,
+    offset: i64,
+    with_row_id: u8,
+) -> FfiResult<StreamHandle> {
+    let config = unsafe { parse_config(config)? };
+    let filter_expr = unsafe {
+        parse_optional_filter_ir(
+            filter_ir,
+            filter_ir_len,
+            ErrorCode::NamespaceQueryTable,
+            "namespace scan filter_ir",
+        )?
+    };
+    let request = build_namespace_scan_request(
+        &config,
+        filter_expr.as_ref(),
+        limit,
+        offset,
+        with_row_id != 0,
+    )?;
+    if limit == 0 {
+        return Ok(StreamHandle::Batches(Vec::new().into_iter()));
+    }
+    execute_to_stream(config, request)
+}
+
 #[no_mangle]
 pub unsafe extern "C" fn lance_create_namespace_vector_search_stream(
-    config: *const LanceNamespaceSearchConfig,
+    config: *const LanceNamespaceQueryConfig,
     options: *const LanceNamespaceVectorSearchOptions,
 ) -> *mut c_void {
     match create_namespace_vector_search_stream_inner(config, options) {
@@ -355,7 +521,7 @@ pub unsafe extern "C" fn lance_create_namespace_vector_search_stream(
 }
 
 unsafe fn create_namespace_vector_search_stream_inner(
-    config: *const LanceNamespaceSearchConfig,
+    config: *const LanceNamespaceQueryConfig,
     options: *const LanceNamespaceVectorSearchOptions,
 ) -> FfiResult<StreamHandle> {
     if options.is_null() {
@@ -365,6 +531,12 @@ unsafe fn create_namespace_vector_search_stream_inner(
         ));
     }
     let config = unsafe { parse_config(config)? };
+    if config.k == 0 {
+        return Err(FfiError::new(
+            ErrorCode::InvalidArgument,
+            "namespace vector search k must be positive",
+        ));
+    }
     let options = unsafe { &*options };
     let vector_column = unsafe { cstr_to_str(options.vector_column, "vector_column")? };
     let query_values =
@@ -399,7 +571,7 @@ unsafe fn create_namespace_vector_search_stream_inner(
 
 #[no_mangle]
 pub unsafe extern "C" fn lance_create_namespace_fts_search_stream(
-    config: *const LanceNamespaceSearchConfig,
+    config: *const LanceNamespaceQueryConfig,
     options: *const LanceNamespaceFtsSearchOptions,
 ) -> *mut c_void {
     match create_namespace_fts_search_stream_inner(config, options) {
@@ -415,7 +587,7 @@ pub unsafe extern "C" fn lance_create_namespace_fts_search_stream(
 }
 
 unsafe fn create_namespace_fts_search_stream_inner(
-    config: *const LanceNamespaceSearchConfig,
+    config: *const LanceNamespaceQueryConfig,
     options: *const LanceNamespaceFtsSearchOptions,
 ) -> FfiResult<StreamHandle> {
     if options.is_null() {
@@ -425,6 +597,12 @@ unsafe fn create_namespace_fts_search_stream_inner(
         ));
     }
     let config = unsafe { parse_config(config)? };
+    if config.k == 0 {
+        return Err(FfiError::new(
+            ErrorCode::InvalidArgument,
+            "namespace FTS search k must be positive",
+        ));
+    }
     let options = unsafe { &*options };
     let text_column = unsafe { cstr_to_str(options.text_column, "text_column")? };
     let query = unsafe { cstr_to_str(options.query, "query")? };
@@ -439,4 +617,62 @@ unsafe fn create_namespace_fts_search_stream_inner(
     request.full_text_query = Some(Box::new(fts_query));
 
     execute_to_stream(config, request)
+}
+
+#[cfg(test)]
+mod tests {
+    use datafusion_expr::{col, lit};
+
+    use super::*;
+
+    fn rest_config(columns: &[&str]) -> ParsedNamespaceQueryConfig {
+        ParsedNamespaceQueryConfig {
+            backend: NamespaceBackend::Rest {
+                endpoint: "http://localhost:8000".to_string(),
+                bearer_token: None,
+                api_key: None,
+                delimiter: Some("$".to_string()),
+                headers: Vec::new(),
+            },
+            table_id: "parent$child$table".to_string(),
+            columns: columns.iter().map(|column| (*column).to_string()).collect(),
+            filter: None,
+            k: 0,
+            prefilter: true,
+        }
+    }
+
+    #[test]
+    fn namespace_scan_request_pushes_query_shape() {
+        let config = rest_config(&["name", "_rowid"]);
+        let filter = col("age").gt(lit(21));
+        let request = build_namespace_scan_request(&config, Some(&filter), 5, 2, true).unwrap();
+
+        assert_eq!(
+            request.id,
+            Some(vec![
+                "parent".to_string(),
+                "child".to_string(),
+                "table".to_string()
+            ])
+        );
+        assert_eq!(request.k, 5);
+        assert_eq!(request.offset, Some(2));
+        assert_eq!(request.with_row_id, Some(true));
+        assert_eq!(request.prefilter, None);
+        assert_eq!(
+            request.columns.unwrap().column_names,
+            Some(vec!["name".to_string()])
+        );
+        let filter = request.filter.unwrap();
+        assert!(filter.contains("age"));
+        assert!(filter.contains("21"));
+    }
+
+    #[test]
+    fn namespace_scan_request_rejects_offset_without_limit() {
+        let config = rest_config(&["name"]);
+        let error = build_namespace_scan_request(&config, None, -1, 1, false).unwrap_err();
+        assert!(error.message.contains("cannot apply OFFSET without LIMIT"));
+    }
 }

--- a/rust/ffi/session.rs
+++ b/rust/ffi/session.rs
@@ -3,7 +3,9 @@ use std::ptr;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 
+use lance::dataset::{DEFAULT_INDEX_CACHE_SIZE, DEFAULT_METADATA_CACHE_SIZE};
 use lance::session::Session;
+use lance_core::cache::{CacheBackend, MokaCacheBackend};
 
 use crate::error::{clear_last_error, set_last_error, ErrorCode};
 
@@ -62,24 +64,42 @@ fn create_session_inner(
     index_cache_size_bytes: u64,
     metadata_cache_size_bytes: u64,
 ) -> FfiResult<SessionHandle> {
-    let session = if index_cache_size_bytes == 0 && metadata_cache_size_bytes == 0 {
-        Arc::new(Session::default())
-    } else {
-        Arc::new(Session::new(
-            u64_to_usize(index_cache_size_bytes, "index_cache_size_bytes")?,
-            u64_to_usize(metadata_cache_size_bytes, "metadata_cache_size_bytes")?,
-            Default::default(),
-        ))
-    };
-    Ok(SessionHandle { session })
+    let (index_cache_size_bytes, metadata_cache_size_bytes) =
+        if index_cache_size_bytes == 0 && metadata_cache_size_bytes == 0 {
+            (DEFAULT_INDEX_CACHE_SIZE, DEFAULT_METADATA_CACHE_SIZE)
+        } else {
+            (
+                u64_to_usize(index_cache_size_bytes, "index_cache_size_bytes")?,
+                u64_to_usize(metadata_cache_size_bytes, "metadata_cache_size_bytes")?,
+            )
+        };
+    let index_cache: Arc<dyn CacheBackend> =
+        Arc::new(MokaCacheBackend::with_capacity(index_cache_size_bytes));
+    let session = Arc::new(Session::with_index_cache_backend(
+        index_cache.clone(),
+        metadata_cache_size_bytes,
+        Default::default(),
+    ));
+    Ok(SessionHandle {
+        session,
+        index_cache,
+    })
+}
+
+fn clear_session_caches(handle: &SessionHandle) {
+    if let Some(runtime) = crate::runtime::initialized_runtime() {
+        runtime.block_on(async {
+            handle.index_cache.clear().await;
+            handle.session.file_metadata_cache().clear().await;
+        });
+    }
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn lance_close_session(session: *mut c_void) {
     if !session.is_null() {
-        unsafe {
-            let _ = Box::from_raw(session as *mut SessionHandle);
-        }
+        let handle = unsafe { Box::from_raw(session as *mut SessionHandle) };
+        clear_session_caches(&handle);
     }
 }
 

--- a/rust/ffi/types.rs
+++ b/rust/ffi/types.rs
@@ -4,6 +4,7 @@ use arrow::array::RecordBatch;
 use arrow::datatypes::Schema;
 use lance::session::Session;
 use lance::Dataset;
+use lance_core::cache::CacheBackend;
 
 use crate::datafusion_stream::DataFusionStream;
 use crate::scanner::{LanceStream, LanceTakeStream};
@@ -14,6 +15,8 @@ pub(crate) type SchemaHandle = Arc<Schema>;
 
 pub(crate) struct SessionHandle {
     pub(crate) session: Arc<Session>,
+    // Lance does not expose clearing its index cache through Session.
+    pub(crate) index_cache: Arc<dyn CacheBackend>,
 }
 
 pub(crate) struct DatasetHandle {

--- a/rust/runtime.rs
+++ b/rust/runtime.rs
@@ -13,6 +13,10 @@ pub fn runtime() -> Result<&'static Runtime, io::Error> {
     }
 }
 
+pub fn initialized_runtime() -> Option<&'static Runtime> {
+    RUNTIME.get()?.as_ref().ok()
+}
+
 pub fn handle() -> Result<Handle, io::Error> {
     Ok(runtime()?.handle().clone())
 }

--- a/src/include/lance_common.hpp
+++ b/src/include/lance_common.hpp
@@ -2,6 +2,8 @@
 
 #include "duckdb.hpp"
 
+struct LanceNamespaceQueryConfig;
+
 namespace duckdb {
 
 string LanceConsumeLastError();
@@ -83,6 +85,14 @@ bool TryLanceNamespaceDropTable(ClientContext &context, const string &endpoint,
 
 struct LanceNamespaceTableConfig;
 class LanceTableEntry;
+
+void FillLanceNamespaceQueryConfig(
+    ClientContext &context, const LanceNamespaceTableConfig &cfg, uint64_t k,
+    bool prefilter, const string &filter, const vector<string> &columns,
+    vector<const char *> &option_key_ptrs,
+    vector<const char *> &option_value_ptrs, vector<const char *> &column_ptrs,
+    string &bearer_token, string &api_key,
+    ::LanceNamespaceQueryConfig &out_config);
 
 string LanceDirectoryNamespaceDatasetUri(const LanceNamespaceTableConfig &cfg);
 

--- a/src/include/lance_ffi.hpp
+++ b/src/include/lance_ffi.hpp
@@ -272,7 +272,7 @@ void *lance_create_fts_stream_ir(void *dataset, const char *text_column,
                                  const uint8_t *filter_ir, size_t filter_ir_len,
                                  uint8_t prefilter);
 
-typedef struct LanceNamespaceSearchConfig {
+typedef struct LanceNamespaceQueryConfig {
   uint8_t namespace_kind;
   const char *root;
   const char **option_keys;
@@ -289,7 +289,7 @@ typedef struct LanceNamespaceSearchConfig {
   const char *filter;
   uint64_t k;
   uint8_t prefilter;
-} LanceNamespaceSearchConfig;
+} LanceNamespaceQueryConfig;
 
 typedef struct LanceNamespaceVectorSearchOptions {
   const char *vector_column;
@@ -306,11 +306,14 @@ typedef struct LanceNamespaceFtsSearchOptions {
 } LanceNamespaceFtsSearchOptions;
 
 void *lance_create_namespace_vector_search_stream(
-    const LanceNamespaceSearchConfig *config,
+    const LanceNamespaceQueryConfig *config,
     const LanceNamespaceVectorSearchOptions *options);
 void *lance_create_namespace_fts_search_stream(
-    const LanceNamespaceSearchConfig *config,
+    const LanceNamespaceQueryConfig *config,
     const LanceNamespaceFtsSearchOptions *options);
+void *lance_create_namespace_scan_stream_ir(
+    const LanceNamespaceQueryConfig *config, const uint8_t *filter_ir,
+    size_t filter_ir_len, int64_t limit, int64_t offset, uint8_t with_row_id);
 
 void *lance_get_hybrid_schema(void *dataset);
 void *lance_create_hybrid_stream_ir(

--- a/src/include/lance_scan_bind_data.hpp
+++ b/src/include/lance_scan_bind_data.hpp
@@ -11,6 +11,7 @@
 
 namespace duckdb {
 class TableCatalogEntry;
+struct LanceNamespaceTableConfig;
 
 struct LanceScanBindData : public TableFunctionData {
   string file_path;
@@ -27,6 +28,7 @@ struct LanceScanBindData : public TableFunctionData {
   vector<string> lance_pushed_filter_ir_parts;
   vector<string> duckdb_pushed_filter_sql_parts;
   optional_ptr<TableCatalogEntry> table_entry = nullptr;
+  unique_ptr<LanceNamespaceTableConfig> namespace_query_config;
 
   bool sampling_pushed_down = false;
   double sample_percentage = 0.0;
@@ -37,6 +39,8 @@ struct LanceScanBindData : public TableFunctionData {
   bool limit_offset_pushed_down = false;
   optional_idx pushed_limit = optional_idx::Invalid();
   idx_t pushed_offset = 0;
+
+  bool UsesNamespaceQuery() const { return namespace_query_config != nullptr; }
 
   ~LanceScanBindData() override;
 };

--- a/src/lance_common.cpp
+++ b/src/lance_common.cpp
@@ -50,6 +50,69 @@ bool IsComputedSearchColumn(const string &name) {
   return name == "_distance" || name == "_score" || name == "_hybrid_score";
 }
 
+static void BuildStringPointerArray(const vector<string> &values,
+                                    vector<const char *> &out_ptrs) {
+  out_ptrs.clear();
+  out_ptrs.reserve(values.size());
+  for (auto &value : values) {
+    out_ptrs.push_back(value.c_str());
+  }
+}
+
+void FillLanceNamespaceQueryConfig(
+    ClientContext &context, const LanceNamespaceTableConfig &cfg, uint64_t k,
+    bool prefilter, const string &filter, const vector<string> &columns,
+    vector<const char *> &option_key_ptrs,
+    vector<const char *> &option_value_ptrs, vector<const char *> &column_ptrs,
+    string &bearer_token, string &api_key,
+    LanceNamespaceQueryConfig &out_config) {
+  static constexpr uint8_t NAMESPACE_KIND_DIRECTORY = 0;
+  static constexpr uint8_t NAMESPACE_KIND_REST = 1;
+
+  out_config = {};
+  out_config.table_id = cfg.table_id.c_str();
+  out_config.k = k;
+  out_config.prefilter = prefilter ? 1 : 0;
+  out_config.filter = filter.empty() ? nullptr : filter.c_str();
+
+  BuildStringPointerArray(columns, column_ptrs);
+  out_config.columns = column_ptrs.empty() ? nullptr : column_ptrs.data();
+  out_config.columns_len = column_ptrs.size();
+
+  if (cfg.IsDirectory()) {
+    out_config.namespace_kind = NAMESPACE_KIND_DIRECTORY;
+    out_config.root = cfg.root.c_str();
+    BuildStorageOptionPointerArrays(cfg.option_keys, cfg.option_values,
+                                    option_key_ptrs, option_value_ptrs);
+    out_config.option_keys =
+        option_key_ptrs.empty() ? nullptr : option_key_ptrs.data();
+    out_config.option_values =
+        option_value_ptrs.empty() ? nullptr : option_value_ptrs.data();
+    out_config.options_len = option_key_ptrs.size();
+    return;
+  }
+
+  out_config.namespace_kind = NAMESPACE_KIND_REST;
+  out_config.endpoint = cfg.endpoint.c_str();
+  out_config.delimiter =
+      cfg.delimiter.empty() ? nullptr : cfg.delimiter.c_str();
+  out_config.headers_tsv =
+      cfg.headers_tsv.empty() ? nullptr : cfg.headers_tsv.c_str();
+
+  unordered_map<string, Value> overrides;
+  if (!cfg.bearer_token_override.empty()) {
+    overrides["bearer_token"] = Value(cfg.bearer_token_override);
+  }
+  if (!cfg.api_key_override.empty()) {
+    overrides["api_key"] = Value(cfg.api_key_override);
+  }
+  ResolveLanceNamespaceAuth(context, cfg.endpoint, overrides, bearer_token,
+                            api_key);
+  out_config.bearer_token =
+      bearer_token.empty() ? nullptr : bearer_token.c_str();
+  out_config.api_key = api_key.empty() ? nullptr : api_key.c_str();
+}
+
 string LanceNormalizeS3Scheme(const string &path) {
   if (StringUtil::StartsWith(path, "s3a://")) {
     return "s3://" + path.substr(6);

--- a/src/lance_scan.cpp
+++ b/src/lance_scan.cpp
@@ -427,6 +427,7 @@ struct LanceScanGlobalState : public GlobalTableFunctionState {
   std::atomic<idx_t> filter_pushdown_fallbacks{0};
 
   bool use_dataset_scanner = false;
+  bool use_namespace_query = false;
   bool sampling_pushed_down = false;
   double sample_percentage = 0.0;
   int64_t sample_seed = -1;
@@ -816,7 +817,7 @@ LancePushdownComplexFilter(ClientContext &context, LogicalGet &get,
     if (!expr || expr->HasParameter() || expr->IsVolatile()) {
       continue;
     }
-    if (scan_bind.take_row_ids.empty()) {
+    if (!scan_bind.UsesNamespaceQuery() && scan_bind.take_row_ids.empty()) {
       vector<uint64_t> take_row_ids;
       if (try_extract_rowids(*expr, take_row_ids) && !take_row_ids.empty()) {
         scan_bind.take_row_ids = std::move(take_row_ids);
@@ -1177,6 +1178,39 @@ LanceScanInitGlobal(ClientContext &context, TableFunctionInitInput &input) {
     }
     scan_state.filter_pushed_down =
         table_filters.all_filters_pushed && !scan_state.lance_filter_ir.empty();
+  }
+
+  if (bind_data.UsesNamespaceQuery()) {
+    if (scan_state.sampling_pushed_down) {
+      throw InternalException(
+          "Lance namespace query_table scan does not support sampling");
+    }
+
+    scan_state.use_namespace_query = true;
+    scan_state.use_dataset_scanner = true;
+    scan_state.max_threads = 1;
+
+    if (scan_state.pushed_limit.IsValid() &&
+        scan_state.pushed_limit.GetIndex() == 0) {
+      scan_state.count_only = true;
+      scan_state.count_only_total_rows = 0;
+      return state;
+    }
+
+    // query_table treats an omitted projection as "all columns". Request one
+    // physical column for count(*) and rowid-only scans so the response has a
+    // stable, minimal schema while preserving its row count.
+    bool has_physical_column = false;
+    for (auto col_id : scan_state.scan_column_ids) {
+      if (col_id < bind_data.types.size()) {
+        has_physical_column = true;
+        break;
+      }
+    }
+    if (!has_physical_column && !bind_data.names.empty()) {
+      add_scan_column(0, bind_data.names[0], bind_data.types[0]);
+    }
+    return state;
   }
 
   if (!bind_data.take_row_ids.empty()) {
@@ -1544,7 +1578,45 @@ static bool LanceScanOpenStream(ClientContext &context,
       global_state.filter_pushed_down && filter_ir && filter_ir_len > 0;
 
   void *stream = nullptr;
-  if (global_state.sampling_pushed_down) {
+  if (global_state.use_namespace_query) {
+    if (!bind_data.namespace_query_config) {
+      throw InternalException(
+          "Lance namespace query scan is missing its namespace config");
+    }
+
+    vector<const char *> option_key_ptrs;
+    vector<const char *> option_value_ptrs;
+    vector<const char *> namespace_column_ptrs;
+    string bearer_token;
+    string api_key;
+    LanceNamespaceQueryConfig config{};
+    FillLanceNamespaceQueryConfig(
+        context, *bind_data.namespace_query_config, 0, true, "",
+        global_state.scan_column_names, option_key_ptrs, option_value_ptrs,
+        namespace_column_ptrs, bearer_token, api_key, config);
+
+    auto limit_i64 =
+        global_state.pushed_limit.IsValid()
+            ? NumericCast<int64_t>(global_state.pushed_limit.GetIndex())
+            : int64_t(-1);
+    auto offset_i64 = NumericCast<int64_t>(global_state.pushed_offset);
+    stream = lance_create_namespace_scan_stream_ir(
+        &config, filter_ir, filter_ir_len, limit_i64, offset_i64,
+        global_state.scan_includes_virtual_rowid ? 1 : 0);
+    if (!stream && filter_ir) {
+      if (global_state.limit_offset_pushed_down) {
+        throw IOException("Lance namespace query_table filter pushdown failed" +
+                          LanceFormatErrorSuffix());
+      }
+      // Without a pushed LIMIT, retrying without the remote filter preserves
+      // correctness because DuckDB still evaluates the predicate locally.
+      global_state.filter_pushdown_fallbacks.fetch_add(1);
+      local_state.filter_pushed_down = false;
+      stream = lance_create_namespace_scan_stream_ir(
+          &config, nullptr, 0, limit_i64, offset_i64,
+          global_state.scan_includes_virtual_rowid ? 1 : 0);
+    }
+  } else if (global_state.sampling_pushed_down) {
     local_state.filter_pushed_down = false;
     stream = lance_create_dataset_sample_stream_ir(
         bind_data.dataset, columns.data(), columns.size(),
@@ -1600,8 +1672,10 @@ static bool LanceScanOpenStream(ClientContext &context,
     }
   }
   if (!stream) {
-    throw IOException("Failed to create Lance scan stream" +
-                      LanceFormatErrorSuffix());
+    auto message = global_state.use_namespace_query
+                       ? "Failed to create Lance namespace query_table stream"
+                       : "Failed to create Lance scan stream";
+    throw IOException(message + LanceFormatErrorSuffix());
   }
   global_state.streams_opened.fetch_add(1);
   local_state.stream = stream;
@@ -1962,6 +2036,8 @@ LanceScanToString(TableFunctionToStringInput &input) {
       bind_data.explain_verbose ? "true" : "false";
   result["Lance Pushed Filter Parts"] =
       to_string(bind_data.lance_pushed_filter_ir_parts.size());
+  result["Lance Scan Backend"] =
+      bind_data.UsesNamespaceQuery() ? "namespace_query_table" : "dataset";
   result["Lance Dataset Cache Hit"] =
       bind_data.dataset_cache_hit ? "true" : "false";
   result["Lance Sampling Pushdown"] =
@@ -1989,14 +2065,16 @@ LanceScanToString(TableFunctionToStringInput &input) {
 
   string plan;
   string error;
-  if (TryLanceExplainDatasetScan(
-          bind_data.dataset, nullptr,
-          filter_ir_msg.empty() ? nullptr : &filter_ir_msg,
-          bind_data.pushed_limit, bind_data.pushed_offset,
-          bind_data.explain_verbose, plan, error)) {
-    result["Lance Plan (Bind)"] = plan;
-  } else if (!error.empty()) {
-    result["Lance Plan Error (Bind)"] = error;
+  if (!bind_data.UsesNamespaceQuery()) {
+    if (TryLanceExplainDatasetScan(
+            bind_data.dataset, nullptr,
+            filter_ir_msg.empty() ? nullptr : &filter_ir_msg,
+            bind_data.pushed_limit, bind_data.pushed_offset,
+            bind_data.explain_verbose, plan, error)) {
+      result["Lance Plan (Bind)"] = plan;
+    } else if (!error.empty()) {
+      result["Lance Plan Error (Bind)"] = error;
+    }
   }
 
   return result;
@@ -2013,8 +2091,12 @@ LanceScanDynamicToString(TableFunctionDynamicToStringInput &input) {
       bind_data.explain_verbose ? "true" : "false";
   result["Lance Dataset Cache Hit"] =
       bind_data.dataset_cache_hit ? "true" : "false";
-  result["Lance Scan Mode"] =
-      global_state.use_dataset_scanner ? "dataset" : "fragment";
+  result["Lance Scan Backend"] =
+      global_state.use_namespace_query ? "namespace_query_table" : "dataset";
+  result["Lance Scan Mode"] = global_state.use_namespace_query
+                                  ? "namespace_query_table"
+                              : global_state.use_dataset_scanner ? "dataset"
+                                                                 : "fragment";
   result["Lance Deferred Materialization"] =
       global_state.deferred_materialization ? "true" : "false";
   if (global_state.deferred_materialization) {
@@ -2060,6 +2142,10 @@ LanceScanDynamicToString(TableFunctionDynamicToStringInput &input) {
   if (!global_state.scan_column_names.empty()) {
     result["Lance Projection"] =
         StringUtil::Join(global_state.scan_column_names, "\n");
+  }
+
+  if (global_state.use_namespace_query) {
+    return result;
   }
 
   if (!global_state.explain_computed.load()) {
@@ -2278,6 +2364,9 @@ LanceRowIdInRewrite(unique_ptr<LogicalOperator> op) {
       return op;
     }
     auto &scan_bind = get.bind_data->Cast<LanceScanBindData>();
+    if (scan_bind.UsesNamespaceQuery()) {
+      return op;
+    }
 
     column_t filter_col_id = LANCE_COLUMN_IDENTIFIER_ROW_ID;
     auto it = get.table_filters.filters.find(filter_col_id);
@@ -2350,6 +2439,9 @@ LanceRowIdInRewrite(unique_ptr<LogicalOperator> op) {
     return op;
   }
   auto &scan_bind = get.bind_data->Cast<LanceScanBindData>();
+  if (scan_bind.UsesNamespaceQuery()) {
+    return op;
+  }
 
   vector<uint64_t> row_ids;
   idx_t idx = 0;
@@ -2517,6 +2609,15 @@ LanceLimitOffsetPushdown(unique_ptr<LogicalOperator> op) {
   }
 
   auto &scan_bind = get.bind_data->Cast<LanceScanBindData>();
+  if (scan_bind.UsesNamespaceQuery()) {
+    auto max_query_value =
+        static_cast<idx_t>(std::numeric_limits<int32_t>::max());
+    if ((!pushed_limit.IsValid() && pushed_offset != 0) ||
+        (pushed_limit.IsValid() && pushed_limit.GetIndex() > max_query_value) ||
+        pushed_offset > max_query_value) {
+      return op;
+    }
+  }
   if (!scan_bind.take_row_ids.empty()) {
     return op;
   }
@@ -2626,6 +2727,10 @@ LanceExecPushdown(ClientContext &context, Optimizer &optimizer,
       return bail("Lance exec pushdown: expected Lance scan LogicalGet");
     }
     auto &scan_bind = scan_get.bind_data->Cast<LanceScanBindData>();
+    if (scan_bind.UsesNamespaceQuery()) {
+      return bail(
+          "Lance exec pushdown: namespace query_table scans not supported");
+    }
 
     vector<string> filter_parts;
     string filter_ir_msg;
@@ -3697,12 +3802,56 @@ unique_ptr<CatalogEntry> LanceTableEntry::Copy(ClientContext &context) const {
   return unique_ptr_cast<LanceTableEntry, CatalogEntry>(std::move(copy));
 }
 
+static void PopulateNamespaceQueryScanSchema(ClientContext &context,
+                                             const LanceTableEntry &table,
+                                             LanceScanBindData &result) {
+  vector<string> field_names;
+  vector<LogicalType> field_types;
+  field_names.reserve(table.GetColumns().PhysicalColumnCount());
+  field_types.reserve(table.GetColumns().PhysicalColumnCount());
+  for (auto &column : table.GetColumns().Physical()) {
+    field_names.push_back(column.Name());
+    field_types.push_back(column.Type());
+  }
+
+  memset(&result.schema_root.arrow_schema, 0,
+         sizeof(result.schema_root.arrow_schema));
+  auto properties = context.GetClientProperties();
+  ArrowConverter::ToArrowSchema(&result.schema_root.arrow_schema, field_types,
+                                field_names, properties);
+  LanceCoerceArrowSchemaForDuckDB(&result.schema_root.arrow_schema);
+  ArrowTableFunction::PopulateArrowTableSchema(context, result.arrow_table,
+                                               result.schema_root.arrow_schema);
+  result.names = result.arrow_table.GetNames();
+  result.types = result.arrow_table.GetTypes();
+
+  field_names.push_back(LANCE_ROW_ID_COLUMN_NAME);
+  field_types.push_back(LogicalType::UBIGINT);
+  memset(&result.scan_schema_root.arrow_schema, 0,
+         sizeof(result.scan_schema_root.arrow_schema));
+  ArrowConverter::ToArrowSchema(&result.scan_schema_root.arrow_schema,
+                                field_types, field_names, properties);
+  LanceCoerceArrowSchemaForDuckDB(&result.scan_schema_root.arrow_schema);
+  ArrowTableFunction::PopulateArrowTableSchema(
+      context, result.scan_arrow_table, result.scan_schema_root.arrow_schema);
+}
+
 TableFunction
 LanceTableEntry::GetScanFunction(ClientContext &context,
                                  unique_ptr<FunctionData> &bind_data) {
   auto result = make_uniq<LanceScanBindData>();
   result->table_entry = this;
   result->file_path = dataset_uri;
+
+  if (IsNamespaceBacked() && NamespaceConfig().IsRest()) {
+    result->namespace_query_config =
+        make_uniq<LanceNamespaceTableConfig>(NamespaceConfig());
+    PopulateNamespaceQueryScanSchema(context, *this, *result);
+    bind_data = std::move(result);
+    auto function = LanceTableScanFunction();
+    function.sampling_pushdown = false;
+    return function;
+  }
 
   string display_uri;
   result->dataset_entry = LanceGetOrOpenDatasetEntryForTable(

--- a/src/lance_search.cpp
+++ b/src/lance_search.cpp
@@ -249,69 +249,6 @@ static void PopulateNamespaceSearchSchema(
   return_types = result_types;
 }
 
-static void BuildStringPointerArray(const vector<string> &values,
-                                    vector<const char *> &out_ptrs) {
-  out_ptrs.clear();
-  out_ptrs.reserve(values.size());
-  for (auto &value : values) {
-    out_ptrs.push_back(value.c_str());
-  }
-}
-
-static void FillNamespaceSearchConfig(
-    ClientContext &context, const LanceNamespaceTableConfig &cfg, uint64_t k,
-    bool prefilter, const string &filter, const vector<string> &columns,
-    vector<const char *> &option_key_ptrs,
-    vector<const char *> &option_value_ptrs, vector<const char *> &column_ptrs,
-    string &bearer_token, string &api_key,
-    LanceNamespaceSearchConfig &out_config) {
-  static constexpr uint8_t NAMESPACE_KIND_DIRECTORY = 0;
-  static constexpr uint8_t NAMESPACE_KIND_REST = 1;
-
-  out_config = {};
-  out_config.table_id = cfg.table_id.c_str();
-  out_config.k = k;
-  out_config.prefilter = prefilter ? 1 : 0;
-  out_config.filter = filter.empty() ? nullptr : filter.c_str();
-
-  BuildStringPointerArray(columns, column_ptrs);
-  out_config.columns = column_ptrs.empty() ? nullptr : column_ptrs.data();
-  out_config.columns_len = column_ptrs.size();
-
-  if (cfg.IsDirectory()) {
-    out_config.namespace_kind = NAMESPACE_KIND_DIRECTORY;
-    out_config.root = cfg.root.c_str();
-    BuildStorageOptionPointerArrays(cfg.option_keys, cfg.option_values,
-                                    option_key_ptrs, option_value_ptrs);
-    out_config.option_keys =
-        option_key_ptrs.empty() ? nullptr : option_key_ptrs.data();
-    out_config.option_values =
-        option_value_ptrs.empty() ? nullptr : option_value_ptrs.data();
-    out_config.options_len = option_key_ptrs.size();
-    return;
-  }
-
-  out_config.namespace_kind = NAMESPACE_KIND_REST;
-  out_config.endpoint = cfg.endpoint.c_str();
-  out_config.delimiter =
-      cfg.delimiter.empty() ? nullptr : cfg.delimiter.c_str();
-  out_config.headers_tsv =
-      cfg.headers_tsv.empty() ? nullptr : cfg.headers_tsv.c_str();
-
-  unordered_map<string, Value> overrides;
-  if (!cfg.bearer_token_override.empty()) {
-    overrides["bearer_token"] = Value(cfg.bearer_token_override);
-  }
-  if (!cfg.api_key_override.empty()) {
-    overrides["api_key"] = Value(cfg.api_key_override);
-  }
-  ResolveLanceNamespaceAuth(context, cfg.endpoint, overrides, bearer_token,
-                            api_key);
-  out_config.bearer_token =
-      bearer_token.empty() ? nullptr : bearer_token.c_str();
-  out_config.api_key = api_key.empty() ? nullptr : api_key.c_str();
-}
-
 struct LanceKnnBindData : public TableFunctionData {
   string file_path;
   string vector_column;
@@ -678,8 +615,8 @@ LanceKnnLocalInit(ExecutionContext &context, TableFunctionInitInput &input,
     vector<const char *> column_ptrs;
     string bearer_token;
     string api_key;
-    LanceNamespaceSearchConfig config;
-    FillNamespaceSearchConfig(
+    LanceNamespaceQueryConfig config;
+    FillLanceNamespaceQueryConfig(
         context.client, bind_data.namespace_config, bind_data.k,
         bind_data.prefilter, bind_data.namespace_filter,
         global.namespace_columns, option_key_ptrs, option_value_ptrs,
@@ -1076,8 +1013,8 @@ static bool LanceSearchLoadNextBatch(ClientContext &context,
       vector<const char *> column_ptrs;
       string bearer_token;
       string api_key;
-      LanceNamespaceSearchConfig config;
-      FillNamespaceSearchConfig(
+      LanceNamespaceQueryConfig config;
+      FillLanceNamespaceQueryConfig(
           context, bind_data.namespace_config, bind_data.k, bind_data.prefilter,
           bind_data.namespace_filter, global.namespace_columns, option_key_ptrs,
           option_value_ptrs, column_ptrs, bearer_token, api_key, config);

--- a/test/sql/namespace_rest_attach.test
+++ b/test/sql/namespace_rest_attach.test
@@ -20,6 +20,12 @@ SHOW TABLES FROM ns.main
 ----
 ${LANCE_NAMESPACE_TABLE}
 
+query II
+EXPLAIN (FORMAT JSON)
+SELECT * FROM ns.main."${LANCE_NAMESPACE_TABLE}" LIMIT 1;
+----
+physical_plan	<REGEX>:[\s\S]*"Lance Scan Backend": "namespace_query_table"[\s\S]*"Lance Limit Offset Pushdown": "true"[\s\S]*
+
 query I
 SELECT count(*) FROM ns.main."${LANCE_NAMESPACE_TABLE}"
 ----


### PR DESCRIPTION
REST namespace scans currently resolve table locations and open the underlying Lance dataset, bypassing the LanceDB query API and requiring direct storage access. This PR follows lance-spark's query pushdown design by routing those scans through `query_table`, pushing projection, supported filters, and bounded LIMIT/OFFSET while preserving DuckDB fallback semantics. Directory namespaces and direct dataset scans retain their existing behavior. Session shutdown now also drains Lance caches so indexed-search resources are released cleanly after the Lance 8 upgrade.
