### PR TITLE
chore: update lance dependency to v9.0.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,24 +19,24 @@ panic = "abort"
 [dependencies]
 
 # Lance and Arrow dependencies - using compatible versions
-lance = { version = "8.0.0", default-features = false, features = ["aws", "azure", "gcp", "oss", "huggingface"] }
-lance-arrow = "8.0.0"
-lance-core = "8.0.0"
-lance-index = "8.0.0"
-lance-linalg = "8.0.0"
-lance-namespace = "8.0.0"
-lance-namespace-impls = { version = "8.0.0", features = ["rest"] }
-lance-table = "8.0.0"
+lance = { version = "9.0.0", default-features = false, features = ["aws", "azure", "gcp", "oss", "huggingface"] }
+lance-arrow = "9.0.0"
+lance-core = "9.0.0"
+lance-index = "9.0.0"
+lance-linalg = "9.0.0"
+lance-namespace = "9.0.0"
+lance-namespace-impls = { version = "9.0.0", features = ["rest"] }
+lance-table = "9.0.0"
 
 arrow = { version = "58.0.0", features = ["ffi"] }
 arrow-array = "58.0.0"
 arrow-schema = "58.0.0"
 
-datafusion = "53.0.0"
-datafusion-common = "53.0.0"
-datafusion-expr = "53.0.0"
-datafusion-functions = "53.0.0"
-datafusion-sql = "53.0.0"
+datafusion = "54.0.0"
+datafusion-common = "54.0.0"
+datafusion-expr = "54.0.0"
+datafusion-functions = "54.0.0"
+datafusion-sql = "54.0.0"
 
 anyhow = "1.0"
 async-trait = "0.1"

--- a/rust/ffi/exec.rs
+++ b/rust/ffi/exec.rs
@@ -105,10 +105,6 @@ struct LanceExecTableProvider {
 
 #[async_trait::async_trait]
 impl TableProvider for LanceExecTableProvider {
-    fn as_any(&self) -> &dyn std::any::Any {
-        self
-    }
-
     fn schema(&self) -> arrow::datatypes::SchemaRef {
         self.schema.clone()
     }


### PR DESCRIPTION
## Summary

Updates the lance crates from 8.0.0 to 9.0.0 (and datafusion 53 -> 54, which lance v9 builds against).

The main motivation is that lance v9.0.0 carries the nested-list decoder fix (lance-format/lance#7546, fixes lance-format/lance#7538): reading a `List<List<T>>` column that was written in multiple batches fails with

```
Invalid argument error: Max offset of N exceeds length of values M
  rust/lance-encoding/src/encodings/logical/list.rs
```

whenever a read batch spans a page boundary. We hit this in production through this extension (`lance-encoding 4.0.1` at our pinned build, but any lance < 9 is affected, including current main on 8.0.0) on a table with a `list<struct<..., values: list<list<float>>>>` column.

## Changes

- `Cargo.toml`: `lance*` 8.0.0 -> 9.0.0, `datafusion*` 53.0.0 -> 54.0.0 (matching lance v9's datafusion pin), `Cargo.lock` regenerated
- `rust/ffi/exec.rs`: drop the `as_any` method from the `TableProvider` impl — it is no longer a member of the trait in datafusion 54

## Testing

- `cargo check` passes with zero errors on the bumped dependency set
- The affected production table reads correctly with a lance >= 9 reader (verified via pylance 9.1.0b2 scanning the previously-failing multi-batch nested-list column — same data, no rewrite), consistent with the upstream fix being reader-side only
- We will additionally validate the bundled extension end-to-end via our engine's integration suite when picking this commit up on our side