### PR TITLE
fix: replace schema-only directory namespace tables

### DIFF
--- a/docs/sql.md
+++ b/docs/sql.md
@@ -232,6 +232,27 @@ DETACH ns;
 `CREATE TABLE` and CTAS default to data storage version `2.2`. Override it with
 `WITH (data_storage_version = '<version>')` when another version is required.
 
+#### `CREATE OR REPLACE TABLE` semantics (schema-only)
+
+An empty writer in `overwrite` mode does not replace an existing dataset, so a
+schema-only `CREATE OR REPLACE TABLE` (without `AS SELECT`) must drop and
+recreate the dataset instead of relying on overwrite mode.
+
+- **Local directory namespaces** (`ATTACH '/path/to/dir' ...`, `ATTACH 'file:///path/to/dir'
+  ...`, or `ATTACH 'file://localhost/path/to/dir' ...`): the extension stages the new
+  dataset under `{root}/.duckdb_replace/{uuid}.lance`, then swaps it into place with a
+  local backup/restore path. A writer failure before the swap leaves the
+  original table intact.
+- **Remote directory namespaces** (`s3://`, `cos://`, ...): there is no atomic
+  rename across object stores. The extension drops the existing dataset first,
+  then writes the replacement in place. This is **not atomic** — if the writer
+  fails after the drop, the table may be missing or left in a partial state.
+  Concurrent `CREATE OR REPLACE TABLE` on the same table can also observe
+  intermediate states.
+
+CTAS `CREATE OR REPLACE TABLE ... AS SELECT` writes rows through the writer and
+does not use the staging swap path above.
+
 ## DML on attached tables
 
 These statements apply to tables inside an attached namespace (e.g. `ns.main.my_table`).

