### PR TITLE
feat(pushdown): push array_has_any/array_has_all

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 
 ## [Unreleased]
 
+### Added
+
+- `array_has_any` / `array_has_all` (and their `list_has_any` / `list_has_all` aliases) on `LIST` columns are now pushed down to Lance, where a `LABEL_LIST` index turns them into an index query instead of a scan.
+
 ### Fixed
 
 - List child fields written by `COPY`, `INSERT`, `CREATE TABLE`, CTAS and `ALTER TABLE` are now named `item` (Arrow's convention) instead of DuckDB's `l`. Lance persists the name, and DataFusion's array-function coercion casts any column that disagrees, which hides list columns from Lance's scalar-index planner. Appends to datasets written before this change keep their existing field names.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 
 - `array_has_any` / `array_has_all` (and their `list_has_any` / `list_has_all` aliases) on `LIST` columns are now pushed down to Lance, where a `LABEL_LIST` index turns them into an index query instead of a scan.
 - `lance_fts` and `lance_hybrid_search` now push scalar-function predicates (containment, `starts_with`, `LIKE`, `regexp_matches`) to Lance as a prefilter. Previously only simple comparisons reached Lance from those two functions, and `prefilter := true` silently ignored everything else.
+- Searches over namespace-backed tables now prefilter on a pushed `WHERE` clause. `lance_vector_search` and `lance_fts` previously rejected `prefilter := true` on such tables unless the caller passed an explicit `filter := '<string>'` argument, because a pushed predicate could not reach the namespace request. A pushed predicate is now unparsed into that request, and combines with an explicit `filter` argument when both are present.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 
 ## [Unreleased]
 
+### Fixed
+
+- List child fields written by `COPY`, `INSERT`, `CREATE TABLE`, CTAS and `ALTER TABLE` are now named `item` (Arrow's convention) instead of DuckDB's `l`. Lance persists the name, and DataFusion's array-function coercion casts any column that disagrees, which hides list columns from Lance's scalar-index planner. Appends to datasets written before this change keep their existing field names.
+
 ### Changed
 
 - `COPY`, `CREATE TABLE`, and CTAS now default new or replaced datasets to Lance data storage version `2.2`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,11 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 ### Added
 
 - `array_has_any` / `array_has_all` (and their `list_has_any` / `list_has_all` aliases) on `LIST` columns are now pushed down to Lance, where a `LABEL_LIST` index turns them into an index query instead of a scan.
+- `lance_fts` and `lance_hybrid_search` now push scalar-function predicates (containment, `starts_with`, `LIKE`, `regexp_matches`) to Lance as a prefilter. Previously only simple comparisons reached Lance from those two functions, and `prefilter := true` silently ignored everything else.
 
 ### Fixed
 
-- List child fields written by `COPY`, `INSERT`, `CREATE TABLE`, CTAS and `ALTER TABLE` are now named `item` (Arrow's convention) instead of DuckDB's `l`. Lance persists the name, and DataFusion's array-function coercion casts any column that disagrees, which hides list columns from Lance's scalar-index planner. Appends to datasets written before this change keep their existing field names.
+- List child fields written by `COPY`, `INSERT`, `CREATE TABLE`, CTAS and `ALTER TABLE` are now named `item` (Arrow's convention) instead of DuckDB's `l`. Lance persists the name, and DataFusion's array-function coercion casts any column that disagrees, which hid list columns from Lance's scalar-index planner. Appends to datasets written before this change keep their existing field names.
 
 ### Changed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3872,6 +3872,7 @@ dependencies = [
  "datafusion-common",
  "datafusion-expr",
  "datafusion-functions",
+ "datafusion-functions-nested",
  "datafusion-sql",
  "futures",
  "lance",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -263,7 +263,7 @@ dependencies = [
  "arrow-select",
  "chrono",
  "half",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "itoa",
  "lexical-core",
  "memchr",
@@ -385,7 +385,7 @@ checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -396,7 +396,7 @@ checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -838,15 +838,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 
 [[package]]
-name = "bitpacking"
-version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96a7139abd3d9cebf8cd6f920a389cf3dc9576172e32f4563f188cae3c3eb019"
-dependencies = [
- "crunchy",
-]
-
-[[package]]
 name = "bitvec"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -960,6 +951,20 @@ name = "bytemuck"
 version = "1.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
+dependencies = [
+ "bytemuck_derive",
+]
+
+[[package]]
+name = "bytemuck_derive"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f65693059b6b9c588b9f62fed1cedbf0a8b805631457ea162d68f0de186f3de5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "byteorder"
@@ -1422,7 +1427,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1433,7 +1438,7 @@ checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
  "darling_core",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1452,14 +1457,13 @@ dependencies = [
 
 [[package]]
 name = "datafusion"
-version = "53.1.0"
+version = "54.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93db0e623840612f7f2cd757f7e8a8922064192363732c88692e0870016e141b"
+checksum = "754ef4e8f073922a26f5b23133b9db4829342362b09be0bc94309cf261c2f098"
 dependencies = [
  "arrow",
  "arrow-schema",
  "async-trait",
- "bytes",
  "bzip2",
  "chrono",
  "datafusion-catalog",
@@ -1489,14 +1493,13 @@ dependencies = [
  "datafusion-sql",
  "flate2",
  "futures",
- "itertools 0.14.0",
+ "indexmap 2.14.0",
+ "itertools",
  "liblzma",
  "log",
  "object_store",
  "parking_lot",
  "parquet",
- "rand 0.9.2",
- "regex",
  "sqlparser",
  "tempfile",
  "tokio",
@@ -1507,9 +1510,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-catalog"
-version = "53.1.0"
+version = "54.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37cefde60b26a7f4ff61e9d2ff2833322f91df2b568d7238afe67bde5bdffb66"
+checksum = "06afd1e38dd27bbb1258685a1fc6524df6aff4e07b25b393a47de59635178d99"
 dependencies = [
  "arrow",
  "async-trait",
@@ -1523,7 +1526,7 @@ dependencies = [
  "datafusion-physical-plan",
  "datafusion-session",
  "futures",
- "itertools 0.14.0",
+ "itertools",
  "log",
  "object_store",
  "parking_lot",
@@ -1532,9 +1535,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-catalog-listing"
-version = "53.1.0"
+version = "54.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17e112307715d6a7a331111a4c2330ff54bc237183511c319e3708a4cff431fb"
+checksum = "f0668fb32c12065ec242be0e5b4bc62bd7a06a0be3ecd83791ef877e4be67e02"
 dependencies = [
  "arrow",
  "async-trait",
@@ -1548,41 +1551,42 @@ dependencies = [
  "datafusion-physical-expr-common",
  "datafusion-physical-plan",
  "futures",
- "itertools 0.14.0",
+ "itertools",
  "log",
  "object_store",
 ]
 
 [[package]]
 name = "datafusion-common"
-version = "53.1.0"
+version = "54.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d72a11ca44a95e1081870d3abb80c717496e8a7acb467a1d3e932bb636af5cc2"
+checksum = "ca43b263cdff57042cfa8fb817fb3469f4878933380dccff25f5e793580abbf9"
 dependencies = [
- "ahash",
  "arrow",
  "arrow-ipc",
+ "arrow-schema",
  "chrono",
+ "foldhash 0.2.0",
  "half",
- "hashbrown 0.16.1",
- "indexmap 2.13.0",
- "itertools 0.14.0",
+ "hashbrown 0.17.1",
+ "indexmap 2.14.0",
+ "itertools",
  "libc",
  "log",
  "object_store",
  "parquet",
- "paste",
  "recursive",
  "sqlparser",
  "tokio",
+ "uuid",
  "web-time",
 ]
 
 [[package]]
 name = "datafusion-common-runtime"
-version = "53.1.0"
+version = "54.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89f4afaed29670ec4fd6053643adc749fe3f4bc9d1ce1b8c5679b22c67d12def"
+checksum = "05f0ba2b864792bdca4d76c59a1de0ab6e1b61946596b9936888dbd6360035f2"
 dependencies = [
  "futures",
  "log",
@@ -1591,9 +1595,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-datasource"
-version = "53.1.0"
+version = "54.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9fb386e1691355355a96419978a0022b7947b44d4a24a6ea99f00b6b485cbb6"
+checksum = "b840a8bce0bcbf5afad02946d438591e7c373f7afccaf3d874c04485772514dd"
 dependencies = [
  "arrow",
  "async-compression",
@@ -1613,10 +1617,11 @@ dependencies = [
  "flate2",
  "futures",
  "glob",
- "itertools 0.14.0",
+ "itertools",
  "liblzma",
  "log",
  "object_store",
+ "parking_lot",
  "rand 0.9.2",
  "tokio",
  "tokio-util",
@@ -1626,9 +1631,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-datasource-arrow"
-version = "53.1.0"
+version = "54.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffa6c52cfed0734c5f93754d1c0175f558175248bf686c944fb05c373e5fc096"
+checksum = "a24cc0b9cf6e367f27f27406eff13abf48a11b72446aaa40b3105c0ded5c17d9"
 dependencies = [
  "arrow",
  "arrow-ipc",
@@ -1643,16 +1648,16 @@ dependencies = [
  "datafusion-physical-plan",
  "datafusion-session",
  "futures",
- "itertools 0.14.0",
+ "itertools",
  "object_store",
  "tokio",
 ]
 
 [[package]]
 name = "datafusion-datasource-csv"
-version = "53.1.0"
+version = "54.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "503f29e0582c1fc189578d665ff57d9300da1f80c282777d7eb67bb79fb8cdca"
+checksum = "e1abe56b2a7a2d1d6de5117dd1a203181e267f28529faa5da546947621b697d7"
 dependencies = [
  "arrow",
  "async-trait",
@@ -1673,9 +1678,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-datasource-json"
-version = "53.1.0"
+version = "54.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e33804749abc8d0c8cb7473228483cb8070e524c6f6086ee1b85a64debe2b3d2"
+checksum = "9c3e467f0611ad7bdd5aad17c63c9bb6182d04e5282e5496d897ea2b49c024ba"
 dependencies = [
  "arrow",
  "async-trait",
@@ -1690,16 +1695,15 @@ dependencies = [
  "datafusion-session",
  "futures",
  "object_store",
- "serde_json",
  "tokio",
  "tokio-stream",
 ]
 
 [[package]]
 name = "datafusion-datasource-parquet"
-version = "53.1.0"
+version = "54.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32a8e0365e0e08e8ff94d912f0ababcf9065a1a304018ba90b1fc83c855b4997"
+checksum = "4cc35b92cd560082155e80d9c826929c852d3c51543f4affd3a51c464a0aab3a"
 dependencies = [
  "arrow",
  "async-trait",
@@ -1709,6 +1713,7 @@ dependencies = [
  "datafusion-datasource",
  "datafusion-execution",
  "datafusion-expr",
+ "datafusion-functions",
  "datafusion-functions-aggregate-common",
  "datafusion-physical-expr",
  "datafusion-physical-expr-adapter",
@@ -1717,7 +1722,7 @@ dependencies = [
  "datafusion-pruning",
  "datafusion-session",
  "futures",
- "itertools 0.14.0",
+ "itertools",
  "log",
  "object_store",
  "parking_lot",
@@ -1727,20 +1732,19 @@ dependencies = [
 
 [[package]]
 name = "datafusion-doc"
-version = "53.1.0"
+version = "54.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8de6ac0df1662b9148ad3c987978b32cbec7c772f199b1d53520c8fa764a87ee"
+checksum = "d69bb69d8769e34f76839c960dbde24c1ac0c885a79b6c3c2287bdc56ec67891"
 
 [[package]]
 name = "datafusion-execution"
-version = "53.1.0"
+version = "54.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c03c7fbdaefcca4ef6ffe425a5fc2325763bfb426599bb0bf4536466efabe709"
+checksum = "d8eac0a09bc8d263f52025cad9e001da4d8138d633fa288edda4d06b1772eae6"
 dependencies = [
  "arrow",
  "arrow-buffer",
  "async-trait",
- "chrono",
  "dashmap",
  "datafusion-common",
  "datafusion-expr",
@@ -1756,11 +1760,12 @@ dependencies = [
 
 [[package]]
 name = "datafusion-expr"
-version = "53.1.0"
+version = "54.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "574b9b6977fedbd2a611cbff12e5caf90f31640ad9dc5870f152836d94bad0dd"
+checksum = "eeb14d374767ee0fc62dc79a5ba8bcf8a63c14e993c7d992d0e63adfa23d77d3"
 dependencies = [
  "arrow",
+ "arrow-schema",
  "async-trait",
  "chrono",
  "datafusion-common",
@@ -1769,9 +1774,8 @@ dependencies = [
  "datafusion-functions-aggregate-common",
  "datafusion-functions-window-common",
  "datafusion-physical-expr-common",
- "indexmap 2.13.0",
- "itertools 0.14.0",
- "paste",
+ "indexmap 2.14.0",
+ "itertools",
  "recursive",
  "serde_json",
  "sqlparser",
@@ -1779,22 +1783,21 @@ dependencies = [
 
 [[package]]
 name = "datafusion-expr-common"
-version = "53.1.0"
+version = "54.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d7c3adf3db8bf61e92eb90cb659c8e8b734593a8f7c8e12a843c7ddba24b87e"
+checksum = "b7b19a8c95522bee8cbb313d74263b85e355d2b52f42e67ef5694bf5de9e9356"
 dependencies = [
  "arrow",
  "datafusion-common",
- "indexmap 2.13.0",
- "itertools 0.14.0",
- "paste",
+ "indexmap 2.14.0",
+ "itertools",
 ]
 
 [[package]]
 name = "datafusion-functions"
-version = "53.1.0"
+version = "54.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f28aa4e10384e782774b10e72aca4d93ef7b31aa653095d9d4536b0a3dbc51b6"
+checksum = "5f64c983bbbdcb729d921a2b2ac3375598719b5cc0c30345ad664936f3176fc7"
 dependencies = [
  "arrow",
  "arrow-buffer",
@@ -1809,26 +1812,25 @@ dependencies = [
  "datafusion-expr",
  "datafusion-expr-common",
  "datafusion-macros",
+ "datafusion-physical-expr-common",
  "hex",
- "itertools 0.14.0",
+ "itertools",
  "log",
- "md-5 0.10.6",
+ "md-5 0.11.0",
  "memchr",
  "num-traits",
  "rand 0.9.2",
  "regex",
- "sha2 0.10.9",
- "unicode-segmentation",
+ "sha2 0.11.0",
  "uuid",
 ]
 
 [[package]]
 name = "datafusion-functions-aggregate"
-version = "53.1.0"
+version = "54.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00aa6217e56098ba84e0a338176fe52f0a84cca398021512c6c8c5eff806d0ad"
+checksum = "89bc17041e424a47ed062f43df24d84aab8b57c4c3221e5c1a5eef46d6c5718b"
 dependencies = [
- "ahash",
  "arrow",
  "datafusion-common",
  "datafusion-doc",
@@ -1838,19 +1840,18 @@ dependencies = [
  "datafusion-macros",
  "datafusion-physical-expr",
  "datafusion-physical-expr-common",
+ "foldhash 0.2.0",
  "half",
  "log",
  "num-traits",
- "paste",
 ]
 
 [[package]]
 name = "datafusion-functions-aggregate-common"
-version = "53.1.0"
+version = "54.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b511250349407db7c43832ab2de63f5557b19a20dfd236b39ca2c04468b50d47"
+checksum = "97dd2a9e865c6108059f5b37b77934f84b50bfb108f837bd0e5c9536e03f0545"
 dependencies = [
- "ahash",
  "arrow",
  "datafusion-common",
  "datafusion-expr-common",
@@ -1859,9 +1860,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-functions-nested"
-version = "53.1.0"
+version = "54.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef13a858e20d50f0a9bb5e96e7ac82b4e7597f247515bccca4fdd2992df0212a"
+checksum = "75f0bdfeef16d96417b9632ef855645376b242e9006a126dfd0bedfc54a93f5f"
 dependencies = [
  "arrow",
  "arrow-ord",
@@ -1875,34 +1876,34 @@ dependencies = [
  "datafusion-functions-aggregate-common",
  "datafusion-macros",
  "datafusion-physical-expr-common",
- "hashbrown 0.16.1",
- "itertools 0.14.0",
+ "hashbrown 0.17.1",
+ "itertools",
  "itoa",
  "log",
- "paste",
+ "memchr",
 ]
 
 [[package]]
 name = "datafusion-functions-table"
-version = "53.1.0"
+version = "54.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b40d3f5bbb3905f9ccb1ce9485a9595c77b69758a7c24d3ba79e334ff51e7e"
+checksum = "f4e4941673c917819616877e9993da4503e4f4739812be0bc32c5356184c6383"
 dependencies = [
  "arrow",
  "async-trait",
  "datafusion-catalog",
  "datafusion-common",
  "datafusion-expr",
+ "datafusion-physical-expr",
  "datafusion-physical-plan",
  "parking_lot",
- "paste",
 ]
 
 [[package]]
 name = "datafusion-functions-window"
-version = "53.1.0"
+version = "54.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4e88ec9d57c9b685d02f58bfee7be62d72610430ddcedb82a08e5d9925dbfb6"
+checksum = "12dd2e16c12b84b6f6b41b19f55b366dd1c46876bb35b86896c6349067379e8d"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -1913,14 +1914,13 @@ dependencies = [
  "datafusion-physical-expr",
  "datafusion-physical-expr-common",
  "log",
- "paste",
 ]
 
 [[package]]
 name = "datafusion-functions-window-common"
-version = "53.1.0"
+version = "54.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8307bb93519b1a91913723a1130cfafeee3f72200d870d88e91a6fc5470ede5c"
+checksum = "4cdc5e4b6f8b6ef823cc1c761f85088ad4c884fe8df64df3cbcc6b2b84698441"
 dependencies = [
  "datafusion-common",
  "datafusion-physical-expr-common",
@@ -1928,20 +1928,20 @@ dependencies = [
 
 [[package]]
 name = "datafusion-macros"
-version = "53.1.0"
+version = "54.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e367e6a71051d0ebdd29b2f85d12059b38b1d1f172c6906e80016da662226bd"
+checksum = "1a3614234dd93578c92428cb4f408e020874f0d2b7e6c90c928d9d28b5df2ceb"
 dependencies = [
  "datafusion-doc",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "datafusion-optimizer"
-version = "53.1.0"
+version = "54.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e929015451a67f77d9d8b727b2bf3a40c4445fdef6cdc53281d7d97c76888ace"
+checksum = "a0635620b050b81bb92764e99250868f654e2cd5ad1bece413283b3f73c83179"
 dependencies = [
  "arrow",
  "chrono",
@@ -1949,8 +1949,8 @@ dependencies = [
  "datafusion-expr",
  "datafusion-expr-common",
  "datafusion-physical-expr",
- "indexmap 2.13.0",
- "itertools 0.14.0",
+ "indexmap 2.14.0",
+ "itertools",
  "log",
  "recursive",
  "regex",
@@ -1959,11 +1959,10 @@ dependencies = [
 
 [[package]]
 name = "datafusion-physical-expr"
-version = "53.1.0"
+version = "54.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b1e68aba7a4b350401cfdf25a3d6f989ad898a7410164afe9ca52080244cb59"
+checksum = "8cabf7a86eb70b816729e33c81bf7767c936ee1226f607a114f5dac2decac8d0"
 dependencies = [
- "ahash",
  "arrow",
  "datafusion-common",
  "datafusion-expr",
@@ -1971,11 +1970,10 @@ dependencies = [
  "datafusion-functions-aggregate-common",
  "datafusion-physical-expr-common",
  "half",
- "hashbrown 0.16.1",
- "indexmap 2.13.0",
- "itertools 0.14.0",
+ "hashbrown 0.17.1",
+ "indexmap 2.14.0",
+ "itertools",
  "parking_lot",
- "paste",
  "petgraph",
  "recursive",
  "tokio",
@@ -1983,9 +1981,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-physical-expr-adapter"
-version = "53.1.0"
+version = "54.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea22315f33cf2e0adc104e8ec42e285f6ed93998d565c65e82fec6a9ee9f9db4"
+checksum = "de222e04f7e6744501555a54ab0abe26bfdfebee380af79a9bdc175704246859"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -1993,31 +1991,31 @@ dependencies = [
  "datafusion-functions",
  "datafusion-physical-expr",
  "datafusion-physical-expr-common",
- "itertools 0.14.0",
+ "itertools",
 ]
 
 [[package]]
 name = "datafusion-physical-expr-common"
-version = "53.1.0"
+version = "54.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b04b45ea8ad3ac2d78f2ea2a76053e06591c9629c7a603eda16c10649ecf4362"
+checksum = "72d0d0057fc5a502d45c870cb6d47c66eb7bdd5edb1bd71ad6f3f724975ac2a8"
 dependencies = [
- "ahash",
  "arrow",
  "chrono",
  "datafusion-common",
  "datafusion-expr-common",
- "hashbrown 0.16.1",
- "indexmap 2.13.0",
- "itertools 0.14.0",
+ "hashbrown 0.17.1",
+ "indexmap 2.14.0",
+ "itertools",
  "parking_lot",
+ "pin-project",
 ]
 
 [[package]]
 name = "datafusion-physical-optimizer"
-version = "53.1.0"
+version = "54.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cb13397809a425918f608dfe8653f332015a3e330004ab191b4404187238b95"
+checksum = "86046eed10950c5f9aaed9acfd148e9bd2e1dfdfe4f9aef607d1447b271e4183"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -2028,18 +2026,19 @@ dependencies = [
  "datafusion-physical-expr-common",
  "datafusion-physical-plan",
  "datafusion-pruning",
- "itertools 0.14.0",
+ "itertools",
  "recursive",
 ]
 
 [[package]]
 name = "datafusion-physical-plan"
-version = "53.1.0"
+version = "54.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5edc023675791af9d5fb4cc4c24abf5f7bd3bd4dcf9e5bd90ea1eff6976dcc79"
+checksum = "9bc84da934c903407ba297971ebcc020c4c1a38aafd765d6c144c76eff3fa6a1"
 dependencies = [
- "ahash",
  "arrow",
+ "arrow-data",
+ "arrow-ipc",
  "arrow-ord",
  "arrow-schema",
  "async-trait",
@@ -2054,9 +2053,9 @@ dependencies = [
  "datafusion-physical-expr-common",
  "futures",
  "half",
- "hashbrown 0.16.1",
- "indexmap 2.13.0",
- "itertools 0.14.0",
+ "hashbrown 0.17.1",
+ "indexmap 2.14.0",
+ "itertools",
  "log",
  "num-traits",
  "parking_lot",
@@ -2066,9 +2065,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-pruning"
-version = "53.1.0"
+version = "54.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac8c76860e355616555081cab5968cec1af7a80701ff374510860bcd567e365a"
+checksum = "eb63eeac6de19be40f487b65dd84e546195f783c5a9928618e0c4f2a3569b0d7"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -2077,15 +2076,14 @@ dependencies = [
  "datafusion-physical-expr",
  "datafusion-physical-expr-common",
  "datafusion-physical-plan",
- "itertools 0.14.0",
  "log",
 ]
 
 [[package]]
 name = "datafusion-session"
-version = "53.1.0"
+version = "54.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5412111aa48e2424ba926112e192f7a6b7e4ccb450145d25ce5ede9f19dc491e"
+checksum = "5f961d209177f91bd014db5cbb2c33b7d28a2597b9003e77f17aeb712964315a"
 dependencies = [
  "async-trait",
  "datafusion-common",
@@ -2097,9 +2095,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-sql"
-version = "53.1.0"
+version = "54.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa0d133ddf8b9b3b872acac900157f783e7b879fe9a6bccf389abebbfac45ec1"
+checksum = "b1d71cb454da682b2af7488e1fc1ddd72ee1b28f19297b8ccad73f0a21ee9a69"
 dependencies = [
  "arrow",
  "bigdecimal",
@@ -2107,7 +2105,7 @@ dependencies = [
  "datafusion-common",
  "datafusion-expr",
  "datafusion-functions-nested",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "log",
  "recursive",
  "regex",
@@ -2188,7 +2186,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2350,9 +2348,9 @@ checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "fsst"
-version = "8.0.0"
+version = "9.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7af6e24ed12cf382082d5a7f365df2b8e3d6b1518f615d54c85165e9b9718250"
+checksum = "d6f1155128aba964cf6925c22a667ed763b52c8c653693c4b46f8a79d509a8c1"
 dependencies = [
  "arrow-array",
  "rand 0.9.2",
@@ -2429,7 +2427,7 @@ checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2555,7 +2553,7 @@ checksum = "53010ccb100b96a67bc32c0175f0ed1426b31b655d562898e57325f81c023ac0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2588,7 +2586,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http 1.4.0",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -2601,6 +2599,7 @@ version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
 dependencies = [
+ "bytemuck",
  "cfg-if 1.0.4",
  "crunchy",
  "num-traits",
@@ -2630,20 +2629,14 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.16.1"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 dependencies = [
  "allocator-api2",
  "equivalent",
  "foldhash 0.2.0",
 ]
-
-[[package]]
-name = "hashbrown"
-version = "0.17.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "heapify"
@@ -3056,12 +3049,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.13.0"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
  "serde",
  "serde_core",
 ]
@@ -3111,15 +3104,6 @@ dependencies = [
 
 [[package]]
 name = "itertools"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
-dependencies = [
- "either",
-]
-
-[[package]]
-name = "itertools"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
@@ -3158,7 +3142,7 @@ checksum = "2a8c8b344124222efd714b73bb41f8b5120b27a7cc1c75593a6ff768d9d05aa4"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3203,7 +3187,7 @@ dependencies = [
  "quote",
  "rustc_version",
  "simd_cesu8",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3222,7 +3206,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
 dependencies = [
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3284,9 +3268,9 @@ checksum = "e037a2e1d8d5fdbd49b16a4ea09d5d6401c1f29eca5ff29d03d3824dba16256a"
 
 [[package]]
 name = "lance"
-version = "8.0.0"
+version = "9.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2122e9f5f5f4b38bb9f0c4991c8d5171696402b3cc6187885c8385875f6df2e"
+checksum = "23d04bed056e254bc6e31264b031c8492507ca57939586f016924081dcf221a9"
 dependencies = [
  "arc-swap",
  "arrow",
@@ -3303,7 +3287,6 @@ dependencies = [
  "async-trait",
  "async_cell",
  "aws-credential-types",
- "bitpacking",
  "byteorder",
  "bytes",
  "chrono",
@@ -3320,8 +3303,9 @@ dependencies = [
  "futures",
  "half",
  "humantime",
- "itertools 0.13.0",
+ "itertools",
  "lance-arrow",
+ "lance-bitpacking",
  "lance-core",
  "lance-datafusion",
  "lance-encoding",
@@ -3359,9 +3343,9 @@ dependencies = [
 
 [[package]]
 name = "lance-arrow"
-version = "8.0.0"
+version = "9.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95f45fb7e0822cc0233d686222ab451f6ec58879620029e0b7bae8192c2f7c7e"
+checksum = "b6e7b87c8183988c40a6bd30a6d8ec588b84e53f702b82f19859dc71ba6c02bc"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -3370,6 +3354,7 @@ dependencies = [
  "arrow-ord",
  "arrow-schema",
  "arrow-select",
+ "bytemuck",
  "bytes",
  "futures",
  "getrandom 0.2.17",
@@ -3408,20 +3393,21 @@ dependencies = [
 
 [[package]]
 name = "lance-bitpacking"
-version = "8.0.0"
+version = "9.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c56c21a39860ca7bae712b4e24b9fd066029c570a72428a579faf697de5b8822"
+checksum = "4a4d84a3f36133c70bf89d306d813a29f8eb8555bba2b84995260867cfafdd5e"
 dependencies = [
  "arrayref",
+ "crunchy",
  "paste",
  "seq-macro",
 ]
 
 [[package]]
 name = "lance-core"
-version = "8.0.0"
+version = "9.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ccc7b0b61c11bdb74f929111214553b36b1ee43c88445edda17bc9a2bda75e9"
+checksum = "238c8a58308e7718d6bd96b53494eb7953fa299778bc4911cc571c3576e9446d"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -3433,7 +3419,7 @@ dependencies = [
  "datafusion-common",
  "datafusion-sql",
  "futures",
- "itertools 0.13.0",
+ "itertools",
  "lance-arrow",
  "lance-derive",
  "libc",
@@ -3459,9 +3445,9 @@ dependencies = [
 
 [[package]]
 name = "lance-datafusion"
-version = "8.0.0"
+version = "9.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0932140306faa6c3c4e17f0478c031e2be659ea2721311a530fb7c664e1b9a0"
+checksum = "12f0ac4e1cf2f9b1b2fb5ee11bcd04af617bdd6f6cca13726a41c4212220193e"
 dependencies = [
  "arrow",
  "arrow-array",
@@ -3491,9 +3477,9 @@ dependencies = [
 
 [[package]]
 name = "lance-datagen"
-version = "8.0.0"
+version = "9.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "075c8154e6b27ff6859f90886efd8cbac348cca255c8b855da630994b4fed714"
+checksum = "dd65e7ea88ab28e5d3e91b58a56c02bfd44c47474caae5f8aed1322df1611476"
 dependencies = [
  "arrow",
  "arrow-array",
@@ -3510,20 +3496,20 @@ dependencies = [
 
 [[package]]
 name = "lance-derive"
-version = "8.0.0"
+version = "9.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7056da2e742fd466f6bdfaa876c91d3e0e99bb4f756be058e374ceae2630ec2f"
+checksum = "bf46656b359786f0b73f13936193583972b7af6e53ccb542da87830be18e94b2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "lance-encoding"
-version = "8.0.0"
+version = "9.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e165c668ae61fce336d5f6f9a999ee99b963bb395a3fb818737c533fc9528d1"
+checksum = "4725f14fe6cc1b2a5644786b4afa828d0c243064e208fa17378f839243d049c0"
 dependencies = [
  "arrow-arith",
  "arrow-array",
@@ -3539,7 +3525,7 @@ dependencies = [
  "futures",
  "hex",
  "hyperloglogplus",
- "itertools 0.13.0",
+ "itertools",
  "lance-arrow",
  "lance-bitpacking",
  "lance-core",
@@ -3558,9 +3544,9 @@ dependencies = [
 
 [[package]]
 name = "lance-file"
-version = "8.0.0"
+version = "9.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1691bd5c37bc5e07bde00e32950b5526c2e5653bd2493a3773712574366a37a1"
+checksum = "8c161b00eb5813f98f1d6d52e06f1b712f9eebb0a7f535a8dc1e1122ceca7307"
 dependencies = [
  "arrow-arith",
  "arrow-array",
@@ -3590,9 +3576,9 @@ dependencies = [
 
 [[package]]
 name = "lance-index"
-version = "8.0.0"
+version = "9.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b4792b56f0e047eed706d05a1eedc5f549090913fb4527585bb3a331b83416b"
+checksum = "bf7980b0a6287fd46b9308a31e2cf284065d5693bfb43336297f0400172670ad"
 dependencies = [
  "arc-swap",
  "arrow",
@@ -3604,7 +3590,6 @@ dependencies = [
  "async-channel",
  "async-recursion",
  "async-trait",
- "bitpacking",
  "bitvec",
  "bytes",
  "chrono",
@@ -3617,15 +3602,17 @@ dependencies = [
  "fst",
  "futures",
  "half",
- "itertools 0.13.0",
+ "itertools",
  "jsonb",
  "lance-arrow",
  "lance-arrow-stats",
+ "lance-bitpacking",
  "lance-core",
  "lance-datafusion",
  "lance-datagen",
  "lance-encoding",
  "lance-file",
+ "lance-index-core",
  "lance-io",
  "lance-linalg",
  "lance-select",
@@ -3655,10 +3642,34 @@ dependencies = [
 ]
 
 [[package]]
-name = "lance-io"
-version = "8.0.0"
+name = "lance-index-core"
+version = "9.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c81dda99d5b8c8741f413d65650a28ff203d94eda3cbbdda6fd3af3ea9b2a69"
+checksum = "a95f46ac3e4cdd710ca6929226cfb0dd343d5d2370ecb4b40e1c452043f7d27a"
+dependencies = [
+ "arrow-array",
+ "arrow-schema",
+ "arrow-select",
+ "async-trait",
+ "bytes",
+ "datafusion",
+ "datafusion-common",
+ "datafusion-expr",
+ "futures",
+ "lance-core",
+ "lance-io",
+ "lance-select",
+ "prost-types",
+ "roaring",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "lance-io"
+version = "9.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6deecd351ed6849184cc83000eabb87c8a5bfc519996f92451284498af7b42c"
 dependencies = [
  "arrow",
  "arrow-arith",
@@ -3699,9 +3710,9 @@ dependencies = [
 
 [[package]]
 name = "lance-linalg"
-version = "8.0.0"
+version = "9.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c0a8d2a2bc7e6b6229abe320ec6d9e2049a0e65e084684cba01cf032fc71896"
+checksum = "0e5a9b99bd1f49bc2fe5afb81323141abc506c818f589de95dbab4f6143d9a88"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -3712,13 +3723,14 @@ dependencies = [
  "lance-core",
  "num-traits",
  "rand 0.9.2",
+ "rayon",
 ]
 
 [[package]]
 name = "lance-namespace"
-version = "8.0.0"
+version = "9.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ee2d75929caec41747e58ce090b1a061b650a16cb10d09998128d7912203b1d"
+checksum = "8624fd33a894b5f2eb411cb56588d29138137ce100dee8e335843828e249b860"
 dependencies = [
  "arrow",
  "async-trait",
@@ -3730,9 +3742,9 @@ dependencies = [
 
 [[package]]
 name = "lance-namespace-impls"
-version = "8.0.0"
+version = "9.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c92dd5dcb98562a91650da0b5fa63726d435fad8b03327625cc3de445b7e191a"
+checksum = "39f0cb9651a65f8eb411d825f34967fff46ba575a76e6ae9becda6ee31c1a974"
 dependencies = [
  "arrow",
  "arrow-ipc",
@@ -3778,16 +3790,16 @@ dependencies = [
 
 [[package]]
 name = "lance-select"
-version = "8.0.0"
+version = "9.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf3a2162385a4392376ed7a732e070afd1432bb6f86b0ebcb7c4304c7196953b"
+checksum = "bb5c718c141ea4f067203b11a54ccf57f8effbf963f345bc811f4837a660ad57"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
  "arrow-schema",
  "byteorder",
  "bytes",
- "itertools 0.13.0",
+ "itertools",
  "lance-core",
  "roaring",
  "tracing",
@@ -3795,9 +3807,9 @@ dependencies = [
 
 [[package]]
 name = "lance-table"
-version = "8.0.0"
+version = "9.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73da3932a85489e80d5458d4bbc1d340e15c72b89bab529723f575d4d8fda5eb"
+checksum = "ffc125611b4fe46f99f00b5262e71e17bd947a3bc3b81f3a4a604cc9ca290b3f"
 dependencies = [
  "arrow",
  "arrow-array",
@@ -3834,9 +3846,9 @@ dependencies = [
 
 [[package]]
 name = "lance-tokenizer"
-version = "8.0.0"
+version = "9.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d16326f6b6d3b736aac40a0ffa78d8aa17d3a53a3766cd0af6d23db87472bd5e"
+checksum = "73060a844ceda2405759b8f0f16a1c586b5b285dbdf7a3784350d048f991cfd3"
 dependencies = [
  "icu_segmenter",
  "rust-stemmers",
@@ -3958,9 +3970,9 @@ checksum = "2c4a545a15244c7d945065b5d392b2d2d7f21526fba56ce51467b06ed445e8f7"
 
 [[package]]
 name = "libc"
-version = "0.2.183"
+version = "0.2.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
+checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 
 [[package]]
 name = "liblzma"
@@ -4177,9 +4189,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.1.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
+checksum = "30d65c71f1ce40ab09135ce117d742b9f8a19ff91a41a8b57ed50bc2de59c427"
 dependencies = [
  "libc",
  "wasi 0.11.1+wasi-snapshot-preview1",
@@ -4397,7 +4409,7 @@ dependencies = [
  "httparse",
  "humantime",
  "hyper",
- "itertools 0.14.0",
+ "itertools",
  "md-5 0.10.6",
  "parking_lot",
  "percent-encoding",
@@ -4852,7 +4864,7 @@ checksum = "8701b58ea97060d5e5b155d383a69952a60943f0e6dfe30b04c287beb0b27455"
 dependencies = [
  "fixedbitset",
  "hashbrown 0.15.5",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "serde",
 ]
 
@@ -4891,7 +4903,7 @@ checksum = "d9b20ed30f105399776b9c883e68e536ef602a16ae6f596d2c473591d6ad64c6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4998,7 +5010,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5027,7 +5039,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
 dependencies = [
  "heck",
- "itertools 0.14.0",
+ "itertools",
  "log",
  "multimap",
  "petgraph",
@@ -5035,7 +5047,7 @@ dependencies = [
  "prost",
  "prost-types",
  "regex",
- "syn",
+ "syn 2.0.117",
  "tempfile",
 ]
 
@@ -5046,10 +5058,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5318,7 +5330,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76009fbe0614077fc1a2ce255e3a1881a2e3a3527097d5dc6d8212c585e7e38b"
 dependencies = [
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5367,7 +5379,7 @@ checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5941,7 +5953,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5965,7 +5977,7 @@ checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5991,7 +6003,7 @@ dependencies = [
  "chrono",
  "hex",
  "indexmap 1.9.3",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "schemars 0.9.0",
  "schemars 1.2.1",
  "serde_core",
@@ -6009,7 +6021,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -6179,7 +6191,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -6191,7 +6203,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -6228,9 +6240,9 @@ dependencies = [
 
 [[package]]
 name = "sqlparser"
-version = "0.61.0"
+version = "0.62.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbf5ea8d4d7c808e1af1cbabebca9a2abe603bcefc22294c5b95018d53200cb7"
+checksum = "13c6d1b651dc4edf07eead2a0c6c78016ce971bc2c10da5266861b13f25e7cec"
 dependencies = [
  "log",
  "recursive",
@@ -6245,7 +6257,7 @@ checksum = "a6dd45d8fc1c79299bfbb7190e42ccbbdf6a5f52e4a6ad98d92357ea965bd289"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -6329,7 +6341,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -6356,6 +6368,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "syn"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
 name = "sync_wrapper"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6372,7 +6395,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -6452,7 +6475,7 @@ checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -6552,9 +6575,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.50.0"
+version = "1.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27ad5e34374e03cfffefc301becb44e9dc3c17584f414349ebe29ed26661822d"
+checksum = "202caea871b69668250d242070849eb495be178ed697a3e98aebce5bc81a0bed"
 dependencies = [
  "bytes",
  "libc",
@@ -6569,13 +6592,13 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.6.1"
+version = "2.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c55a2eff8b69ce66c84f85e1da1c233edc36ceb85a2058d11b0d6a3c7e7569c"
+checksum = "78773a2a397f451582ce068015985c33193cf6dea8b74d2a639fe457b2f07b0e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -6645,7 +6668,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d01145a2c788d6aae4cd653afec1e8332534d7d783d01897cefcafe4428de992"
 dependencies = [
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -6730,7 +6753,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -6889,9 +6912,9 @@ checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "uuid"
-version = "1.22.0"
+version = "1.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a68d3c8f01c0cfa54a75291d83601161799e4a89a39e0929f4b0354d88757a37"
+checksum = "bf3923a6f5c4c6382e0b653c4117f48d631ea17f38ed86e2a828e6f7412f5239"
 dependencies = [
  "getrandom 0.4.2",
  "js-sys",
@@ -7024,7 +7047,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "wasm-bindgen-shared",
 ]
 
@@ -7054,7 +7077,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
 dependencies = [
  "anyhow",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "wasm-encoder",
  "wasmparser",
 ]
@@ -7093,7 +7116,7 @@ checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
  "bitflags",
  "hashbrown 0.15.5",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "semver",
 ]
 
@@ -7223,7 +7246,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -7234,7 +7257,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -7484,9 +7507,9 @@ checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
 dependencies = [
  "anyhow",
  "heck",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "prettyplease",
- "syn",
+ "syn 2.0.117",
  "wasm-metadata",
  "wit-bindgen-core",
  "wit-component",
@@ -7502,7 +7525,7 @@ dependencies = [
  "prettyplease",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "wit-bindgen-core",
  "wit-bindgen-rust",
 ]
@@ -7515,7 +7538,7 @@ checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
  "bitflags",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "log",
  "serde",
  "serde_derive",
@@ -7534,7 +7557,7 @@ checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
 dependencies = [
  "anyhow",
  "id-arena",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "log",
  "semver",
  "serde",
@@ -7612,7 +7635,7 @@ dependencies = [
  "futures-util",
  "getrandom 0.4.2",
  "heapify",
- "itertools 0.14.0",
+ "itertools",
  "lazy_static",
  "lz4_flex",
  "more-asserts",
@@ -7642,7 +7665,7 @@ dependencies = [
  "chrono",
  "gearhash",
  "http 1.4.0",
- "itertools 0.14.0",
+ "itertools",
  "lazy_static",
  "more-asserts",
  "rand 0.10.2",
@@ -7735,7 +7758,7 @@ checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "synstructure",
 ]
 
@@ -7756,7 +7779,7 @@ checksum = "7e6cc098ea4d3bd6246687de65af3f920c430e236bee1e3bf2e441463f08a02f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -7776,7 +7799,7 @@ checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "synstructure",
 ]
 
@@ -7818,7 +7841,7 @@ checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ datafusion = "54.0.0"
 datafusion-common = "54.0.0"
 datafusion-expr = "54.0.0"
 datafusion-functions = "54.0.0"
+datafusion-functions-nested = "54.0.0"
 datafusion-sql = "54.0.0"
 
 anyhow = "1.0"

--- a/docs/sql.md
+++ b/docs/sql.md
@@ -59,7 +59,7 @@ Named parameters:
 - `refine_factor` (BIGINT, optional): Over-fetch factor for re-ranking using original vectors. Must be > 0. A value of `1` still enables re-ranking.
 - `prefilter` (BOOLEAN, default `false`): If `true`, filters are applied before top-k selection.
 - `explain_verbose` (BOOLEAN, default `false`): Emit a more verbose Lance plan in `EXPLAIN` output.
-- `filter` (VARCHAR, optional): Namespace `query_table` filter expression. Only supported when `uri` resolves to an attached Lance namespace table.
+- `filter` (VARCHAR, optional): Namespace `query_table` filter expression. Only supported when `uri` resolves to an attached Lance namespace table. Combined with pushed `WHERE` predicates using `AND`.
 
 Output:
 - Dataset columns plus `_distance` (smaller is closer).
@@ -67,7 +67,7 @@ Output:
 Filter semantics:
 - If `prefilter=false`, filter pushdown is best-effort. If pushdown fails, the query is retried without pushed filters and DuckDB applies filters for correctness.
 - If `prefilter=true`, prefilterable filters must be pushed down, otherwise the query fails with an error.
-- For attached namespace tables, DuckDB `WHERE` filters are applied after the namespace search result. Use the explicit `filter` parameter to send a filter expression to Lance Namespace `query_table`; `prefilter=true` on namespace tables requires this explicit `filter`.
+- `WHERE` predicates push down for both dataset paths and attached namespace tables. For namespace tables, pushed predicates are translated to a Lance Namespace `query_table` filter; a pushed predicate and an explicit `filter` combine with `AND`.
 
 ### Full-text search: `lance_fts`
 
@@ -88,7 +88,7 @@ Positional arguments:
 Named parameters:
 - `k` (BIGINT, default `10`): Number of results to return. Must be > 0.
 - `prefilter` (BOOLEAN, default `false`): If `true`, filters are applied before top-k selection.
-- `filter` (VARCHAR, optional): Namespace `query_table` filter expression. Only supported when `uri` resolves to an attached Lance namespace table.
+- `filter` (VARCHAR, optional): Namespace `query_table` filter expression. Only supported when `uri` resolves to an attached Lance namespace table. Combined with pushed `WHERE` predicates using `AND`.
 
 Output:
 - Dataset columns plus `_score` (larger is better).
@@ -96,7 +96,7 @@ Output:
 Filter semantics:
 - If `prefilter=false`, filter pushdown is best-effort. If pushdown fails, the query is retried without pushed filters and DuckDB applies filters for correctness.
 - If `prefilter=true`, prefilterable filters must be pushed down, otherwise the query fails with an error.
-- For attached namespace tables, DuckDB `WHERE` filters are applied after the namespace search result. Use the explicit `filter` parameter to send a filter expression to Lance Namespace `query_table`; `prefilter=true` on namespace tables requires this explicit `filter`.
+- `WHERE` predicates push down for both dataset paths and attached namespace tables. For namespace tables, pushed predicates are translated to a Lance Namespace `query_table` filter; a pushed predicate and an explicit `filter` combine with `AND`.
 
 ### Hybrid search: `lance_hybrid_search`
 
@@ -120,7 +120,7 @@ ORDER BY _hybrid_score DESC;
 Signature: `lance_hybrid_search(uri, vector_column, query_vector, text_column, query, ...)`
 
 Positional arguments:
-- `uri` (VARCHAR): Dataset root path or object store URI (e.g. `s3://...`).
+- `uri` (VARCHAR): Dataset root path, object store URI (e.g. `s3://...`), or an attached Lance table name.
 - `vector_column` (VARCHAR): Vector column name.
 - `query_vector` (FLOAT[dim] or DOUBLE[dim], preferred): Query vector (must be non-empty; values are cast to float32). `FLOAT[]` / `DOUBLE[]` are also accepted.
 - `text_column` (VARCHAR): Text column name.
@@ -141,6 +141,18 @@ Output:
 Filter semantics:
 - If `prefilter=false`, filter pushdown is best-effort. If pushdown fails, the query is retried without pushed filters and DuckDB applies filters for correctness.
 - If `prefilter=true`, prefilterable filters must be pushed down, otherwise the query fails with an error.
+- `WHERE` predicates push down for both dataset paths and attached namespace tables.
+
+### Filter pushdown notes
+
+These notes apply to all three search functions.
+
+- Comparison predicates (`=`, `>`, numeric `IN`, ...) and string predicates (`starts_with`, `LIKE`, `regexp_matches`) push down into Lance.
+- Containment predicates over list columns — `array_has_any` and `array_has_all` — push down. With `prefilter=true` and a `LABEL_LIST` index on the list column, Lance answers them from the index; without one, Lance evaluates them with a scan. The index is used for `VARCHAR[]` and `BIGINT[]` element types; narrower integer widths still push and prefilter, but scan.
+- `IS NULL` / `IS NOT NULL` on list columns push down. No scalar index answers them.
+- Containment forms that cannot push — empty or non-constant needles, needles containing `NULL`, `array_has` / `array_contains`, and the `&&` / `@>` / `<@` aliases — are evaluated by DuckDB after the search.
+- Datasets whose list columns have a child field named `l` (written by older versions of this extension) push and prefilter correctly, but the `LABEL_LIST` index is not used. A metadata-only rename fixes this without rewriting data: `ALTER TABLE ns.main.t RENAME COLUMN "tags.l" TO item;`
+- Known limitation: `IN` over a `VARCHAR` column with two or more values currently raises an error from the search functions when it must prefilter. Apply it after the search, or use a scan.
 
 ## Namespaces
 

--- a/rust/expr_ir.rs
+++ b/rust/expr_ir.rs
@@ -1,4 +1,5 @@
 use datafusion::execution::context::SessionContext;
+use datafusion_common::utils::SingleRowListArrayBuilder;
 use datafusion_common::{Column, ScalarValue};
 use datafusion_expr::expr::{BinaryExpr, Case, InList, Like, ScalarFunction};
 use datafusion_expr::registry::FunctionRegistry;
@@ -6,6 +7,7 @@ use datafusion_expr::{Expr, Operator, ScalarUDF};
 use std::sync::{Arc, OnceLock};
 
 use datafusion_functions::core::getfield::GetFieldFunc;
+use datafusion_functions_nested::array_has::{array_has_all_udf, array_has_any_udf};
 
 const MAGIC: &[u8; 4] = b"LUE1";
 
@@ -34,6 +36,7 @@ const LIT_STRING: u8 = 6;
 const LIT_DATE32: u8 = 7;
 const LIT_TIMESTAMP: u8 = 8;
 const LIT_DECIMAL128: u8 = 9;
+const LIT_LIST: u8 = 10;
 
 const TYPE_BOOL: u8 = 1;
 const TYPE_INT8: u8 = 2;
@@ -406,6 +409,8 @@ fn resolve_scalar_function(
         "contains" => Ok(contains_udf()),
         "lower" => Ok(lower_udf()),
         "upper" => Ok(upper_udf()),
+        "array_has_any" => Ok(array_has_any_udf()),
+        "array_has_all" => Ok(array_has_all_udf()),
         _ => match ctx {
             Some(ctx) => ctx
                 .udf(name)
@@ -515,6 +520,10 @@ fn parse_regexp(cursor: &mut Cursor<'_>, ctx: Option<&SessionContext>) -> Result
 }
 
 fn parse_literal(cursor: &mut Cursor<'_>) -> Result<Expr, String> {
+    Ok(Expr::Literal(parse_literal_value(cursor)?, None))
+}
+
+fn parse_literal_value(cursor: &mut Cursor<'_>) -> Result<ScalarValue, String> {
     let lit = match cursor.read_u8()? {
         LIT_NULL => ScalarValue::Null,
         LIT_BOOL => ScalarValue::Boolean(Some(cursor.read_u8()? != 0)),
@@ -540,9 +549,22 @@ fn parse_literal(cursor: &mut Cursor<'_>) -> Result<Expr, String> {
             let scale = cursor.read_u8()? as i8;
             ScalarValue::Decimal128(Some(cursor.read_i128()?), precision, scale)
         }
+        LIT_LIST => {
+            let element_count = cursor.read_u32()? as usize;
+            if element_count == 0 {
+                return Err("expr_ir list literal has no elements".to_string());
+            }
+            let mut elements = Vec::with_capacity(element_count);
+            for _ in 0..element_count {
+                elements.push(parse_literal_value(cursor)?);
+            }
+            let element_array = ScalarValue::iter_to_array(elements)
+                .map_err(|e| format!("expr_ir list literal: {e}"))?;
+            SingleRowListArrayBuilder::new(element_array).build_list_scalar()
+        }
         other => return Err(format!("invalid expr_ir literal tag: {other}")),
     };
-    Ok(Expr::Literal(lit, None))
+    Ok(lit)
 }
 
 fn parse_type(cursor: &mut Cursor<'_>) -> Result<arrow::datatypes::DataType, String> {

--- a/rust/ffi/query_table.rs
+++ b/rust/ffi/query_table.rs
@@ -365,9 +365,27 @@ fn filter_expr_to_sql(expr: &Expr) -> FfiResult<String> {
         .map_err(|err| {
             FfiError::new(
                 ErrorCode::NamespaceQueryTable,
-                format!("unparse namespace scan filter: {err}"),
+                format!("unparse namespace filter: {err}"),
             )
         })
+}
+
+// A pushed filter arrives as a DataFusion `Expr`, but namespace query_table only accepts a
+// filter string, so it is unparsed here and ANDed with whatever the caller passed as the
+// explicit `filter :=` argument.
+fn apply_filter_expr(
+    request: &mut QueryTableRequest,
+    filter_expr: Option<&Expr>,
+) -> FfiResult<()> {
+    let Some(filter_expr) = filter_expr else {
+        return Ok(());
+    };
+    let filter_sql = filter_expr_to_sql(filter_expr)?;
+    request.filter = Some(match request.filter.take() {
+        Some(existing) => format!("({existing}) AND ({filter_sql})"),
+        None => filter_sql,
+    });
+    Ok(())
 }
 
 fn build_namespace_scan_request(
@@ -433,13 +451,7 @@ fn build_namespace_scan_request(
         }
     }
 
-    if let Some(filter_expr) = filter_expr {
-        let filter_sql = filter_expr_to_sql(filter_expr)?;
-        request.filter = Some(match request.filter.take() {
-            Some(existing) => format!("({existing}) AND ({filter_sql})"),
-            None => filter_sql,
-        });
-    }
+    apply_filter_expr(&mut request, filter_expr)?;
     Ok(request)
 }
 
@@ -507,8 +519,12 @@ unsafe fn create_namespace_scan_stream_ir_inner(
 pub unsafe extern "C" fn lance_create_namespace_vector_search_stream(
     config: *const LanceNamespaceQueryConfig,
     options: *const LanceNamespaceVectorSearchOptions,
+    filter_ir: *const u8,
+    filter_ir_len: usize,
 ) -> *mut c_void {
-    match create_namespace_vector_search_stream_inner(config, options) {
+    match unsafe {
+        create_namespace_vector_search_stream_inner(config, options, filter_ir, filter_ir_len)
+    } {
         Ok(stream) => {
             clear_last_error();
             Box::into_raw(Box::new(stream)) as *mut c_void
@@ -523,6 +539,8 @@ pub unsafe extern "C" fn lance_create_namespace_vector_search_stream(
 unsafe fn create_namespace_vector_search_stream_inner(
     config: *const LanceNamespaceQueryConfig,
     options: *const LanceNamespaceVectorSearchOptions,
+    filter_ir: *const u8,
+    filter_ir_len: usize,
 ) -> FfiResult<StreamHandle> {
     if options.is_null() {
         return Err(FfiError::new(
@@ -550,8 +568,18 @@ unsafe fn create_namespace_vector_search_stream_inner(
 
     let mut vector = QueryTableRequestVector::new();
     vector.single_vector = Some(query_values.to_vec());
+    let filter_expr = unsafe {
+        parse_optional_filter_ir(
+            filter_ir,
+            filter_ir_len,
+            ErrorCode::NamespaceQueryTable,
+            "namespace vector search filter_ir",
+        )?
+    };
+
     let mut request = QueryTableRequest::new(config.k, vector);
     apply_base_request(&config, &mut request);
+    apply_filter_expr(&mut request, filter_expr.as_ref())?;
     request.vector_column = Some(vector_column.to_string());
     if options.nprobes != 0 {
         request.nprobes =
@@ -573,8 +601,12 @@ unsafe fn create_namespace_vector_search_stream_inner(
 pub unsafe extern "C" fn lance_create_namespace_fts_search_stream(
     config: *const LanceNamespaceQueryConfig,
     options: *const LanceNamespaceFtsSearchOptions,
+    filter_ir: *const u8,
+    filter_ir_len: usize,
 ) -> *mut c_void {
-    match create_namespace_fts_search_stream_inner(config, options) {
+    match unsafe {
+        create_namespace_fts_search_stream_inner(config, options, filter_ir, filter_ir_len)
+    } {
         Ok(stream) => {
             clear_last_error();
             Box::into_raw(Box::new(stream)) as *mut c_void
@@ -589,6 +621,8 @@ pub unsafe extern "C" fn lance_create_namespace_fts_search_stream(
 unsafe fn create_namespace_fts_search_stream_inner(
     config: *const LanceNamespaceQueryConfig,
     options: *const LanceNamespaceFtsSearchOptions,
+    filter_ir: *const u8,
+    filter_ir_len: usize,
 ) -> FfiResult<StreamHandle> {
     if options.is_null() {
         return Err(FfiError::new(
@@ -607,8 +641,18 @@ unsafe fn create_namespace_fts_search_stream_inner(
     let text_column = unsafe { cstr_to_str(options.text_column, "text_column")? };
     let query = unsafe { cstr_to_str(options.query, "query")? };
 
+    let filter_expr = unsafe {
+        parse_optional_filter_ir(
+            filter_ir,
+            filter_ir_len,
+            ErrorCode::NamespaceQueryTable,
+            "namespace FTS search filter_ir",
+        )?
+    };
+
     let mut request = QueryTableRequest::new(config.k, QueryTableRequestVector::new());
     apply_base_request(&config, &mut request);
+    apply_filter_expr(&mut request, filter_expr.as_ref())?;
 
     let mut string_query = StringFtsQuery::new(query.to_string());
     string_query.columns = Some(vec![text_column.to_string()]);

--- a/rust/ffi/session.rs
+++ b/rust/ffi/session.rs
@@ -87,6 +87,14 @@ fn create_session_inner(
 }
 
 fn clear_session_caches(handle: &SessionHandle) {
+    // Skip during process teardown: a C++ static destructor can close a session after
+    // this thread's TLS is destroyed, and `block_on` would then panic inside tokio's
+    // context thread-local and wedge shutdown. The caches die with the process anyway.
+    if let Err(err) = tokio::runtime::Handle::try_current() {
+        if err.is_thread_local_destroyed() {
+            return;
+        }
+    }
     if let Some(runtime) = crate::runtime::initialized_runtime() {
         runtime.block_on(async {
             handle.index_cache.clear().await;

--- a/rust/ffi/write.rs
+++ b/rust/ffi/write.rs
@@ -12,7 +12,7 @@ use arrow_array::{
     make_array, Array, FixedSizeListArray, Float32Array, Float64Array, LargeListArray, ListArray,
     RecordBatch, RecordBatchReader, StructArray,
 };
-use arrow_schema::{ArrowError, DataType, Field, Schema, SchemaRef};
+use arrow_schema::{ArrowError, DataType, Field, FieldRef, Fields, Schema, SchemaRef};
 use lance::dataset::{CommitBuilder, Dataset, InsertBuilder, WriteMode, WriteParams};
 use lance::io::{ObjectStoreParams, StorageOptionsAccessor};
 
@@ -430,6 +430,79 @@ fn convert_list_array_to_fixed_size(
     }
 }
 
+/// Best-effort read of the destination dataset's schema; `None` when the
+/// dataset does not exist yet, in which case an append behaves like a create.
+fn existing_dataset_schema(path: &str, storage_options: &HashMap<String, String>) -> Option<Schema> {
+    let builder = lance::dataset::builder::DatasetBuilder::from_uri(path)
+        .with_storage_options(storage_options.clone());
+    let dataset = runtime::block_on(builder.load()).ok()?.ok()?;
+    Some(Schema::from(dataset.schema()))
+}
+
+/// Rewrites list child field names in `schema` to match `reference`.
+///
+/// DuckDB's Arrow exporter names list children `l`; the C++ write paths rewrite
+/// them to Arrow's `item` so DataFusion leaves list columns uncoerced and Lance
+/// can answer `array_has_*` from a LABEL_LIST index. Datasets written before
+/// that change still carry `l`, and Lance rejects an append whose schema
+/// disagrees, so an append has to speak whatever the destination already uses.
+fn align_list_field_names(fields: &Fields, reference: &Fields) -> Option<Fields> {
+    let mut aligned = fields.as_ref().to_vec();
+    let mut changed = false;
+    for slot in &mut aligned {
+        let Some(reference_field) = reference.iter().find(|f| f.name() == slot.name()) else {
+            continue;
+        };
+        let Some(field) = align_list_field(slot, reference_field) else {
+            continue;
+        };
+        *slot = field;
+        changed = true;
+    }
+    changed.then(|| Fields::from(aligned))
+}
+
+fn align_list_field(field: &FieldRef, reference: &FieldRef) -> Option<FieldRef> {
+    let data_type = match (field.data_type(), reference.data_type()) {
+        (DataType::List(child), DataType::List(reference_child)) => {
+            let child = align_list_child(child, reference_child)?;
+            DataType::List(child)
+        }
+        (DataType::LargeList(child), DataType::LargeList(reference_child)) => {
+            let child = align_list_child(child, reference_child)?;
+            DataType::LargeList(child)
+        }
+        (DataType::Struct(children), DataType::Struct(reference_children)) => {
+            DataType::Struct(align_list_field_names(children, reference_children)?)
+        }
+        _ => return None,
+    };
+    Some(Arc::new(
+        Field::new(field.name(), data_type, field.is_nullable())
+            .with_metadata(field.metadata().clone()),
+    ))
+}
+
+fn align_list_child(child: &FieldRef, reference: &FieldRef) -> Option<FieldRef> {
+    let nested = match (child.data_type(), reference.data_type()) {
+        (DataType::Struct(children), DataType::Struct(reference_children)) => {
+            align_list_field_names(children, reference_children).map(DataType::Struct)
+        }
+        _ => None,
+    };
+    if child.name() == reference.name() && nested.is_none() {
+        return None;
+    }
+    Some(Arc::new(
+        Field::new(
+            reference.name(),
+            nested.unwrap_or_else(|| child.data_type().clone()),
+            child.is_nullable(),
+        )
+        .with_metadata(child.metadata().clone()),
+    ))
+}
+
 fn build_output_schema(
     input_schema: &SchemaRef,
     conversions: &[VectorConversion],
@@ -686,7 +759,7 @@ fn open_uncommitted_writer_inner(
             "schema must be a struct",
         ));
     };
-    let schema: SchemaRef = std::sync::Arc::new(Schema::new(fields.clone()));
+    let mut schema: SchemaRef = std::sync::Arc::new(Schema::new(fields.clone()));
 
     let write_mode = WriteMode::try_from(mode).map_err(|err| {
         FfiError::new(
@@ -694,6 +767,18 @@ fn open_uncommitted_writer_inner(
             format!("invalid write mode '{mode}': {err}"),
         )
     })?;
+
+    // The incoming Arrow arrays are imported against `data_type`, so realigning
+    // the schema without it would fail RecordBatch validation.
+    let mut data_type = data_type.clone();
+    if matches!(write_mode, WriteMode::Append) {
+        if let Some(existing) = existing_dataset_schema(&path, &storage_options) {
+            if let Some(fields) = align_list_field_names(schema.fields(), existing.fields()) {
+                data_type = DataType::Struct(fields.clone());
+                schema = Arc::new(Schema::new(fields));
+            }
+        }
+    }
 
     let max_rows_per_file = usize::try_from(max_rows_per_file).map_err(|err| {
         FfiError::new(
@@ -837,7 +922,7 @@ fn open_writer_inner(
             "schema must be a struct",
         ));
     };
-    let schema: SchemaRef = std::sync::Arc::new(Schema::new(fields.clone()));
+    let mut schema: SchemaRef = std::sync::Arc::new(Schema::new(fields.clone()));
 
     let write_mode = WriteMode::try_from(mode).map_err(|err| {
         FfiError::new(
@@ -845,6 +930,18 @@ fn open_writer_inner(
             format!("invalid write mode '{mode}': {err}"),
         )
     })?;
+
+    // The incoming Arrow arrays are imported against `data_type`, so realigning
+    // the schema without it would fail RecordBatch validation.
+    let mut data_type = data_type.clone();
+    if matches!(write_mode, WriteMode::Append) {
+        if let Some(existing) = existing_dataset_schema(&path, &storage_options) {
+            if let Some(fields) = align_list_field_names(schema.fields(), existing.fields()) {
+                data_type = DataType::Struct(fields.clone());
+                schema = Arc::new(Schema::new(fields));
+            }
+        }
+    }
 
     let max_rows_per_file = usize::try_from(max_rows_per_file).map_err(|err| {
         FfiError::new(
@@ -1434,5 +1531,56 @@ pub unsafe extern "C" fn lance_free_transaction(transaction: *mut c_void) {
     }
     unsafe {
         let _ = Box::from_raw(transaction as *mut lance::dataset::transaction::Transaction);
+    }
+}
+
+#[cfg(test)]
+mod align_tests {
+    use super::*;
+
+    fn list_of(child_name: &str) -> DataType {
+        DataType::List(Arc::new(Field::new(child_name, DataType::Utf8, true)))
+    }
+
+    #[test]
+    fn renames_list_child_to_match_the_destination() {
+        let incoming = Fields::from(vec![Field::new("tags", list_of("item"), true)]);
+        let existing = Fields::from(vec![Field::new("tags", list_of("l"), true)]);
+
+        let aligned = align_list_field_names(&incoming, &existing).expect("expected a rename");
+        assert_eq!(aligned[0].data_type(), &list_of("l"));
+    }
+
+    #[test]
+    fn leaves_matching_schemas_alone() {
+        let fields = Fields::from(vec![Field::new("tags", list_of("item"), true)]);
+        assert!(align_list_field_names(&fields, &fields.clone()).is_none());
+    }
+
+    #[test]
+    fn ignores_columns_the_destination_does_not_have() {
+        let incoming = Fields::from(vec![Field::new("tags", list_of("item"), true)]);
+        let existing = Fields::from(vec![Field::new("other", list_of("l"), true)]);
+        assert!(align_list_field_names(&incoming, &existing).is_none());
+    }
+
+    #[test]
+    fn descends_into_struct_columns() {
+        let incoming = Fields::from(vec![Field::new(
+            "meta",
+            DataType::Struct(Fields::from(vec![Field::new("tags", list_of("item"), true)])),
+            true,
+        )]);
+        let existing = Fields::from(vec![Field::new(
+            "meta",
+            DataType::Struct(Fields::from(vec![Field::new("tags", list_of("l"), true)])),
+            true,
+        )]);
+
+        let aligned = align_list_field_names(&incoming, &existing).expect("expected a rename");
+        let DataType::Struct(children) = aligned[0].data_type() else {
+            panic!("expected a struct");
+        };
+        assert_eq!(children[0].data_type(), &list_of("l"));
     }
 }

--- a/src/include/lance_arrow_compat.hpp
+++ b/src/include/lance_arrow_compat.hpp
@@ -40,4 +40,15 @@ void LanceCoerceArrowArrayForDuckDB(const ArrowSchema *schema,
 // helpers above would rewrite.
 bool LanceArrowSchemaNeedsCoercion(const ArrowSchema *schema);
 
+// DuckDB's Arrow exporter names list child fields `l`; Arrow (and therefore
+// Lance, pyarrow and DataFusion) call them `item`. Lance persists the name, and
+// DataFusion's array-function coercion rewrites any list argument to an `item`
+// field — which wraps a non-`item` column in a cast and hides it from Lance's
+// scalar-index planner, so `array_has_any` / `array_has_all` can never reach a
+// LABEL_LIST index. Rewrite the name on every DuckDB → Lance write boundary.
+//
+// Call on the ROOT ArrowSchema before handing it to Lance. Names are rewritten
+// to static storage, so no allocation is added to the producer's lifetime.
+void LanceNormalizeArrowListFieldNames(ArrowSchema *schema);
+
 } // namespace duckdb

--- a/src/include/lance_expr_ir.hpp
+++ b/src/include/lance_expr_ir.hpp
@@ -14,6 +14,7 @@ bool TryEncodeLanceExprIRColumnRef(const string &name, string &out_ir);
 bool TryEncodeLanceExprIRColumnRef(const vector<string> &segments,
                                    string &out_ir);
 bool TryEncodeLanceExprIRLiteral(const Value &value, string &out_ir);
+bool TryEncodeLanceExprIRListLiteral(const Value &value, string &out_ir);
 bool TryEncodeLanceExprIRComparisonOp(ExpressionType type, uint8_t &out_op);
 bool TryEncodeLanceExprIRAnd(const vector<string> &children, string &out_ir);
 bool TryEncodeLanceExprIROr(const vector<string> &children, string &out_ir);

--- a/src/include/lance_ffi.hpp
+++ b/src/include/lance_ffi.hpp
@@ -307,10 +307,12 @@ typedef struct LanceNamespaceFtsSearchOptions {
 
 void *lance_create_namespace_vector_search_stream(
     const LanceNamespaceQueryConfig *config,
-    const LanceNamespaceVectorSearchOptions *options);
+    const LanceNamespaceVectorSearchOptions *options, const uint8_t *filter_ir,
+    size_t filter_ir_len);
 void *lance_create_namespace_fts_search_stream(
     const LanceNamespaceQueryConfig *config,
-    const LanceNamespaceFtsSearchOptions *options);
+    const LanceNamespaceFtsSearchOptions *options, const uint8_t *filter_ir,
+    size_t filter_ir_len);
 void *lance_create_namespace_scan_stream_ir(
     const LanceNamespaceQueryConfig *config, const uint8_t *filter_ir,
     size_t filter_ir_len, int64_t limit, int64_t offset, uint8_t with_row_id);

--- a/src/lance_arrow_compat.cpp
+++ b/src/lance_arrow_compat.cpp
@@ -294,4 +294,24 @@ void LanceCoerceArrowArrayForDuckDB(const ArrowSchema *schema,
   array->release = ArrayReleaseWrapper;
 }
 
+void LanceNormalizeArrowListFieldNames(ArrowSchema *schema) {
+  if (!schema || schema->release == nullptr) {
+    return;
+  }
+  static constexpr const char ARROW_LIST_ITEM_NAME[] = "item";
+  if (schema->format &&
+      (std::strcmp(schema->format, "+l") == 0 ||
+       std::strcmp(schema->format, "+L") == 0) &&
+      schema->n_children == 1 && schema->children && schema->children[0]) {
+    // DuckDB assigns a string literal here, so overwriting the pointer with
+    // another literal keeps the producer's release callback correct.
+    schema->children[0]->name = ARROW_LIST_ITEM_NAME;
+  }
+  for (int64_t i = 0; i < schema->n_children; i++) {
+    if (schema->children && schema->children[i]) {
+      LanceNormalizeArrowListFieldNames(schema->children[i]);
+    }
+  }
+}
+
 } // namespace duckdb

--- a/src/lance_expr_ir.cpp
+++ b/src/lance_expr_ir.cpp
@@ -50,6 +50,7 @@ bool LanceExprIRSupportsLogicalType(const LogicalType &type) {
   case LogicalTypeId::TIMESTAMP_TZ:
   case LogicalTypeId::DECIMAL:
   case LogicalTypeId::STRUCT:
+  case LogicalTypeId::LIST:
     return true;
   default:
     return false;
@@ -86,6 +87,7 @@ enum class LanceUpdateExprIRLiteralTag : uint8_t {
   DATE32 = 7,
   TIMESTAMP = 8,
   DECIMAL128 = 9,
+  LIST = 10,
 };
 
 enum class LanceUpdateExprIRTimestampUnit : uint8_t {
@@ -232,10 +234,7 @@ static void EncodeColumnRef(const string &name, string &out) {
   EncodeColumnRef(vector<string>{name}, out);
 }
 
-static void EncodeLiteral(const Value &value, string &out) {
-  out.clear();
-  AppendU8(out, static_cast<uint8_t>(LanceUpdateExprIRTag::LITERAL));
-
+static void AppendLiteralPayload(const Value &value, string &out) {
   if (value.IsNull()) {
     AppendU8(out,
              static_cast<uint8_t>(LanceUpdateExprIRLiteralTag::NULL_VALUE));
@@ -374,6 +373,45 @@ static void EncodeLiteral(const Value &value, string &out) {
     throw NotImplementedException("Lance UPDATE does not support literal type "
                                   "%s in SET expressions",
                                   value.type().ToString());
+  }
+}
+
+static void EncodeLiteral(const Value &value, string &out) {
+  out.clear();
+  AppendU8(out, static_cast<uint8_t>(LanceUpdateExprIRTag::LITERAL));
+  AppendLiteralPayload(value, out);
+}
+
+static void EncodeListLiteral(const Value &value, string &out) {
+  if (value.IsNull() || value.type().id() != LogicalTypeId::LIST) {
+    throw NotImplementedException(
+        "Lance expression IR list literals require a non-null LIST value");
+  }
+  auto &children = ListValue::GetChildren(value);
+  // Lance's LABEL_LIST query parser rejects an empty needle, and DuckDB's
+  // `list_has_all([], ...)` short-circuits to `true` where DataFusion combines
+  // the row-level NULL mask instead. Refuse the degenerate case so DuckDB keeps
+  // evaluating it.
+  if (children.empty()) {
+    throw NotImplementedException(
+        "Lance expression IR does not support empty list literals");
+  }
+  if (children.size() > std::numeric_limits<uint32_t>::max()) {
+    throw InvalidInputException("ExprIR list literal too large");
+  }
+  out.clear();
+  AppendU8(out, static_cast<uint8_t>(LanceUpdateExprIRTag::LITERAL));
+  AppendU8(out, static_cast<uint8_t>(LanceUpdateExprIRLiteralTag::LIST));
+  AppendU32(out, static_cast<uint32_t>(children.size()));
+  for (auto &child : children) {
+    // DuckDB's containment predicates ignore NULL elements while
+    // DataFusion/Lance compare them as values, so a NULL element is not
+    // pushable.
+    if (child.IsNull()) {
+      throw NotImplementedException(
+          "Lance expression IR does not support NULL list literal elements");
+    }
+    AppendLiteralPayload(child, out);
   }
 }
 
@@ -661,6 +699,15 @@ bool TryEncodeLanceExprIRColumnRef(const vector<string> &segments,
 bool TryEncodeLanceExprIRLiteral(const Value &value, string &out_ir) {
   try {
     EncodeLiteral(value, out_ir);
+    return true;
+  } catch (...) {
+    return false;
+  }
+}
+
+bool TryEncodeLanceExprIRListLiteral(const Value &value, string &out_ir) {
+  try {
+    EncodeListLiteral(value, out_ir);
     return true;
   } catch (...) {
     return false;

--- a/src/lance_filter_ir.cpp
+++ b/src/lance_filter_ir.cpp
@@ -63,6 +63,11 @@ static bool TryEncodeLanceFilterIRLiteral(const Value &value, string &out_ir) {
   return TryEncodeLanceExprIRLiteral(value, out_ir);
 }
 
+static bool TryEncodeLanceFilterIRListLiteral(const Value &value,
+                                              string &out_ir) {
+  return TryEncodeLanceExprIRListLiteral(value, out_ir);
+}
+
 static bool TryEncodeLanceFilterIRComparisonOp(ExpressionType type,
                                                uint8_t &out_op) {
   return TryEncodeLanceExprIRComparisonOp(type, out_op);
@@ -166,6 +171,60 @@ static bool TryGetNonNullVarcharConstant(const Expression &expr,
   return false;
 }
 
+static bool TryGetNonNullListConstant(const Expression &expr,
+                                      Value &out_value) {
+  if (expr.expression_class == ExpressionClass::BOUND_CONSTANT) {
+    auto &c = expr.Cast<BoundConstantExpression>();
+    if (c.value.IsNull() || c.value.type().id() != LogicalTypeId::LIST) {
+      return false;
+    }
+    out_value = c.value;
+    return true;
+  }
+  if (expr.expression_class == ExpressionClass::BOUND_CAST) {
+    auto &cast = expr.Cast<BoundCastExpression>();
+    if (cast.try_cast) {
+      return false;
+    }
+    if (!cast.child ||
+        cast.child->expression_class != ExpressionClass::BOUND_CONSTANT) {
+      return false;
+    }
+    auto &c = cast.child->Cast<BoundConstantExpression>();
+    if (c.value.IsNull()) {
+      return false;
+    }
+    try {
+      auto casted = c.value.DefaultCastAs(cast.return_type);
+      if (casted.IsNull() || casted.type().id() != LogicalTypeId::LIST) {
+        return false;
+      }
+      out_value = std::move(casted);
+      return true;
+    } catch (...) {
+      return false;
+    }
+  }
+  return false;
+}
+
+// DuckDB exposes the containment predicates under both a `list_*` and an
+// `array_*` name; Lance's scalar-index planner matches DataFusion's
+// `array_has_*` names, so the IR always carries the DataFusion spelling. The
+// `&&` / `@>` / `<@` operator aliases are deliberately excluded.
+static bool TryGetLanceContainmentFunctionName(const string &duckdb_name,
+                                               string &out_name) {
+  if (duckdb_name == "array_has_any" || duckdb_name == "list_has_any") {
+    out_name = "array_has_any";
+    return true;
+  }
+  if (duckdb_name == "array_has_all" || duckdb_name == "list_has_all") {
+    out_name = "array_has_all";
+    return true;
+  }
+  return false;
+}
+
 static bool TryBuildLanceTableFilterIRExpr(const string &col_ref_ir,
                                            const TableFilter &filter,
                                            string &out_ir) {
@@ -224,6 +283,34 @@ static bool TryBuildLanceTableFilterIRExpr(const string &col_ref_ir,
         args.push_back(std::move(input_ir));
         args.push_back(std::move(needle_ir));
         return TryEncodeLanceFilterIRScalarFunction(func.function.name, args,
+                                                    out_expr_ir);
+      }
+
+      string containment_name;
+      if (TryGetLanceContainmentFunctionName(func.function.name,
+                                             containment_name)) {
+        if (func.children.size() != 2) {
+          return false;
+        }
+
+        string input_ir;
+        if (!build_from_expr(*func.children[0], input_ir)) {
+          return false;
+        }
+
+        Value needle_value;
+        if (!TryGetNonNullListConstant(*func.children[1], needle_value)) {
+          return false;
+        }
+        string needle_ir;
+        if (!TryEncodeLanceFilterIRListLiteral(needle_value, needle_ir)) {
+          return false;
+        }
+
+        vector<string> args;
+        args.push_back(std::move(input_ir));
+        args.push_back(std::move(needle_ir));
+        return TryEncodeLanceFilterIRScalarFunction(containment_name, args,
                                                     out_expr_ir);
       }
 
@@ -803,6 +890,35 @@ bool TryBuildLanceExprFilterIR(const LogicalGet &get,
       args.push_back(std::move(input_ir));
       args.push_back(std::move(needle_ir));
       return TryEncodeLanceFilterIRScalarFunction(func.function.name, args,
+                                                  out_ir);
+    }
+
+    string containment_name;
+    if (TryGetLanceContainmentFunctionName(func.function.name,
+                                           containment_name)) {
+      if (func.children.size() != 2 || !func.children[0] || !func.children[1]) {
+        return false;
+      }
+      string input_ir;
+      if (!TryBuildLanceExprFilterIR(get, names, types,
+                                     exclude_computed_columns,
+                                     *func.children[0], input_ir)) {
+        return false;
+      }
+
+      Value needle_value;
+      if (!TryGetNonNullListConstant(*func.children[1], needle_value)) {
+        return false;
+      }
+      string needle_ir;
+      if (!TryEncodeLanceFilterIRListLiteral(needle_value, needle_ir)) {
+        return false;
+      }
+
+      vector<string> args;
+      args.push_back(std::move(input_ir));
+      args.push_back(std::move(needle_ir));
+      return TryEncodeLanceFilterIRScalarFunction(containment_name, args,
                                                   out_ir);
     }
 

--- a/src/lance_insert.cpp
+++ b/src/lance_insert.cpp
@@ -6,6 +6,7 @@
 #include "duckdb/main/client_context.hpp"
 #include "duckdb/planner/operator/logical_insert.hpp"
 
+#include "lance_arrow_compat.hpp"
 #include "lance_common.hpp"
 #include "lance_dataset_cache.hpp"
 #include "lance_ffi.hpp"
@@ -95,6 +96,7 @@ public:
       ArrowConverter::ToArrowSchema(&gstate.schema_root.arrow_schema,
                                     gstate.column_types, gstate.column_names,
                                     props);
+      LanceNormalizeArrowListFieldNames(&gstate.schema_root.arrow_schema);
 
       if (!gstate.table) {
         throw InternalException("Lance INSERT missing table reference");

--- a/src/lance_scan.cpp
+++ b/src/lance_scan.cpp
@@ -3605,6 +3605,7 @@ unique_ptr<CatalogEntry> LanceTableEntry::AlterEntry(ClientContext &context,
       auto props = context.GetClientProperties();
       ArrowConverter::ToArrowSchema(&new_schema_root.arrow_schema, types, names,
                                     props);
+      LanceNormalizeArrowListFieldNames(&new_schema_root.arrow_schema);
 
       vector<string> expressions;
       if (add.new_column.HasDefaultValue()) {
@@ -3700,6 +3701,7 @@ unique_ptr<CatalogEntry> LanceTableEntry::AlterEntry(ClientContext &context,
       ArrowConverter::ToArrowSchema(&new_type_schema.arrow_schema,
                                     {cast.target_type}, {cast.column_name},
                                     props);
+      LanceNormalizeArrowListFieldNames(&new_type_schema.arrow_schema);
 
       auto rc = lance_dataset_alter_columns_cast(
           dataset, cast.column_name.c_str(), &new_type_schema.arrow_schema);

--- a/src/lance_search.cpp
+++ b/src/lance_search.cpp
@@ -375,9 +375,6 @@ LancePushdownComplexFilter(ClientContext &, LogicalGet &get,
     return;
   }
   auto &scan_bind = bind_data->Cast<LanceKnnBindData>();
-  if (scan_bind.namespace_backed) {
-    return;
-  }
   CollectLancePushedFilterIRParts(get, scan_bind.names, scan_bind.types,
                                   filters,
                                   scan_bind.lance_pushed_filter_ir_parts);
@@ -491,11 +488,6 @@ LanceSearchVectorBind(ClientContext &context, TableFunctionBindInput &input,
     result->file_path = table->DatasetUri();
     result->vector_column = RequireNamespaceSearchColumn(
         *table, result->vector_column, "lance_vector_search", "vector_column");
-    if (result->prefilter && result->namespace_filter.empty()) {
-      throw InvalidInputException(
-          "lance_vector_search requires explicit filter when prefilter=true "
-          "on namespace-backed tables");
-    }
     PopulateNamespaceSearchSchema(
         context, *table, "_distance", result->schema_root, result->arrow_table,
         result->names, result->types, names, return_types);
@@ -564,10 +556,6 @@ LanceKnnInitGlobal(ClientContext &, TableFunctionInitInput &input) {
       }
       global.scanned_types.push_back(bind_data.types[col_id]);
     }
-  }
-
-  if (bind_data.namespace_backed) {
-    return state;
   }
 
   auto table_filters = BuildLanceTableFilterIRParts(
@@ -639,8 +627,12 @@ LanceKnnLocalInit(ExecutionContext &context, TableFunctionInitInput &input,
     options.nprobes = bind_data.nprobes;
     options.refine_factor = bind_data.refine_factor;
     options.use_index = bind_data.use_index ? 1 : 0;
-    result->stream =
-        lance_create_namespace_vector_search_stream(&config, &options);
+    const uint8_t *ns_filter_ir =
+        global.lance_filter_ir.empty()
+            ? nullptr
+            : reinterpret_cast<const uint8_t *>(global.lance_filter_ir.data());
+    result->stream = lance_create_namespace_vector_search_stream(
+        &config, &options, ns_filter_ir, global.lance_filter_ir.size());
     if (!result->stream) {
       throw IOException("Failed to create Lance namespace vector search "
                         "stream" +
@@ -807,10 +799,6 @@ LanceKnnToString(TableFunctionToStringInput &input) {
     result["Lance Namespace Filter"] = bind_data.namespace_filter;
   }
 
-  if (bind_data.namespace_backed) {
-    return result;
-  }
-
   result["Lance Pushed Filter Parts"] =
       to_string(bind_data.lance_pushed_filter_ir_parts.size());
   string filter_ir_msg;
@@ -819,6 +807,12 @@ LanceKnnToString(TableFunctionToStringInput &input) {
                                   filter_ir_msg);
   }
   result["Lance Filter IR Bytes (Bind)"] = to_string(filter_ir_msg.size());
+
+  // A namespace-backed search has no local dataset handle, so there is no plan
+  // to explain -- but the pushdown metrics above are still meaningful.
+  if (bind_data.namespace_backed) {
+    return result;
+  }
 
   string plan;
   string error;
@@ -1034,8 +1028,12 @@ static bool LanceSearchLoadNextBatch(ClientContext &context,
       LanceNamespaceFtsSearchOptions options;
       options.text_column = bind_data.text_column.c_str();
       options.query = bind_data.query.c_str();
-      local_state.stream =
-          lance_create_namespace_fts_search_stream(&config, &options);
+      const uint8_t *ns_filter_ir = global.lance_filter_ir.empty()
+                                        ? nullptr
+                                        : reinterpret_cast<const uint8_t *>(
+                                              global.lance_filter_ir.data());
+      local_state.stream = lance_create_namespace_fts_search_stream(
+          &config, &options, ns_filter_ir, global.lance_filter_ir.size());
       if (!local_state.stream) {
         throw IOException("Failed to create Lance namespace FTS stream" +
                           LanceFormatErrorSuffix());
@@ -1171,11 +1169,6 @@ static unique_ptr<FunctionData> LanceFtsBind(ClientContext &context,
     result->file_path = table->DatasetUri();
     result->text_column = RequireNamespaceSearchColumn(
         *table, result->text_column, "lance_fts", "text_column");
-    if (result->prefilter && result->namespace_filter.empty()) {
-      throw InvalidInputException(
-          "lance_fts requires explicit filter when prefilter=true on "
-          "namespace-backed tables");
-    }
     PopulateNamespaceSearchSchema(
         context, *table, "_score", result->schema_root, result->arrow_table,
         result->names, result->types, names, return_types);
@@ -1382,9 +1375,6 @@ LanceSearchPushdownComplexFilter(ClientContext &, LogicalGet &get,
     return;
   }
   auto &search_bind = bind_data->Cast<LanceSearchBindData>();
-  if (search_bind.namespace_backed) {
-    return;
-  }
   CollectLancePushedFilterIRParts(get, search_bind.names, search_bind.types,
                                   filters,
                                   search_bind.lance_pushed_filter_ir_parts);
@@ -1406,10 +1396,6 @@ LanceSearchInitGlobal(ClientContext &, TableFunctionInitInput &input) {
       }
       global.scanned_types.push_back(bind_data.types[col_id]);
     }
-  }
-
-  if (bind_data.namespace_backed) {
-    return state;
   }
 
   auto table_filters = BuildLanceTableFilterIRParts(

--- a/src/lance_search.cpp
+++ b/src/lance_search.cpp
@@ -313,18 +313,14 @@ struct LanceKnnLocalState : public ArrowScanLocalState {
   }
 };
 
+// Encodes whatever DuckDB could not express as a TableFilter -- scalar
+// functions, LIKE/regexp, containment -- into filter IR parts the search
+// functions hand to Lance as a prefilter.
 static void
-LancePushdownComplexFilter(ClientContext &, LogicalGet &get,
-                           FunctionData *bind_data,
-                           vector<unique_ptr<Expression>> &filters) {
-  if (!bind_data || filters.empty()) {
-    return;
-  }
-  auto &scan_bind = bind_data->Cast<LanceKnnBindData>();
-  if (scan_bind.namespace_backed) {
-    return;
-  }
-
+CollectLancePushedFilterIRParts(LogicalGet &get, const vector<string> &names,
+                                const vector<LogicalType> &types,
+                                const vector<unique_ptr<Expression>> &filters,
+                                vector<string> &out_parts) {
   for (auto &expr : filters) {
     if (!expr || expr->HasParameter() || expr->IsVolatile()) {
       continue;
@@ -364,12 +360,27 @@ LancePushdownComplexFilter(ClientContext &, LogicalGet &get,
       }
     }
     string filter_ir;
-    if (!TryBuildLanceExprFilterIR(get, scan_bind.names, scan_bind.types, true,
-                                   *expr, filter_ir)) {
+    if (!TryBuildLanceExprFilterIR(get, names, types, true, *expr, filter_ir)) {
       continue;
     }
-    scan_bind.lance_pushed_filter_ir_parts.push_back(std::move(filter_ir));
+    out_parts.push_back(std::move(filter_ir));
   }
+}
+
+static void
+LancePushdownComplexFilter(ClientContext &, LogicalGet &get,
+                           FunctionData *bind_data,
+                           vector<unique_ptr<Expression>> &filters) {
+  if (!bind_data || filters.empty()) {
+    return;
+  }
+  auto &scan_bind = bind_data->Cast<LanceKnnBindData>();
+  if (scan_bind.namespace_backed) {
+    return;
+  }
+  CollectLancePushedFilterIRParts(get, scan_bind.names, scan_bind.types,
+                                  filters,
+                                  scan_bind.lance_pushed_filter_ir_parts);
 }
 
 static bool LancePushdownExpression(ClientContext &, const LogicalGet &,
@@ -966,6 +977,8 @@ struct LanceSearchBindData : public TableFunctionData {
   ArrowTableSchema arrow_table;
   vector<string> names;
   vector<LogicalType> types;
+
+  vector<string> lance_pushed_filter_ir_parts;
 };
 
 struct LanceSearchGlobalState : public GlobalTableFunctionState {
@@ -1361,6 +1374,22 @@ LanceHybridBind(ClientContext &context, TableFunctionBindInput &input,
   return std::move(result);
 }
 
+static void
+LanceSearchPushdownComplexFilter(ClientContext &, LogicalGet &get,
+                                 FunctionData *bind_data,
+                                 vector<unique_ptr<Expression>> &filters) {
+  if (!bind_data || filters.empty()) {
+    return;
+  }
+  auto &search_bind = bind_data->Cast<LanceSearchBindData>();
+  if (search_bind.namespace_backed) {
+    return;
+  }
+  CollectLancePushedFilterIRParts(get, search_bind.names, search_bind.types,
+                                  filters,
+                                  search_bind.lance_pushed_filter_ir_parts);
+}
+
 static unique_ptr<GlobalTableFunctionState>
 LanceSearchInitGlobal(ClientContext &, TableFunctionInitInput &input) {
   auto &bind_data = input.bind_data->Cast<LanceSearchBindData>();
@@ -1395,9 +1424,18 @@ LanceSearchInitGlobal(ClientContext &, TableFunctionInitInput &input) {
   }
 
   bool has_table_filter_parts = !table_filters.parts.empty();
+  auto filter_parts = std::move(table_filters.parts);
+  if (!bind_data.lance_pushed_filter_ir_parts.empty()) {
+    filter_parts.reserve(filter_parts.size() +
+                         bind_data.lance_pushed_filter_ir_parts.size());
+    for (auto &part : bind_data.lance_pushed_filter_ir_parts) {
+      filter_parts.push_back(part);
+    }
+  }
+
   string filter_ir_msg;
-  if (!table_filters.parts.empty()) {
-    if (!TryEncodeLanceFilterIRMessage(table_filters.parts, filter_ir_msg)) {
+  if (!filter_parts.empty()) {
+    if (!TryEncodeLanceFilterIRMessage(filter_parts, filter_ir_msg)) {
       filter_ir_msg.clear();
     }
     global.lance_filter_ir = std::move(filter_ir_msg);
@@ -1560,6 +1598,7 @@ static void RegisterLanceFtsSearch(ExtensionLoader &loader) {
   fts.filter_pushdown = true;
   fts.filter_prune = true;
   fts.pushdown_expression = LancePushdownExpression;
+  fts.pushdown_complex_filter = LanceSearchPushdownComplexFilter;
   fts.to_string = LanceSearchToString;
   fts.dynamic_to_string = LanceSearchDynamicToString;
   loader.RegisterFunction(fts);
@@ -1578,6 +1617,7 @@ static void RegisterLanceHybridSearch(ExtensionLoader &loader) {
     fun.filter_pushdown = true;
     fun.filter_prune = true;
     fun.pushdown_expression = LancePushdownExpression;
+    fun.pushdown_complex_filter = LanceSearchPushdownComplexFilter;
     fun.to_string = LanceSearchToString;
     fun.dynamic_to_string = LanceSearchDynamicToString;
   };

--- a/src/lance_search.cpp
+++ b/src/lance_search.cpp
@@ -313,6 +313,31 @@ struct LanceKnnLocalState : public ArrowScanLocalState {
   }
 };
 
+// One stream-creation policy for every search backend, dataset- and
+// namespace-backed alike. Generated filter IR is best-effort when
+// prefilter=false: a stream that fails to open with pushed IR is retried
+// without it and DuckDB re-applies the filters after top-k. The explicit
+// namespace filter is unaffected by the retry -- it travels in the query
+// config, not in the IR. With prefilter=true the IR is required for
+// correctness, so the failure surfaces to the caller.
+template <class GLOBAL, class LOCAL, class CREATE>
+static void *CreateLanceSearchStreamWithFallback(GLOBAL &global, LOCAL &local,
+                                                 bool prefilter,
+                                                 CREATE &&create) {
+  const uint8_t *filter_ir =
+      global.lance_filter_ir.empty()
+          ? nullptr
+          : reinterpret_cast<const uint8_t *>(global.lance_filter_ir.data());
+  auto *stream = create(filter_ir, global.lance_filter_ir.size());
+  if (!stream && filter_ir && !prefilter) {
+    global.filter_pushdown_fallbacks.fetch_add(1);
+    global.filter_pushed_down = false;
+    local.filter_pushed_down = false;
+    stream = create(nullptr, size_t{0});
+  }
+  return stream;
+}
+
 // Encodes whatever DuckDB could not express as a TableFilter -- scalar
 // functions, LIKE/regexp, containment -- into filter IR parts the search
 // functions hand to Lance as a prefilter.
@@ -665,12 +690,12 @@ LanceKnnLocalInit(ExecutionContext &context, TableFunctionInitInput &input,
     options.nprobes = bind_data.nprobes;
     options.refine_factor = bind_data.refine_factor;
     options.use_index = bind_data.use_index ? 1 : 0;
-    const uint8_t *ns_filter_ir =
-        global.lance_filter_ir.empty()
-            ? nullptr
-            : reinterpret_cast<const uint8_t *>(global.lance_filter_ir.data());
-    result->stream = lance_create_namespace_vector_search_stream(
-        &config, &options, ns_filter_ir, global.lance_filter_ir.size());
+    result->stream = CreateLanceSearchStreamWithFallback(
+        global, *result, bind_data.prefilter,
+        [&](const uint8_t *ir, size_t ir_len) {
+          return lance_create_namespace_vector_search_stream(&config, &options,
+                                                             ir, ir_len);
+        });
     if (!result->stream) {
       throw IOException("Failed to create Lance namespace vector search "
                         "stream" +
@@ -679,28 +704,15 @@ LanceKnnLocalInit(ExecutionContext &context, TableFunctionInitInput &input,
     return std::move(result);
   }
 
-  const uint8_t *filter_ir =
-      global.lance_filter_ir.empty()
-          ? nullptr
-          : reinterpret_cast<const uint8_t *>(global.lance_filter_ir.data());
-  auto filter_ir_len = global.lance_filter_ir.size();
-  result->stream = lance_create_knn_stream_ir(
-      bind_data.dataset, bind_data.vector_column.c_str(),
-      bind_data.query.data(), bind_data.query.size(), bind_data.k,
-      bind_data.nprobes, bind_data.refine_factor, filter_ir, filter_ir_len,
-      bind_data.prefilter ? 1 : 0, bind_data.use_index ? 1 : 0);
-  if (!result->stream && filter_ir && !bind_data.prefilter) {
-    // Best-effort: if filter pushdown failed, retry without it and rely on
-    // DuckDB-side filter execution for correctness.
-    global.filter_pushdown_fallbacks.fetch_add(1);
-    global.filter_pushed_down = false;
-    result->filter_pushed_down = false;
-    result->stream = lance_create_knn_stream_ir(
-        bind_data.dataset, bind_data.vector_column.c_str(),
-        bind_data.query.data(), bind_data.query.size(), bind_data.k,
-        bind_data.nprobes, bind_data.refine_factor, nullptr, 0,
-        bind_data.prefilter ? 1 : 0, bind_data.use_index ? 1 : 0);
-  }
+  result->stream = CreateLanceSearchStreamWithFallback(
+      global, *result, bind_data.prefilter,
+      [&](const uint8_t *ir, size_t ir_len) {
+        return lance_create_knn_stream_ir(
+            bind_data.dataset, bind_data.vector_column.c_str(),
+            bind_data.query.data(), bind_data.query.size(), bind_data.k,
+            bind_data.nprobes, bind_data.refine_factor, ir, ir_len,
+            bind_data.prefilter ? 1 : 0, bind_data.use_index ? 1 : 0);
+      });
   if (!result->stream) {
     throw IOException("Failed to create Lance KNN stream" +
                       LanceFormatErrorSuffix());
@@ -1066,49 +1078,35 @@ static bool LanceSearchLoadNextBatch(ClientContext &context,
       LanceNamespaceFtsSearchOptions options;
       options.text_column = bind_data.text_column.c_str();
       options.query = bind_data.query.c_str();
-      const uint8_t *ns_filter_ir = global.lance_filter_ir.empty()
-                                        ? nullptr
-                                        : reinterpret_cast<const uint8_t *>(
-                                              global.lance_filter_ir.data());
-      local_state.stream = lance_create_namespace_fts_search_stream(
-          &config, &options, ns_filter_ir, global.lance_filter_ir.size());
+      local_state.stream = CreateLanceSearchStreamWithFallback(
+          global, local_state, bind_data.prefilter,
+          [&](const uint8_t *ir, size_t ir_len) {
+            return lance_create_namespace_fts_search_stream(&config, &options,
+                                                            ir, ir_len);
+          });
       if (!local_state.stream) {
         throw IOException("Failed to create Lance namespace FTS stream" +
                           LanceFormatErrorSuffix());
       }
     } else {
-      const uint8_t *filter_ir = global.lance_filter_ir.empty()
-                                     ? nullptr
-                                     : reinterpret_cast<const uint8_t *>(
-                                           global.lance_filter_ir.data());
-      auto filter_ir_len = NumericCast<idx_t>(global.lance_filter_ir.size());
-
-      auto create_stream = [&](const uint8_t *ir, idx_t ir_len) -> void * {
-        if (bind_data.mode == LanceSearchMode::Fts) {
-          return lance_create_fts_stream_ir(
-              bind_data.dataset, bind_data.text_column.c_str(),
-              bind_data.query.c_str(), bind_data.k, ir,
-              NumericCast<size_t>(ir_len), bind_data.prefilter ? 1 : 0);
-        }
-        return lance_create_hybrid_stream_ir(
-            bind_data.dataset, bind_data.vector_column.c_str(),
-            bind_data.vector_query.data(), bind_data.vector_query.size(),
-            bind_data.text_column.c_str(), bind_data.text_query.c_str(),
-            bind_data.k, bind_data.nprobes, bind_data.refine_factor, ir,
-            NumericCast<size_t>(ir_len), bind_data.prefilter ? 1 : 0,
-            bind_data.use_index ? 1 : 0, bind_data.alpha,
-            bind_data.oversample_factor);
-      };
-
-      local_state.stream = create_stream(filter_ir, filter_ir_len);
-      if (!local_state.stream && filter_ir && !bind_data.prefilter) {
-        // Best-effort: if filter pushdown failed, retry without it and rely on
-        // DuckDB-side filter execution for correctness.
-        global.filter_pushdown_fallbacks.fetch_add(1);
-        global.filter_pushed_down = false;
-        local_state.filter_pushed_down = false;
-        local_state.stream = create_stream(nullptr, 0);
-      }
+      local_state.stream = CreateLanceSearchStreamWithFallback(
+          global, local_state, bind_data.prefilter,
+          [&](const uint8_t *ir, size_t ir_len) -> void * {
+            if (bind_data.mode == LanceSearchMode::Fts) {
+              return lance_create_fts_stream_ir(
+                  bind_data.dataset, bind_data.text_column.c_str(),
+                  bind_data.query.c_str(), bind_data.k, ir, ir_len,
+                  bind_data.prefilter ? 1 : 0);
+            }
+            return lance_create_hybrid_stream_ir(
+                bind_data.dataset, bind_data.vector_column.c_str(),
+                bind_data.vector_query.data(), bind_data.vector_query.size(),
+                bind_data.text_column.c_str(), bind_data.text_query.c_str(),
+                bind_data.k, bind_data.nprobes, bind_data.refine_factor, ir,
+                ir_len, bind_data.prefilter ? 1 : 0,
+                bind_data.use_index ? 1 : 0, bind_data.alpha,
+                bind_data.oversample_factor);
+          });
       if (!local_state.stream) {
         throw IOException("Failed to create Lance search stream" +
                           LanceFormatErrorSuffix());

--- a/src/lance_search.cpp
+++ b/src/lance_search.cpp
@@ -316,13 +316,38 @@ struct LanceKnnLocalState : public ArrowScanLocalState {
 // Encodes whatever DuckDB could not express as a TableFilter -- scalar
 // functions, LIKE/regexp, containment -- into filter IR parts the search
 // functions hand to Lance as a prefilter.
-static void
+//
+// Returns false when any predicate could not be encoded. Callers that require
+// a complete prefilter (prefilter=true) must reject the query in that case:
+// Lance would run top-k before the missing predicate, and DuckDB's post-scan
+// filter cannot restore rows lost to the truncation. Silent skipping is only
+// sound for prefilter=false, where filtering after top-k is the documented
+// semantics. `out_unencodable` receives the first predicate that failed.
+static bool
 CollectLancePushedFilterIRParts(LogicalGet &get, const vector<string> &names,
                                 const vector<LogicalType> &types,
                                 const vector<unique_ptr<Expression>> &filters,
-                                vector<string> &out_parts) {
+                                vector<string> &out_parts,
+                                string &out_unencodable) {
+  auto complete = true;
+  auto mark_unencodable = [&](const Expression &expr) {
+    if (complete) {
+      out_unencodable = expr.ToString();
+    }
+    complete = false;
+  };
   for (auto &expr : filters) {
-    if (!expr || expr->HasParameter() || expr->IsVolatile()) {
+    if (!expr) {
+      continue;
+    }
+    // Parameters are exempt from completeness: PREPARE plans once with the
+    // parameter unbound, and every EXECUTE re-plans with the value folded to a
+    // constant, which then encodes (or fails) here. Deferral, not loss.
+    if (expr->HasParameter()) {
+      continue;
+    }
+    if (expr->IsVolatile()) {
+      mark_unencodable(*expr);
       continue;
     }
     if (expr->expression_class == ExpressionClass::BOUND_COMPARISON) {
@@ -353,6 +378,9 @@ CollectLancePushedFilterIRParts(LogicalGet &get, const vector<string> &names,
                  node->expression_class == ExpressionClass::BOUND_REF;
         };
 
+        // Exempt from completeness: these comparisons are routed through
+        // `pushdown_expression` into TableFilters and reach Lance as prefilter
+        // SQL, so nothing is lost.
         if ((is_column(cmp.left) && is_constant(cmp.right)) ||
             (is_column(cmp.right) && is_constant(cmp.left))) {
           continue;
@@ -361,10 +389,12 @@ CollectLancePushedFilterIRParts(LogicalGet &get, const vector<string> &names,
     }
     string filter_ir;
     if (!TryBuildLanceExprFilterIR(get, names, types, true, *expr, filter_ir)) {
+      mark_unencodable(*expr);
       continue;
     }
     out_parts.push_back(std::move(filter_ir));
   }
+  return complete;
 }
 
 static void
@@ -375,9 +405,17 @@ LancePushdownComplexFilter(ClientContext &, LogicalGet &get,
     return;
   }
   auto &scan_bind = bind_data->Cast<LanceKnnBindData>();
-  CollectLancePushedFilterIRParts(get, scan_bind.names, scan_bind.types,
-                                  filters,
-                                  scan_bind.lance_pushed_filter_ir_parts);
+  string unencodable;
+  if (!CollectLancePushedFilterIRParts(
+          get, scan_bind.names, scan_bind.types, filters,
+          scan_bind.lance_pushed_filter_ir_parts, unencodable) &&
+      scan_bind.prefilter) {
+    throw InvalidInputException(
+        "lance_vector_search: predicate %s cannot be pushed to Lance as a "
+        "required prefilter; rewrite the predicate or set prefilter := false "
+        "to filter after top-k",
+        unencodable);
+  }
 }
 
 static bool LancePushdownExpression(ClientContext &, const LogicalGet &,
@@ -1375,9 +1413,19 @@ LanceSearchPushdownComplexFilter(ClientContext &, LogicalGet &get,
     return;
   }
   auto &search_bind = bind_data->Cast<LanceSearchBindData>();
-  CollectLancePushedFilterIRParts(get, search_bind.names, search_bind.types,
-                                  filters,
-                                  search_bind.lance_pushed_filter_ir_parts);
+  string unencodable;
+  if (!CollectLancePushedFilterIRParts(
+          get, search_bind.names, search_bind.types, filters,
+          search_bind.lance_pushed_filter_ir_parts, unencodable) &&
+      search_bind.prefilter) {
+    throw InvalidInputException(
+        "%s: predicate %s cannot be pushed to Lance as a required prefilter; "
+        "rewrite the predicate or set prefilter := false to filter after "
+        "top-k",
+        search_bind.mode == LanceSearchMode::Fts ? "lance_fts"
+                                                 : "lance_hybrid_search",
+        unencodable);
+  }
 }
 
 static unique_ptr<GlobalTableFunctionState>

--- a/src/lance_storage.cpp
+++ b/src/lance_storage.cpp
@@ -1031,6 +1031,7 @@ public:
     auto props = context.GetClientProperties();
     ArrowConverter::ToArrowSchema(&schema_root.arrow_schema, types, names,
                                   props);
+    LanceNormalizeArrowListFieldNames(&schema_root.arrow_schema);
 
     auto mode = CreateTableModeFromConflict(create_info.on_conflict);
     vector<const char *> key_ptrs;
@@ -1279,6 +1280,7 @@ public:
           ArrowConverter::ToArrowSchema(&state->schema_root.arrow_schema,
                                         state->column_types,
                                         state->column_names, props);
+          LanceNormalizeArrowListFieldNames(&state->schema_root.arrow_schema);
 
           unordered_map<string, Value> overrides;
           if (!state->bearer_token_override.empty()) {

--- a/src/lance_write.cpp
+++ b/src/lance_write.cpp
@@ -5,6 +5,7 @@
 #include "duckdb/function/copy_function.hpp"
 #include "duckdb/main/extension/extension_loader.hpp"
 
+#include "lance_arrow_compat.hpp"
 #include "lance_common.hpp"
 #include "lance_dataset_cache.hpp"
 #include "lance_ffi.hpp"
@@ -135,6 +136,7 @@ LanceWriteInitGlobal(ClientContext &context, FunctionData &bind_data_p,
          sizeof(state->schema_root.arrow_schema));
   ArrowConverter::ToArrowSchema(&state->schema_root.arrow_schema,
                                 bind_data.types, bind_data.names, props);
+  LanceNormalizeArrowListFieldNames(&state->schema_root.arrow_schema);
 
   vector<string> option_keys;
   vector<string> option_values;

--- a/test/sql/pushdown_filter_ir_containment.test
+++ b/test/sql/pushdown_filter_ir_containment.test
@@ -383,3 +383,51 @@ FROM lance_hybrid_search('test/.tmp/filter_ir_containment.lance',
 WHERE array_has_all(tags, ['red', 'green']);
 ----
 analyzed_plan	<REGEX>:[\s\S]*"Lance Filter IR Bytes": "[1-9][0-9]*"[\s\S]*
+
+# ===================================================================
+# Required prefilter rejects predicates it cannot encode
+# ===================================================================
+
+# An empty needle is not pushed down. With prefilter=true that must be an
+# error, not a silent skip: top-k would run before the missing predicate and
+# post-filtering the truncated result loses rows.
+
+statement error
+SELECT id
+FROM lance_vector_search('test/.tmp/filter_ir_containment.lance', 'vec',
+                         [0.0, 0.0, 0.0, 0.0]::FLOAT[4], k = 2, prefilter = true)
+WHERE array_has_all(tags, []::VARCHAR[]);
+----
+Invalid Input Error: lance_vector_search: predicate array_has_all(tags, []) cannot be pushed to Lance as a required prefilter
+
+statement error
+SELECT id
+FROM lance_fts('test/.tmp/filter_ir_containment.lance', 'text', 'puppy',
+               k = 6, prefilter = true)
+WHERE array_has_all(tags, []::VARCHAR[]);
+----
+Invalid Input Error: lance_fts: predicate array_has_all(tags, []) cannot be pushed to Lance as a required prefilter
+
+statement error
+SELECT id
+FROM lance_hybrid_search('test/.tmp/filter_ir_containment.lance',
+                         'vec', [0.0, 0.0, 0.0, 0.0]::FLOAT[4],
+                         'text', 'puppy',
+                         k = 4, prefilter = true)
+WHERE array_has_all(tags, []::VARCHAR[]);
+----
+Invalid Input Error: lance_hybrid_search: predicate array_has_all(tags, []) cannot be pushed to Lance as a required prefilter
+
+# With prefilter=false the same predicate stays on the DuckDB side and filters
+# after top-k, which is the documented semantics.
+query I
+SELECT id
+FROM lance_vector_search('test/.tmp/filter_ir_containment.lance', 'vec',
+                         [0.0, 0.0, 0.0, 0.0]::FLOAT[4], k = 6, prefilter = false)
+WHERE array_has_all(tags, []::VARCHAR[]) ORDER BY id;
+----
+1
+2
+3
+4
+5

--- a/test/sql/pushdown_filter_ir_containment.test
+++ b/test/sql/pushdown_filter_ir_containment.test
@@ -250,6 +250,30 @@ EXECUTE containment_all(['red', 'green']::VARCHAR[]);
 ----
 4
 
+# A bound list parameter folds to a list constant and pushes down from the
+# search functions too -- `pushdown_complex_filter` skips anything still
+# carrying a parameter, so this must stay folded.
+
+statement ok
+PREPARE hybrid_containment AS
+SELECT id
+FROM lance_hybrid_search('test/.tmp/filter_ir_containment.lance',
+                         'vec', [0.0, 0.0, 0.0, 0.0]::FLOAT[4],
+                         'text', 'puppy',
+                         k = 4, prefilter = true)
+WHERE array_has_any(tags, $1) ORDER BY id;
+
+query I
+EXECUTE hybrid_containment(['red']::VARCHAR[]);
+----
+1
+4
+
+query II
+EXPLAIN (ANALYZE, FORMAT JSON) EXECUTE hybrid_containment(['red']::VARCHAR[]);
+----
+analyzed_plan	<REGEX>:[\s\S]*"Lance Filter IR Bytes": "[1-9][0-9]*"[\s\S]*
+
 # ===================================================================
 # Search prefilter: k matching rows come back
 # ===================================================================
@@ -287,11 +311,75 @@ ORDER BY id;
 2
 3
 
+# `puppy` matches rows 1, 2, 4 and 6; `red` narrows that to 1 and 4.
+query I
+SELECT id
+FROM lance_hybrid_search('test/.tmp/filter_ir_containment.lance',
+                         'vec', [0.0, 0.0, 0.0, 0.0]::FLOAT[4],
+                         'text', 'puppy',
+                         k = 4, prefilter = true)
+WHERE array_has_any(tags, ['red'])
+ORDER BY id;
+----
+1
+4
+
+query I
+SELECT id
+FROM lance_hybrid_search('test/.tmp/filter_ir_containment.lance',
+                         'vec', [0.0, 0.0, 0.0, 0.0]::FLOAT[4],
+                         'text', 'puppy',
+                         k = 4, prefilter = true)
+WHERE array_has_all(tags, ['red', 'green'])
+ORDER BY id;
+----
+4
+
+# `puppy` matches rows 1, 2, 4 and 6 in the inverted index.
+query I
+SELECT id
+FROM lance_fts('test/.tmp/filter_ir_containment.lance', 'text', 'puppy',
+               k = 6, prefilter = true)
+WHERE array_has_any(tags, ['red'])
+ORDER BY id;
+----
+1
+4
+
+query I
+SELECT id
+FROM lance_fts('test/.tmp/filter_ir_containment.lance', 'text', 'puppy',
+               k = 6, prefilter = true)
+WHERE array_has_all(tags, ['red', 'green'])
+ORDER BY id;
+----
+4
+
+query II
+EXPLAIN (ANALYZE, FORMAT JSON)
+SELECT id
+FROM lance_fts('test/.tmp/filter_ir_containment.lance', 'text', 'puppy',
+               k = 6, prefilter = true)
+WHERE array_has_any(tags, ['red']);
+----
+analyzed_plan	<REGEX>:[\s\S]*"Lance Filter IR Bytes": "[1-9][0-9]*"[\s\S]*
+
 query II
 EXPLAIN (ANALYZE, FORMAT JSON)
 SELECT id
 FROM lance_vector_search('test/.tmp/filter_ir_containment.lance', 'vec',
                          [0.0, 0.0, 0.0, 0.0]::FLOAT[4], k = 2, prefilter = true)
 WHERE array_has_any(tags, ['green']);
+----
+analyzed_plan	<REGEX>:[\s\S]*"Lance Filter IR Bytes": "[1-9][0-9]*"[\s\S]*
+
+query II
+EXPLAIN (ANALYZE, FORMAT JSON)
+SELECT id
+FROM lance_hybrid_search('test/.tmp/filter_ir_containment.lance',
+                         'vec', [0.0, 0.0, 0.0, 0.0]::FLOAT[4],
+                         'text', 'puppy',
+                         k = 4, prefilter = true)
+WHERE array_has_all(tags, ['red', 'green']);
 ----
 analyzed_plan	<REGEX>:[\s\S]*"Lance Filter IR Bytes": "[1-9][0-9]*"[\s\S]*

--- a/test/sql/pushdown_filter_ir_containment.test
+++ b/test/sql/pushdown_filter_ir_containment.test
@@ -1,0 +1,297 @@
+# name: test/sql/pushdown_filter_ir_containment.test
+# description: array_has_any/array_has_all containment pushdown over LABEL_LIST columns
+# group: [sql]
+
+require lance
+
+statement ok
+COPY (
+  SELECT * FROM (VALUES
+    (1::BIGINT, 'puppy dog'::VARCHAR, [0.1, 0.0, 0.0, 0.0]::FLOAT[4],
+     ['red', 'blue']::VARCHAR[], [1, 2]::BIGINT[], ['blue']::VARCHAR[]),
+    (2::BIGINT, 'puppy cat'::VARCHAR, [0.2, 0.0, 0.0, 0.0]::FLOAT[4],
+     ['blue', 'green']::VARCHAR[], [2, 3]::BIGINT[], ['red']::VARCHAR[]),
+    (3::BIGINT, 'kitten cat'::VARCHAR, [0.3, 0.0, 0.0, 0.0]::FLOAT[4],
+     ['green']::VARCHAR[], [3]::BIGINT[], ['green']::VARCHAR[]),
+    (4::BIGINT, 'puppy bird'::VARCHAR, [0.4, 0.0, 0.0, 0.0]::FLOAT[4],
+     ['red', 'green']::VARCHAR[], [1, 3]::BIGINT[], ['purple']::VARCHAR[]),
+    (5::BIGINT, 'fish tank'::VARCHAR, [0.5, 0.0, 0.0, 0.0]::FLOAT[4],
+     []::VARCHAR[], []::BIGINT[], ['red']::VARCHAR[]),
+    (6::BIGINT, 'puppy fish'::VARCHAR, [0.6, 0.0, 0.0, 0.0]::FLOAT[4],
+     NULL::VARCHAR[], NULL::BIGINT[], ['red']::VARCHAR[])
+  ) t(id, text, vec, tags, nums, other_tags)
+) TO 'test/.tmp/filter_ir_containment.lance' (FORMAT lance, mode 'overwrite');
+
+statement ok
+CREATE INDEX tags_idx ON 'test/.tmp/filter_ir_containment.lance' (tags) USING LABEL_LIST;
+
+statement ok
+CREATE INDEX text_idx ON 'test/.tmp/filter_ir_containment.lance' (text) USING INVERTED;
+
+# ===================================================================
+# Correctness on plain scans
+# ===================================================================
+
+query I
+SELECT id FROM 'test/.tmp/filter_ir_containment.lance'
+WHERE array_has_any(tags, ['red']) ORDER BY id;
+----
+1
+4
+
+query I
+SELECT id FROM 'test/.tmp/filter_ir_containment.lance'
+WHERE array_has_any(tags, ['red', 'green']) ORDER BY id;
+----
+1
+2
+3
+4
+
+query I
+SELECT id FROM 'test/.tmp/filter_ir_containment.lance'
+WHERE array_has_all(tags, ['red', 'blue']) ORDER BY id;
+----
+1
+
+query I
+SELECT id FROM 'test/.tmp/filter_ir_containment.lance'
+WHERE array_has_all(tags, ['green']) ORDER BY id;
+----
+2
+3
+4
+
+# The `list_*` spelling of the same DuckDB functions pushes down identically.
+query I
+SELECT id FROM 'test/.tmp/filter_ir_containment.lance'
+WHERE list_has_any(tags, ['blue']) ORDER BY id;
+----
+1
+2
+
+query I
+SELECT id FROM 'test/.tmp/filter_ir_containment.lance'
+WHERE list_has_all(tags, ['red', 'green']) ORDER BY id;
+----
+4
+
+# Non-string element types.
+query I
+SELECT id FROM 'test/.tmp/filter_ir_containment.lance'
+WHERE array_has_any(nums, [3]::BIGINT[]) ORDER BY id;
+----
+2
+3
+4
+
+query I
+SELECT id FROM 'test/.tmp/filter_ir_containment.lance'
+WHERE array_has_all(nums, [1, 3]::BIGINT[]) ORDER BY id;
+----
+4
+
+# Cast-wrapped constant needle.
+query I
+SELECT id FROM 'test/.tmp/filter_ir_containment.lance'
+WHERE array_has_any(tags, CAST(['red', 'green'] AS VARCHAR[])) ORDER BY id;
+----
+1
+2
+3
+4
+
+# Negation keeps SQL three-valued semantics: row 6 has NULL tags.
+query I
+SELECT id FROM 'test/.tmp/filter_ir_containment.lance'
+WHERE NOT array_has_any(tags, ['red']) ORDER BY id;
+----
+2
+3
+5
+
+# Conjunction with an ordinary pushed predicate.
+query I
+SELECT id FROM 'test/.tmp/filter_ir_containment.lance'
+WHERE array_has_any(tags, ['green']) AND id > 2 ORDER BY id;
+----
+3
+4
+
+# ===================================================================
+# Pushdown diagnostics
+# ===================================================================
+
+query II
+EXPLAIN (FORMAT JSON) SELECT id FROM 'test/.tmp/filter_ir_containment.lance'
+WHERE array_has_any(tags, ['red', 'blue']);
+----
+physical_plan	<REGEX>:[\s\S]*"Lance Filter IR Bytes \(Bind\)": "[1-9][0-9]*"[\s\S]*
+
+query II
+EXPLAIN (FORMAT JSON) SELECT id FROM 'test/.tmp/filter_ir_containment.lance'
+WHERE array_has_all(tags, ['red', 'blue']);
+----
+physical_plan	<REGEX>:[\s\S]*"Lance Filter IR Bytes \(Bind\)": "[1-9][0-9]*"[\s\S]*
+
+query II
+EXPLAIN (FORMAT JSON) SELECT id FROM 'test/.tmp/filter_ir_containment.lance'
+WHERE array_has_any(nums, [3]::BIGINT[]);
+----
+physical_plan	<REGEX>:[\s\S]*"Lance Filter IR Bytes \(Bind\)": "[1-9][0-9]*"[\s\S]*
+
+query II
+EXPLAIN (ANALYZE, FORMAT JSON) SELECT id FROM 'test/.tmp/filter_ir_containment.lance'
+WHERE array_has_any(tags, ['red', 'blue']);
+----
+analyzed_plan	<REGEX>:[\s\S]*"Lance Filter Pushdown Fallbacks": "0"[\s\S]*
+
+# An indexed containment predicate resolves through the dataset scanner.
+query II
+EXPLAIN (ANALYZE, FORMAT JSON) SELECT id FROM 'test/.tmp/filter_ir_containment.lance'
+WHERE array_has_any(tags, ['red']);
+----
+analyzed_plan	<REGEX>:[\s\S]*"Lance Scan Mode": "dataset"[\s\S]*
+
+# ===================================================================
+# LABEL_LIST index usage
+#
+# DuckDB's Arrow exporter names list child fields `l`; the write paths rewrite
+# them to Arrow's `item` so DataFusion leaves the column uncoerced and Lance's
+# scalar-index planner can see it. Without that the predicate still pushes down
+# and prefilters, but Lance answers it with a scan.
+# ===================================================================
+
+# The predicate becomes a LABEL_LIST index query with no refine (recheck) step.
+query II
+EXPLAIN (FORMAT JSON)
+SELECT id FROM __lance_scan('test/.tmp/filter_ir_containment.lance',
+                            explain_verbose = true)
+WHERE array_has_any(tags, ['red']);
+----
+physical_plan	<REGEX>:[\s\S]*ScalarIndexQuery: query=\[array_has_any\(tags, List\(\[red\]\)\)\]@tags_idx\(LabelList\)[\s\S]*
+
+query II
+EXPLAIN (FORMAT JSON)
+SELECT id FROM __lance_scan('test/.tmp/filter_ir_containment.lance',
+                            explain_verbose = true)
+WHERE array_has_all(tags, ['red', 'green']);
+----
+physical_plan	<REGEX>:[\s\S]*refine_filter=--[\s\S]*ScalarIndexQuery: query=\[array_has_all\(tags, List\(\[red, green\]\)\)\]@tags_idx\(LabelList\)[\s\S]*
+
+# ===================================================================
+# Negative case: a non-constant needle falls back to DuckDB
+# ===================================================================
+
+query I
+SELECT id FROM 'test/.tmp/filter_ir_containment.lance'
+WHERE array_has_any(tags, other_tags) ORDER BY id;
+----
+1
+3
+
+query II
+EXPLAIN (ANALYZE, FORMAT JSON) SELECT id FROM 'test/.tmp/filter_ir_containment.lance'
+WHERE array_has_any(tags, other_tags);
+----
+analyzed_plan	<REGEX>:[\s\S]*"Lance Filter IR Bytes": "0"[\s\S]*
+
+# An empty needle is not pushed down, but still returns DuckDB semantics.
+query I
+SELECT id FROM 'test/.tmp/filter_ir_containment.lance'
+WHERE array_has_all(tags, []::VARCHAR[]) ORDER BY id;
+----
+1
+2
+3
+4
+5
+
+query I
+SELECT id FROM 'test/.tmp/filter_ir_containment.lance'
+WHERE array_has_any(tags, []::VARCHAR[]) ORDER BY id;
+----
+
+# A NULL needle element is not pushed down, but still returns DuckDB semantics.
+query I
+SELECT id FROM 'test/.tmp/filter_ir_containment.lance'
+WHERE array_has_any(tags, ['red', NULL]::VARCHAR[]) ORDER BY id;
+----
+1
+4
+
+# ===================================================================
+# Bound parameters fold to a list constant
+# ===================================================================
+
+statement ok
+PREPARE containment_any AS SELECT id FROM 'test/.tmp/filter_ir_containment.lance'
+WHERE array_has_any(tags, $1) ORDER BY id;
+
+query I
+EXECUTE containment_any(['red']::VARCHAR[]);
+----
+1
+4
+
+query I
+EXECUTE containment_any(['green']::VARCHAR[]);
+----
+2
+3
+4
+
+statement ok
+PREPARE containment_all AS SELECT id FROM 'test/.tmp/filter_ir_containment.lance'
+WHERE array_has_all(tags, $1) ORDER BY id;
+
+query I
+EXECUTE containment_all(['red', 'green']::VARCHAR[]);
+----
+4
+
+# ===================================================================
+# Search prefilter: k matching rows come back
+# ===================================================================
+
+# Rows 2, 3 and 4 match the predicate; the two nearest of those are 2 and 3, so
+# a prefiltered k=2 search returns k matching rows.
+query I
+SELECT id
+FROM lance_vector_search('test/.tmp/filter_ir_containment.lance', 'vec',
+                         [0.0, 0.0, 0.0, 0.0]::FLOAT[4], k = 2, prefilter = true)
+WHERE array_has_any(tags, ['green'])
+ORDER BY id;
+----
+2
+3
+
+# Without the prefilter the same k=2 search picks rows 1 and 2 first, so only
+# one of them survives the predicate.
+query I
+SELECT id
+FROM lance_vector_search('test/.tmp/filter_ir_containment.lance', 'vec',
+                         [0.0, 0.0, 0.0, 0.0]::FLOAT[4], k = 2, prefilter = false)
+WHERE array_has_any(tags, ['green'])
+ORDER BY id;
+----
+2
+
+query I
+SELECT id
+FROM lance_vector_search('test/.tmp/filter_ir_containment.lance', 'vec',
+                         [0.0, 0.0, 0.0, 0.0]::FLOAT[4], k = 2, prefilter = true)
+WHERE array_has_all(tags, ['green'])
+ORDER BY id;
+----
+2
+3
+
+query II
+EXPLAIN (ANALYZE, FORMAT JSON)
+SELECT id
+FROM lance_vector_search('test/.tmp/filter_ir_containment.lance', 'vec',
+                         [0.0, 0.0, 0.0, 0.0]::FLOAT[4], k = 2, prefilter = true)
+WHERE array_has_any(tags, ['green']);
+----
+analyzed_plan	<REGEX>:[\s\S]*"Lance Filter IR Bytes": "[1-9][0-9]*"[\s\S]*

--- a/test/sql/pushdown_filter_ir_containment_namespace.test
+++ b/test/sql/pushdown_filter_ir_containment_namespace.test
@@ -1,0 +1,116 @@
+# name: test/sql/pushdown_filter_ir_containment_namespace.test
+# description: array_has_any/array_has_all containment pushdown on namespace-backed tables
+# group: [sql]
+
+require lance
+
+# Rows 9 to 12 carry both tags and are the worst matches on purpose: their embeddings are
+# the farthest and their content is padded, which BM25 penalises. With k := 2 the two best
+# scoring rows are 1 and 2, so a search that filters AFTER selecting top-k returns nothing.
+# Every assertion below therefore proves prefiltering from its row set alone.
+#
+# COPY creates the namespace root directory; ATTACH does not.
+statement ok
+COPY (
+  SELECT i::BIGINT                                                    AS id,
+         CASE WHEN i >= 9 THEN 'puppy ' || repeat('filler ', 20)
+              ELSE 'puppy' END                                        AS content,
+         [i / 100.0, 0.0, 0.0, 0.0]::FLOAT[4]                         AS embedding,
+         CASE WHEN i >= 9      THEN ['project-x', 'design']::VARCHAR[]
+              WHEN i % 3 = 0   THEN ['project-x']::VARCHAR[]
+              WHEN i % 3 = 1   THEN ['design']::VARCHAR[]
+              ELSE                  ['other']::VARCHAR[] END          AS tags,
+         (i != 10)                                                    AS active,
+         (i = 11)                                                     AS archived
+  FROM range(1, 13) t(i)
+) TO 'test/.tmp/containment_ns/items.lance' (FORMAT lance, mode 'overwrite');
+
+statement ok
+ATTACH 'test/.tmp/containment_ns' AS containment_ns (TYPE LANCE);
+
+statement ok
+CREATE INDEX tags_idx ON containment_ns.main.items (tags) USING LABEL_LIST;
+
+statement ok
+CREATE INDEX content_idx ON containment_ns.main.items (content) USING INVERTED;
+
+# The boolean guards drop the inactive row 10 and the archived row 11, leaving 9 and 12.
+
+query I
+SELECT id
+FROM lance_fts('containment_ns.main.items', 'content', 'puppy', k := 2, prefilter := true)
+WHERE active = true
+  AND archived = false
+  AND array_has_all(tags, ['project-x', 'design'])
+ORDER BY id;
+----
+9
+12
+
+# The same query without the prefilter: k := 2 selects rows 1 and 2, which carry neither tag.
+query I
+SELECT id
+FROM lance_fts('containment_ns.main.items', 'content', 'puppy', k := 2, prefilter := false)
+WHERE active = true
+  AND archived = false
+  AND array_has_all(tags, ['project-x', 'design'])
+ORDER BY id;
+----
+
+query I
+SELECT id
+FROM lance_vector_search('containment_ns.main.items', 'embedding', [0.0, 0.0, 0.0, 0.0]::FLOAT[4],
+                         k := 2, prefilter := true)
+WHERE active = true
+  AND archived = false
+  AND array_has_all(tags, ['project-x', 'design'])
+ORDER BY id;
+----
+9
+12
+
+query I
+SELECT id
+FROM lance_hybrid_search('containment_ns.main.items', 'embedding', [0.0, 0.0, 0.0, 0.0]::FLOAT[4],
+                         'content', 'puppy', k := 2, prefilter := true)
+WHERE active = true
+  AND archived = false
+  AND array_has_all(tags, ['project-x', 'design'])
+ORDER BY id;
+----
+9
+12
+
+# A bound list parameter must fold to a constant before pushdown, which skips any expression
+# still carrying a parameter. Unfolded, the predicate would post-filter and return nothing.
+statement ok
+PREPARE ns_containment AS
+SELECT id
+FROM lance_fts('containment_ns.main.items', 'content', $query, k := $k, prefilter := $prefilter)
+WHERE active = true
+  AND archived = false
+  AND array_has_all(tags, CAST($tags AS VARCHAR[]))
+ORDER BY id;
+
+query I
+EXECUTE ns_containment(query := 'puppy', k := 2, prefilter := true,
+                       tags := ['project-x', 'design']::VARCHAR[]);
+----
+9
+12
+
+# An explicit filter argument combines with the pushed WHERE clause rather than replacing it:
+# the filter admits rows 9, 11 and 12, and the pushed clause removes the archived row 11.
+query I
+SELECT id
+FROM lance_fts('containment_ns.main.items', 'content', 'puppy', k := 4, prefilter := true,
+               filter := 'active = true')
+WHERE archived = false
+  AND array_has_all(tags, ['project-x', 'design'])
+ORDER BY id;
+----
+9
+12
+
+statement ok
+DETACH containment_ns;

--- a/test/sql/pushdown_filter_ir_containment_namespace.test
+++ b/test/sql/pushdown_filter_ir_containment_namespace.test
@@ -112,5 +112,46 @@ ORDER BY id;
 9
 12
 
+# ===================================================================
+# Pushed IR the namespace backend cannot parse falls back to DuckDB
+# ===================================================================
+
+# Lance rejects the regexp 'p' option flag when parsing the pushed IR at
+# stream creation. With prefilter=false the stream is recreated without the
+# generated IR and DuckDB applies the predicate after top-k -- the same
+# semantics as the path-backed search. Rows 1 and 2 are the top-2 and both
+# match 'p.ppy'.
+query I
+SELECT count(*)
+FROM lance_fts('containment_ns.main.items', 'content', 'puppy', k := 2, prefilter := false)
+WHERE regexp_matches(content, 'p.ppy', 'p');
+----
+2
+
+query II
+EXPLAIN (ANALYZE, FORMAT JSON)
+SELECT count(*)
+FROM lance_fts('containment_ns.main.items', 'content', 'puppy', k := 2, prefilter := false)
+WHERE regexp_matches(content, 'p.ppy', 'p');
+----
+analyzed_plan	<REGEX>:[\s\S]*"Lance Filter Pushdown Fallbacks": "1"[\s\S]*
+
+query I
+SELECT count(*)
+FROM lance_vector_search('containment_ns.main.items', 'embedding', [0.0, 0.0, 0.0, 0.0]::FLOAT[4],
+                         k := 2, prefilter := false)
+WHERE regexp_matches(content, 'p.ppy', 'p');
+----
+2
+
+# With prefilter=true the pushed IR is required for correctness, so the
+# backend's rejection surfaces instead of a silent retry.
+statement error
+SELECT count(*)
+FROM lance_fts('containment_ns.main.items', 'content', 'puppy', k := 2, prefilter := true)
+WHERE regexp_matches(content, 'p.ppy', 'p');
+----
+unsupported regexp option: p
+
 statement ok
 DETACH containment_ns;

--- a/test/sql/search_functions.test
+++ b/test/sql/search_functions.test
@@ -467,8 +467,8 @@ ORDER BY id
 ----
 3
 
-# FTS namespace query_table prefilter requires explicit namespace filter
-statement error
+# FTS namespace query_table prefilter with a pushed WHERE clause
+query I
 SELECT id
 FROM lance_fts(
   'search_ns.main.search_test_data',
@@ -478,8 +478,9 @@ FROM lance_fts(
   prefilter = true
 )
 WHERE label >= 3
+ORDER BY id
 ----
-Invalid Input Error: lance_fts requires explicit filter when prefilter=true on namespace-backed tables
+3
 
 # FTS namespace query_table prefilter with explicit filter
 query I
@@ -528,8 +529,8 @@ ORDER BY _distance
 4
 5
 
-# Vector namespace query_table prefilter requires explicit namespace filter
-statement error
+# Vector namespace query_table prefilter with a pushed WHERE clause
+query I
 SELECT id
 FROM lance_vector_search(
   'search_ns.main.search_test_data',
@@ -540,8 +541,10 @@ FROM lance_vector_search(
   use_index = false
 )
 WHERE label >= 4
+ORDER BY id
 ----
-Invalid Input Error: lance_vector_search requires explicit filter when prefilter=true on namespace-backed tables
+4
+5
 
 # Vector namespace query_table prefilter with explicit filter
 query I


### PR DESCRIPTION
# feat(pushdown): push array_has_any/array_has_all into Lance

*Investigated, implemented and tested with the help of [Claude Code](https://claude.com/claude-code).*

## Summary

No containment predicate on a `LIST` column could prefilter a search. `LanceExprIRSupportsLogicalType`
gated on the column's `LogicalTypeId`, and rejected `LIST` before it looked at the function, so
`array_has_any` and `array_has_all` never left DuckDB while `id > 5`, `IN` and `LIKE` on scalar columns
pushed normally. DuckDB applied the containment predicate after the search had already run, so callers had
to oversample `k` until the candidate pool covered the whole table, or the search silently missed matching
rows outside the top-k. `prefilter := true` neither helped nor errored, it quietly did nothing. Lance can
already answer these predicates from a `LABEL_LIST` index
(`LabelListQueryParser::visit_scalar_function` in `lance-index`); the extension never handed them over.
This PR does that, and fixes three further things that sat between sending the predicate and Lance using
the index.

## Before and After

`ns` is any catalog from `ATTACH '<dir>' AS ns (TYPE LANCE)`. `✅` means the predicate reaches Lance and
Lance filters, `❌` means it never left DuckDB. A scan has no `prefilter` argument and no top-k, so a missed
pushdown costs time. On a search it changes the answer: the search picks its top-k before applying the
predicate, so you get back fewer rows than you asked for.

| Table addressed as | scan | `lance_hybrid_search` | `lance_vector_search` | `lance_fts` |
|---|---|---|---|---|
| `'data/items.lance'` | ❌ → ✅ | ❌ → ✅ | ❌ → ✅ | ❌ → ✅ |
| `ns.main.items` | ❌ → ✅ | ❌ → ✅ | ❌ → ✅ | ❌ → ✅ |

Containment worked nowhere, under either way of addressing the table, and the index was unreachable by
construction. With a `LABEL_LIST` index on the list column the scan `✅` is an index lookup rather than a
full read; without one the predicate still pushes and Lance answers it by scanning. `LABEL_LIST` is the
only scalar index that answers containment.

The same defects blocked other predicates, so those are fixed by construction rather than as extra scope.
Cells with a single `✅` already worked and are unchanged.

| Predicate | Table addressed as | scan | `lance_hybrid_search` | `lance_vector_search` | `lance_fts` |
|---|---|---|---|---|---|
| `id > 5`, `=`, numeric `IN` | `'data/items.lance'` | ✅ | ✅ | ✅ | ✅ |
| | `ns.main.items` | ✅ | ✅ | ❌ → ✅ | ❌ → ✅ |
| `starts_with` / `LIKE` / `regexp` | `'data/items.lance'` | ✅ | ❌ → ✅ | ✅ | ❌ → ✅ |
| | `ns.main.items` | ✅ | ❌ → ✅ | ❌ → ✅ | ❌ → ✅ |
| `IS NULL` on a list column | `'data/items.lance'` | ❌ → ✅ | ❌ → ✅ | ❌ → ✅ | ❌ → ✅ |
| | `ns.main.items` | ❌ → ✅ | ❌ → ✅ | ❌ → ✅ | ❌ → ✅ |

The first two predicate groups resolve to a `BTREE` index when one exists on the compared column. No scalar
index answers `IS NULL` on a list column, so that row always scans.

One case this PR does not fix: `IN` over a `VARCHAR` column with two or more values throws
`requires filter pushdown for prefilterable columns` from all three search functions, before and after.
The same predicate pushes on a scan, and pushes from a search under `prefilter := false`, so the encoder
handles it; the prefilterable check rejects it. `CONJUNCTION_OR` over `VARCHAR` fails the same way.
Out of scope here, but worth an issue.

## Design

`LanceExprIRSupportsLogicalType` rejected `LogicalTypeId::LIST`, so any filter touching a list column
bailed out before anything examined the function name, and the IR had no list literal. This admits `LIST`
to the type gate, adds a `LIST` literal tag (a length-prefixed sequence of the existing scalar payloads,
recursive), and gives containment branches to both the `TableFilterSet` and `Expression` builders. Rust
decodes the tag into a `ScalarValue::List` and resolves the two UDFs from `datafusion-functions-nested`,
promoted from a transitive dependency to an explicit one. The IR always carries the DataFusion spelling, so
DuckDB's `list_has_any` / `list_has_all` aliases stay decoupled from it.

## Search Functions

`lance_fts` and `lance_hybrid_search` registered `filter_pushdown` and `pushdown_expression` but never
`pushdown_complex_filter`, so simple comparisons pushed while the optimizer dropped anything DuckDB models
as an expression. `LancePushdownComplexFilter` is typed against `LanceKnnBindData`, so this extracts its
body into `CollectLancePushedFilterIRParts` and gives both functions a hook over the `LanceSearchBindData`
they already share. This is wider than containment: `starts_with`, `LIKE` and `regexp_matches` have never
prefiltered from those two functions either, and now do.

## Namespace-Backed Tables

`lance_vector_search` and `lance_fts` rejected `prefilter := true` on an attached namespace table without
an explicit `filter := '<string>'`. That guard was correct when #217 added it: `query_table` takes a filter
string, DuckDB supplies an IR, and no converter existed. #232 then added `filter_expr_to_sql` for namespace
scans, but nothing pointed the search path at it. The two search entry points now take the same
`filter_ir` arguments as `lance_create_namespace_scan_stream_ir` and share its machinery via
`apply_filter_expr`; a pushed predicate and an explicit `filter` combine with AND. The init-time check the
path-backed code already used replaces the bind-time guard. The effect is wider than the guard suggests: no pushed
predicate of any kind previously reached a namespace-backed search, and `prefilter := true` without an
explicit filter threw outright rather than degrading.

## List Field Naming

DuckDB's Arrow exporter hardcodes the list child field name to `l`, while Arrow, pyarrow, Lance and
DataFusion use `item`, and Lance persists whatever it receives. DataFusion's array-signature coercion
normalizes every list argument to a child named `item`, so an `l` column gets wrapped in a cast and Lance's
`maybe_indexed_column` no longer matches it. The predicate pushed and prefiltered, but Lance answered it
with a scan:

```
full_filter=array_has_any(CAST(tags AS List(Utf8)), List([red])), refine_filter=array_has_any(…)
```

`LanceNormalizeArrowListFieldNames` rewrites the name to `item` at every write boundary: `COPY`, `INSERT`,
`CREATE TABLE`, CTAS, namespace create, and both `ALTER TABLE` paths. The plan then reads
`refine_filter=--` with a `ScalarIndexQuery … @tags_idx(LabelList)`.

## Compatibility

Renaming on write broke appends to older datasets, since Lance rejects a schema that disagrees with the
destination. The writer now reads the destination schema in `Append` mode and matches whatever that dataset
already uses, realigning the imported `data_type` alongside it. New datasets get `item`, existing ones keep
`l`.

Two behaviour changes. `lance_fts` and `lance_hybrid_search` now genuinely prefilter, which changes results
for anyone who set `prefilter := true` and was silently getting post-filtering. And datasets written before
this change keep `l` and will not use the index; they read, append and prefilter correctly, Lance just
answers with a scan. One metadata-only rename fixes a dataset, with no data rewrite:
`ALTER TABLE ns.main.t RENAME COLUMN "tags.l" TO item`.

## Deliberate Exclusions

Empty needles and NULL needle elements fall back to DuckDB, because DuckDB short-circuits an empty
`list_has_all` to true and ignores NULL elements where DataFusion compares them by value. A non-constant
second argument falls back too. Also excluded: the singular `array_has` / `array_contains`, and the `&&` /
`@>` / `<@` aliases, since DuckDB registers `<@` without swapping its arguments, unlike Postgres. Only the
containment branches emit the `LIST` tag, keeping `tags = ['a','b']` off a DataFusion list equality whose
nested comparison kernels are patchy. Admitting `LIST` to the type gate does push down `IS NULL` and
`IS NOT NULL` on list columns, which matches Arrow semantics.

Two scope notes on the index, found while testing and left alone. The `LABEL_LIST` index is reached for
`VARCHAR[]` and `BIGINT[]` element types. Narrower integer widths encode through the same `I64` literal
tag, so DataFusion coerces the column instead of the literal and the planner falls back to a scan; the
predicate still pushes and still prefilters, it is only the index lookup that is lost. An element-type hint
on the `LIST` tag would close it. Separately, `align_list_field_names` descends into struct children but
not into nested lists, so a legacy `List<List<T>>` column would still fail to append.

## Test Plan

- `pushdown_filter_ir_containment.test`: both functions and both DuckDB spellings across plain scans,
  `lance_vector_search`, `lance_fts` and `lance_hybrid_search`; `VARCHAR[]` and `BIGINT[]` elements; bound
  parameters; a k-semantics probe; index usage asserted through `explain_verbose`; every negative case
  checked for correct results and for not being pushed.
- `pushdown_filter_ir_containment_namespace.test`: the same ground against an attached catalog. The fixture
  makes the tagged rows the worst matches, so at `k := 2` a search that filters after top-k returns
  nothing, and every assertion proves prefiltering from its row set alone.
- Two tests in `search_functions.test` asserted the removed bind-time error as the contract, and now assert
  that a `WHERE` clause prefilters without an explicit filter.
- Four Rust unit tests cover the append schema alignment directly.
- Some assertions check the filter IR byte count rather than a result set, because the failure mode is
  silent: a plan that stops pushing still returns the right rows, from a full scan.
- Full regression suite: 4250 assertions across 53 test cases. `cargo clippy --all-targets` clean.

## Docs

`docs/sql.md` search filter semantics updated to match: pushed `WHERE` predicates and an explicit
`filter` combine with `AND`, and a new "Filter pushdown notes" section covers containment predicates,
the `LABEL_LIST` index, and the legacy `l` field-name remedy.

## Note on Cargo.lock

The lock diff sits in its own commit and is unrelated. `Cargo.toml` on `main` already requires
`datafusion = "54.0.0"` while the committed lock pins `53.1.0`, so `--locked` fails on `main` today and any
build regenerates it. This feature's own dependency change is one line of `Cargo.toml`.