--- a/src/include/lance_common.hpp
+++ b/src/include/lance_common.hpp
@@ -17,6 +17,15 @@ void ApplyDuckDBFilters(ClientContext &context, TableFilterSet &filters,
 void *LanceOpenDataset(ClientContext &context, const string &path);
 
 string LanceNormalizeS3Scheme(const string &path);
+
+struct LanceResolvedPath {
+  string lance_uri;
+  string local_os_path;
+
+  bool IsLocal() const { return !local_os_path.empty(); }
+};
+
+LanceResolvedPath LanceResolvePath(ClientContext &context, const string &path);
 void LanceFillStorageOptionsFromSecrets(ClientContext &context,
                                         const string &path,
                                         vector<string> &out_keys,

--- a/src/lance_common.cpp
+++ b/src/lance_common.cpp
@@ -8,6 +8,7 @@
 #include "duckdb/catalog/catalog_transaction.hpp"
 #include "duckdb/common/arrow/arrow_wrapper.hpp"
 #include "duckdb/common/string_util.hpp"
+#include "duckdb/common/file_system.hpp"
 #include "duckdb/execution/expression_executor.hpp"
 #include "duckdb/main/secret/secret_manager.hpp"
 #include "duckdb/parser/qualified_name.hpp"
@@ -121,6 +122,87 @@ string LanceNormalizeS3Scheme(const string &path) {
     return "s3://" + path.substr(6);
   }
   return path;
+}
+
+static string DecodeFileUriPath(const string &encoded, const string &uri) {
+  auto decoded = StringUtil::URLDecode(encoded, false);
+  if (decoded.find('\0') != string::npos) {
+    throw InvalidInputException("File URI path contains an encoded NUL byte: " +
+                                uri);
+  }
+  return decoded;
+}
+
+static string ParseFileUriPathComponent(const string &path) {
+  if (path.size() < 7 || !StringUtil::CIEquals(path.substr(0, 7), "file://")) {
+    throw InvalidInputException("Expected file URI, got: " + path);
+  }
+  if (path.find('?') != string::npos || path.find('#') != string::npos) {
+    throw InvalidInputException(
+        "File URI query strings and fragments are not supported: " + path);
+  }
+
+  string rest = path.substr(7);
+  if (rest.empty()) {
+    return "/";
+  }
+
+  if (rest[0] == '/') {
+    return DecodeFileUriPath(rest, path);
+  }
+
+  auto slash = rest.find('/');
+  auto authority = slash == string::npos ? rest : rest.substr(0, slash);
+  if (StringUtil::CIEquals(authority, "localhost")) {
+    auto local_path = slash == string::npos ? "/" : rest.substr(slash);
+    return DecodeFileUriPath(local_path, path);
+  }
+  throw InvalidInputException(
+      "Unsupported file URI authority '%s' in '%s'; use "
+      "file:///absolute/path or file://localhost/absolute/path",
+      authority, path);
+}
+
+static string LocalOsPathToLanceUri(const string &path) {
+  auto uri_path = StringUtil::Replace(path, "\\", "/");
+  if (uri_path.empty() || uri_path[0] != '/') {
+    uri_path = "/" + uri_path;
+  }
+  return "file://" + StringUtil::URLEncode(uri_path, false);
+}
+
+static string ResolveLocalOsPath(ClientContext &context, const string &path) {
+  auto &fs = FileSystem::GetFileSystem(context);
+  auto expanded = fs.ExpandPath(path);
+  if (fs.IsPathAbsolute(expanded)) {
+    return expanded;
+  }
+  return fs.JoinPath(FileSystem::GetWorkingDirectory(), expanded);
+}
+
+LanceResolvedPath LanceResolvePath(ClientContext &context, const string &path) {
+  LanceResolvedPath result;
+  if (path.empty()) {
+    return result;
+  }
+  auto normalized = LanceNormalizeS3Scheme(path);
+
+  if (normalized.size() >= 7 &&
+      StringUtil::CIEquals(normalized.substr(0, 7), "file://")) {
+    auto path_component = ParseFileUriPathComponent(normalized);
+    result.local_os_path = ResolveLocalOsPath(context, path_component);
+    result.lance_uri = LocalOsPathToLanceUri(result.local_os_path);
+    return result;
+  }
+
+  if (normalized.find("://") != string::npos) {
+    result.lance_uri = normalized;
+    return result;
+  }
+
+  result.local_os_path = ResolveLocalOsPath(context, normalized);
+  result.lance_uri = LocalOsPathToLanceUri(result.local_os_path);
+  return result;
 }
 
 string LanceDirectoryNamespaceDatasetUri(const LanceNamespaceTableConfig &cfg) {
@@ -266,11 +348,16 @@ void ResolveLanceNamespaceAuthOverrides(
 void ResolveLanceStorageOptions(ClientContext &context, const string &path,
                                 string &out_open_path, vector<string> &out_keys,
                                 vector<string> &out_values) {
-  out_open_path = path;
   out_keys.clear();
   out_values.clear();
 
-  out_open_path = LanceNormalizeS3Scheme(out_open_path);
+  auto normalized = LanceNormalizeS3Scheme(path);
+  auto &fs = FileSystem::GetFileSystem(context);
+  auto is_file_uri = normalized.size() >= 7 &&
+                     StringUtil::CIEquals(normalized.substr(0, 7), "file://");
+  out_open_path = is_file_uri || fs.IsPathAbsolute(normalized)
+                      ? LanceResolvePath(context, normalized).lance_uri
+                      : normalized;
   LanceFillStorageOptionsFromSecrets(context, out_open_path, out_keys,
                                      out_values);
 }

--- a/src/lance_dataset_cache.cpp
+++ b/src/lance_dataset_cache.cpp
@@ -47,6 +47,9 @@ public:
 
   void QueryBegin(ClientContext &) override {
     lock_guard<mutex> guard(lock);
+    // Per-connection cache; clear each query to avoid stale handles across
+    // commits.
+    entries.clear();
     query_hits = 0;
     query_misses = 0;
   }

--- a/src/lance_storage.cpp
+++ b/src/lance_storage.cpp
@@ -12,6 +12,7 @@
 #include "duckdb/common/exception_format_value.hpp"
 #include "duckdb/common/file_system.hpp"
 #include "duckdb/common/string_util.hpp"
+#include "duckdb/common/types/uuid.hpp"
 #include "duckdb/execution/operator/persistent/physical_batch_copy_to_file.hpp"
 #include "duckdb/execution/operator/persistent/physical_copy_to_file.hpp"
 #include "duckdb/execution/operator/scan/physical_empty_result.hpp"
@@ -596,6 +597,98 @@ static string GetDatasetDirName(const string &table_name) {
   return table_name + ".lance";
 }
 
+enum class DirectoryReplaceStrategy { NONE, LOCAL_STAGED, REMOTE_DROP_FIRST };
+
+struct DirectoryReplacePlan {
+  DirectoryReplaceStrategy strategy = DirectoryReplaceStrategy::NONE;
+  LanceResolvedPath final_path;
+  LanceResolvedPath staging_path;
+
+  bool UsesCreateMode() const {
+    return strategy != DirectoryReplaceStrategy::NONE;
+  }
+};
+
+static LanceResolvedPath
+MakeDirectoryReplaceStagingPath(ClientContext &context,
+                                const LanceResolvedPath &namespace_root) {
+  if (!namespace_root.IsLocal()) {
+    throw InternalException(
+        "Staging CREATE OR REPLACE TABLE requires a local namespace root");
+  }
+  auto &fs = FileSystem::GetFileSystem(context);
+  auto staging_root =
+      JoinNamespacePath(namespace_root.local_os_path, ".duckdb_replace");
+  fs.CreateDirectory(staging_root);
+  auto staging_os = JoinNamespacePath(
+      staging_root, UUID::ToString(UUID::GenerateRandomUUID()) + ".lance");
+  return LanceResolvePath(context, staging_os);
+}
+
+static void TryRemoveLocalDatasetDirectory(FileSystem &fs,
+                                           const string &os_path) {
+  try {
+    if (!os_path.empty() && fs.DirectoryExists(os_path)) {
+      fs.RemoveDirectory(os_path);
+    }
+  } catch (...) {
+  }
+}
+
+class DirectoryReplaceStagingGuard {
+public:
+  DirectoryReplaceStagingGuard(ClientContext &context_p,
+                               const string &staging_os_path_p)
+      : context(context_p), staging_os_path(staging_os_path_p),
+        active(!staging_os_path.empty()) {}
+
+  void Release() { active = false; }
+
+  ~DirectoryReplaceStagingGuard() {
+    if (active) {
+      TryRemoveLocalDatasetDirectory(FileSystem::GetFileSystem(context),
+                                     staging_os_path);
+    }
+  }
+
+private:
+  ClientContext &context;
+  string staging_os_path;
+  bool active;
+};
+
+class LanceSchemaEntry;
+
+static void
+DropDirectoryNamespaceTable(const LanceDirectoryNamespaceConfig &directory_ns,
+                            const string &table_name) {
+  vector<const char *> key_ptrs;
+  vector<const char *> value_ptrs;
+  BuildStorageOptionPointerArrays(directory_ns.option_keys,
+                                  directory_ns.option_values, key_ptrs,
+                                  value_ptrs);
+  auto rc = lance_dir_namespace_drop_table(
+      directory_ns.root.c_str(), table_name.c_str(),
+      key_ptrs.empty() ? nullptr : key_ptrs.data(),
+      value_ptrs.empty() ? nullptr : value_ptrs.data(),
+      directory_ns.option_keys.size());
+  if (rc != 0) {
+    throw IOException(
+        "Failed to drop Lance dataset: " +
+        JoinNamespacePath(directory_ns.root, GetDatasetDirName(table_name)) +
+        LanceFormatErrorSuffix());
+  }
+}
+
+static void EvictLanceTableCatalogEntry(LanceSchemaEntry &schema,
+                                        CatalogTransaction transaction,
+                                        const string &table_name);
+
+static void CommitDirectoryNamespaceReplace(
+    ClientContext &context, LanceSchemaEntry &schema,
+    CatalogTransaction transaction, const string &table_name,
+    const LanceResolvedPath &final_path, const LanceResolvedPath &staging_path);
+
 static bool IsSafeDatasetTableName(const string &name) {
   if (name.empty()) {
     return false;
@@ -812,27 +905,8 @@ public:
       if (!directory_ns || directory_ns->root.empty()) {
         throw InternalException("Lance directory namespace root is empty");
       }
-      auto root = directory_ns->root;
 
-      vector<string> option_keys;
-      vector<string> option_values;
-      option_keys = directory_ns->option_keys;
-      option_values = directory_ns->option_values;
-
-      vector<const char *> key_ptrs;
-      vector<const char *> value_ptrs;
-      BuildStorageOptionPointerArrays(option_keys, option_values, key_ptrs,
-                                      value_ptrs);
-
-      auto rc = lance_dir_namespace_drop_table(
-          root.c_str(), info.name.c_str(),
-          key_ptrs.empty() ? nullptr : key_ptrs.data(),
-          value_ptrs.empty() ? nullptr : value_ptrs.data(), option_keys.size());
-      if (rc != 0) {
-        throw IOException("Failed to drop Lance dataset: " + root + "/" +
-                          GetDatasetDirName(info.name) +
-                          LanceFormatErrorSuffix());
-      }
+      DropDirectoryNamespaceTable(*directory_ns, info.name);
     }
 
     // Drop the DuckDB catalog entry after the dataset has been deleted
@@ -885,6 +959,7 @@ public:
     string dataset_path;
     vector<string> option_keys;
     vector<string> option_values;
+    DirectoryReplacePlan replace_plan;
 
     if (rest_ns) {
       unordered_map<string, Value> overrides;
@@ -998,8 +1073,11 @@ public:
         throw InternalException("Lance directory namespace root is empty");
       }
 
-      dataset_path = JoinNamespacePath(directory_ns->root,
-                                       GetDatasetDirName(create_info.table));
+      auto namespace_root = LanceResolvePath(context, directory_ns->root);
+      replace_plan.final_path = LanceResolvePath(
+          context, JoinNamespacePath(directory_ns->root,
+                                     GetDatasetDirName(create_info.table)));
+      dataset_path = replace_plan.final_path.lance_uri;
 
       auto exists =
           DirectoryNamespaceTableExists(*directory_ns, create_info.table);
@@ -1012,10 +1090,30 @@ public:
           exists) {
         throw IOException("Lance dataset already exists: " + dataset_path);
       }
+      if (create_info.on_conflict == OnCreateConflict::REPLACE_ON_CONFLICT &&
+          exists) {
+        if (namespace_root.IsLocal()) {
+          replace_plan.staging_path =
+              MakeDirectoryReplaceStagingPath(context, namespace_root);
+          dataset_path = replace_plan.staging_path.lance_uri;
+          replace_plan.strategy = DirectoryReplaceStrategy::LOCAL_STAGED;
+        } else {
+          // Remote roots: drop in place, then recreate (non-atomic).
+          DropDirectoryNamespaceTable(*directory_ns, create_info.table);
+          LanceInvalidateDatasetCacheForPath(context,
+                                             replace_plan.final_path.lance_uri);
+          EvictLanceTableCatalogEntry(*this, transaction, create_info.table);
+          dataset_path = replace_plan.final_path.lance_uri;
+          replace_plan.strategy = DirectoryReplaceStrategy::REMOTE_DROP_FIRST;
+        }
+      }
 
       option_keys = directory_ns->option_keys;
       option_values = directory_ns->option_values;
     }
+
+    DirectoryReplaceStagingGuard replace_staging_guard(
+        context, replace_plan.staging_path.local_os_path);
 
     vector<string> names;
     vector<LogicalType> types;
@@ -1032,7 +1130,9 @@ public:
     ArrowConverter::ToArrowSchema(&schema_root.arrow_schema, types, names,
                                   props);
 
-    auto mode = CreateTableModeFromConflict(create_info.on_conflict);
+    auto mode = replace_plan.UsesCreateMode()
+                    ? "create"
+                    : CreateTableModeFromConflict(create_info.on_conflict);
     vector<const char *> key_ptrs;
     vector<const char *> value_ptrs;
     BuildStorageOptionPointerArrays(option_keys, option_values, key_ptrs,
@@ -1056,6 +1156,14 @@ public:
     if (rc != 0) {
       throw IOException("Failed to finalize Lance dataset write" +
                         LanceFormatErrorSuffix());
+    }
+
+    if (replace_plan.strategy == DirectoryReplaceStrategy::LOCAL_STAGED) {
+      CommitDirectoryNamespaceReplace(
+          context, *this, transaction, create_info.table,
+          replace_plan.final_path, replace_plan.staging_path);
+      replace_staging_guard.Release();
+      dataset_path = replace_plan.final_path.lance_uri;
     }
 
     // Best-effort persistence of DuckDB column defaults in Lance field
@@ -1101,6 +1209,90 @@ private:
   shared_ptr<LanceRestNamespaceConfig> rest_ns;
   DefaultGenerator *table_default_generator = nullptr;
 };
+
+static void EvictLanceTableCatalogEntry(LanceSchemaEntry &schema,
+                                        CatalogTransaction transaction,
+                                        const string &table_name) {
+  auto &set = schema.GetCatalogSet(CatalogType::TABLE_ENTRY);
+  auto existing_entry = set.GetEntry(transaction, table_name);
+  if (!existing_entry) {
+    return;
+  }
+  auto existing_type = existing_entry->type;
+  if (existing_type != CatalogType::TABLE_ENTRY &&
+      existing_type != CatalogType::VIEW_ENTRY) {
+    throw InternalException(
+        "Unexpected catalog entry type for Lance table '%s': %s", table_name,
+        CatalogTypeToString(existing_type));
+  }
+  auto system_transaction =
+      CatalogTransaction::GetSystemTransaction(schema.catalog.GetDatabase());
+  if (!set.DropEntry(system_transaction, table_name, false, true)) {
+    throw InternalException("Could not drop catalog entry for Lance table '%s'",
+                            table_name);
+  }
+  set.CleanupEntry(*existing_entry);
+}
+
+static void CommitDirectoryNamespaceReplace(
+    ClientContext &context, LanceSchemaEntry &schema,
+    CatalogTransaction transaction, const string &table_name,
+    const LanceResolvedPath &final_path,
+    const LanceResolvedPath &staging_path) {
+  const auto &final_os = final_path.local_os_path;
+  const auto &staging_os = staging_path.local_os_path;
+  if (final_os.empty() || staging_os.empty()) {
+    throw InternalException(
+        "Local CREATE OR REPLACE TABLE swap requires local filesystem paths");
+  }
+
+  auto &fs = FileSystem::GetFileSystem(context);
+  const string backup_os = final_os + ".__duckdb_backup__." +
+                           UUID::ToString(UUID::GenerateRandomUUID());
+  bool backed_up = false;
+
+  try {
+    if (fs.DirectoryExists(final_os)) {
+      fs.MoveFile(final_os, backup_os);
+      backed_up = true;
+    }
+    if (!fs.DirectoryExists(staging_os)) {
+      throw IOException(
+          "Missing staged Lance dataset for CREATE OR REPLACE TABLE: " +
+          staging_path.lance_uri + LanceFormatErrorSuffix());
+    }
+    fs.MoveFile(staging_os, final_os);
+    if (backed_up) {
+      TryRemoveLocalDatasetDirectory(fs, backup_os);
+    }
+  } catch (std::exception &ex) {
+    string restore_error;
+    if (backed_up) {
+      try {
+        if (fs.DirectoryExists(final_os)) {
+          TryRemoveLocalDatasetDirectory(fs, final_os);
+        }
+        if (fs.DirectoryExists(backup_os)) {
+          fs.MoveFile(backup_os, final_os);
+        }
+      } catch (std::exception &restore_ex) {
+        restore_error = restore_ex.what();
+      }
+    }
+    TryRemoveLocalDatasetDirectory(fs, staging_os);
+    if (!restore_error.empty()) {
+      throw IOException(StringUtil::Format(
+          "CREATE OR REPLACE TABLE swap failed: %s; backup restore also "
+          "failed: %s",
+          ex.what(), restore_error));
+    }
+    throw;
+  }
+
+  LanceInvalidateDatasetCacheForPath(context, final_path.lance_uri);
+  LanceInvalidateDatasetCacheForPath(context, staging_path.lance_uri);
+  EvictLanceTableCatalogEntry(schema, transaction, table_name);
+}
 
 class LanceDuckCatalog final : public DuckCatalog {
 public:
@@ -1746,12 +1938,12 @@ LanceStorageAttach(optional_ptr<StorageExtensionInfo>, ClientContext &context,
   string api_key_override;
 
   if (!is_rest_namespace) {
-    auto root = FileSystem::GetFileSystem(context).ExpandPath(attach_path);
+    auto resolved = LanceResolvePath(context, attach_path);
     vector<string> option_keys;
     vector<string> option_values;
     string open_root;
-    ResolveLanceStorageOptions(context, root, open_root, option_keys,
-                               option_values);
+    ResolveLanceStorageOptions(context, resolved.lance_uri, open_root,
+                               option_keys, option_values);
 
     string list_error;
     vector<string> discovered_tables;

--- a/test/sql/namespace_replace_schema.test
+++ b/test/sql/namespace_replace_schema.test
@@ -1,0 +1,56 @@
+# name: test/sql/namespace_replace_schema.test
+# description: CREATE OR REPLACE TABLE replaces schema after INSERT (directory namespace)
+# group: [sql]
+
+require lance
+
+statement ok
+ATTACH 'test/.tmp/nsroot_replace_schema_126' AS ns (TYPE LANCE);
+
+statement ok
+CREATE OR REPLACE TABLE ns.main.replace_schema_t (id BIGINT);
+
+statement ok
+INSERT INTO ns.main.replace_schema_t VALUES (42);
+
+query I
+SELECT count(*) FROM ns.main.replace_schema_t
+----
+1
+
+statement error
+CREATE OR REPLACE TABLE ns.main.replace_schema_t (id BIGINT, label VARCHAR)
+  WITH (data_storage_version = 'bad_version');
+----
+IO Error: Failed to open Lance writer:
+
+query I
+SELECT count(*) FROM ns.main.replace_schema_t
+----
+1
+
+query TT
+SELECT column_name, data_type FROM duckdb_columns()
+WHERE database_name = 'ns' AND schema_name = 'main' AND table_name = 'replace_schema_t'
+ORDER BY column_index
+----
+id	BIGINT
+
+statement ok
+CREATE OR REPLACE TABLE ns.main.replace_schema_t (id BIGINT, label VARCHAR);
+
+query I
+SELECT count(*) FROM ns.main.replace_schema_t
+----
+0
+
+query TT
+SELECT column_name, data_type FROM duckdb_columns()
+WHERE database_name = 'ns' AND schema_name = 'main' AND table_name = 'replace_schema_t'
+ORDER BY column_index
+----
+id	BIGINT
+label	VARCHAR
+
+statement ok
+DETACH ns;

--- a/test/sql/namespace_replace_schema_file_uri.test
+++ b/test/sql/namespace_replace_schema_file_uri.test
@@ -1,0 +1,98 @@
+# name: test/sql/namespace_replace_schema_file_uri.test
+# description: CREATE OR REPLACE on file:// directory namespace keeps data on writer failure
+# group: [sql]
+
+require lance
+
+statement error
+ATTACH 'file://invalid-authority/tmp/foo' AS bad_ns (TYPE LANCE);
+----
+Invalid Input Error: Unsupported file URI authority
+
+statement error
+ATTACH 'file:///tmp/lance?query' AS query_ns (TYPE LANCE);
+----
+Invalid Input Error: File URI query strings and fragments are not supported
+
+statement error
+ATTACH 'file:///tmp/lance#fragment' AS fragment_ns (TYPE LANCE);
+----
+Invalid Input Error: File URI query strings and fragments are not supported
+
+statement error
+ATTACH 'FILE://invalid-authority/tmp/foo' AS uppercase_bad_ns (TYPE LANCE);
+----
+Invalid Input Error: Unsupported file URI authority
+
+statement error
+ATTACH 'file:///tmp/lance%00suffix' AS nul_ns (TYPE LANCE);
+----
+Invalid Input Error: File URI path contains an encoded NUL byte
+
+statement ok
+ATTACH 'FILE://LOCALHOST/__WORKING_DIRECTORY__/__TEST_DIR__/nsroot_uppercase_file_uri' AS uppercase_ns (TYPE LANCE);
+
+statement ok
+CREATE OR REPLACE TABLE uppercase_ns.main.uppercase_t (id BIGINT);
+
+statement ok
+DETACH uppercase_ns;
+
+statement ok
+ATTACH 'file://localhost/__WORKING_DIRECTORY__/__TEST_DIR__/nsroot_replace_file_uri_128' AS ns (TYPE LANCE);
+
+statement ok
+CREATE OR REPLACE TABLE ns.main.replace_file_uri_t (id BIGINT);
+
+statement ok
+INSERT INTO ns.main.replace_file_uri_t VALUES (42);
+
+query I
+SELECT count(*) FROM ns.main.replace_file_uri_t
+----
+1
+
+statement error
+CREATE OR REPLACE TABLE ns.main.replace_file_uri_t (id BIGINT, label VARCHAR)
+  WITH (data_storage_version = 'bad_version');
+----
+IO Error: Failed to open Lance writer:
+
+query I
+SELECT count(*) FROM ns.main.replace_file_uri_t
+----
+1
+
+statement ok
+CREATE OR REPLACE TABLE ns.main.replace_file_uri_t (id BIGINT, label VARCHAR);
+
+query TT
+SELECT column_name, data_type FROM duckdb_columns()
+WHERE database_name = 'ns' AND schema_name = 'main' AND table_name = 'replace_file_uri_t'
+ORDER BY column_index
+----
+id	BIGINT
+label	VARCHAR
+
+statement ok
+DETACH ns;
+
+statement ok
+ATTACH 'file://localhost/__WORKING_DIRECTORY__/__TEST_DIR__/nsroot%20replace%20encoded' AS encoded_ns (TYPE LANCE);
+
+statement ok
+CREATE OR REPLACE TABLE encoded_ns.main.encoded_t (id BIGINT);
+
+statement ok
+CREATE OR REPLACE TABLE encoded_ns.main.encoded_t (id BIGINT, label VARCHAR);
+
+query TT
+SELECT column_name, data_type FROM duckdb_columns()
+WHERE database_name = 'encoded_ns' AND schema_name = 'main' AND table_name = 'encoded_t'
+ORDER BY column_index
+----
+id	BIGINT
+label	VARCHAR
+
+statement ok
+DETACH encoded_ns;


### PR DESCRIPTION
Lance overwrite with zero batches does not replace an existing dataset. Use an explicit replacement path for schema-only CREATE OR REPLACE TABLE.

Local directory namespaces:
- Stage under .duckdb_replace/{uuid}
- Swap with backup/restore on failure

Remote directory namespaces (s3://, cos://, ...):
- Drop in place, then recreate (non-atomic; see docs/sql.md)

Also canonicalize local roots and file URIs, clear dataset cache at QueryBegin, evict replaced catalog entries, and add regression tests.