### PR TITLE
fix(catalog): refresh schema after table replacement

### DIFF
--- a/src/lance_storage.cpp
+++ b/src/lance_storage.cpp
@@ -258,16 +258,16 @@ ListRestNamespaceTables(const string &endpoint, const string &namespace_id,
   return out;
 }
 
-static bool
-DirectoryNamespaceTableExists(const LanceDirectoryNamespaceConfig &ns,
-                              const string &table_name) {
+static string
+FindDirectoryNamespaceTable(const LanceDirectoryNamespaceConfig &ns,
+                            const string &table_name) {
   auto tables = ListDirectoryNamespaceTables(ns);
   for (auto &t : tables) {
     if (StringUtil::CIEquals(t, table_name)) {
-      return true;
+      return t;
     }
   }
-  return false;
+  return string();
 }
 
 class LanceDirectoryDefaultGenerator : public DefaultGenerator {
@@ -1005,11 +1005,12 @@ public:
         throw InternalException("Lance directory namespace root is empty");
       }
 
+      auto matched_table =
+          FindDirectoryNamespaceTable(*directory_ns, create_info.table);
+      auto exists = !matched_table.empty();
+      auto physical_table = exists ? matched_table : create_info.table;
       dataset_path = JoinNamespacePath(directory_ns->root,
-                                       GetDatasetDirName(create_info.table));
-
-      auto exists =
-          DirectoryNamespaceTableExists(*directory_ns, create_info.table);
+                                       GetDatasetDirName(physical_table));
       if (create_info.on_conflict == OnCreateConflict::IGNORE_ON_CONFLICT &&
           exists) {
         InvalidateTableDefaults();
@@ -1621,11 +1622,12 @@ public:
       throw InternalException("Lance directory namespace root is empty");
     }
 
+    auto matched_table =
+        FindDirectoryNamespaceTable(*directory_ns, create_info.table);
+    auto exists = !matched_table.empty();
+    auto physical_table = exists ? matched_table : create_info.table;
     auto dataset_path = JoinNamespacePath(directory_ns->root,
-                                          GetDatasetDirName(create_info.table));
-
-    auto exists =
-        DirectoryNamespaceTableExists(*directory_ns, create_info.table);
+                                          GetDatasetDirName(physical_table));
 
     if (create_info.on_conflict == OnCreateConflict::IGNORE_ON_CONFLICT &&
         exists) {

--- a/src/lance_storage.cpp
+++ b/src/lance_storage.cpp
@@ -287,6 +287,15 @@ public:
           "Unsafe Lance dataset name for directory namespace: " + entry_name);
     }
 
+    // DuckDB resolves catalog identifiers case-insensitively, while directory
+    // namespace paths are case-sensitive. Resolve the requested spelling back
+    // to the physical table identifier before opening and materializing the
+    // catalog entry so an evicted Foo.lance is not rediscovered as foo.lance.
+    auto physical_table = FindDirectoryNamespaceTable(*ns, entry_name);
+    if (physical_table.empty()) {
+      return nullptr;
+    }
+
     vector<const char *> key_ptrs;
     vector<const char *> value_ptrs;
     BuildStorageOptionPointerArrays(ns->option_keys, ns->option_values,
@@ -294,7 +303,7 @@ public:
 
     const char *uri_ptr = nullptr;
     auto *dataset = lance_open_dataset_in_dir_namespace(
-        ns->root.c_str(), entry_name.c_str(),
+        ns->root.c_str(), physical_table.c_str(),
         key_ptrs.empty() ? nullptr : key_ptrs.data(),
         value_ptrs.empty() ? nullptr : value_ptrs.data(),
         ns->option_keys.size(), &uri_ptr);
@@ -307,7 +316,7 @@ public:
       return nullptr;
     }
 
-    CreateTableInfo info(schema, entry_name);
+    CreateTableInfo info(schema, physical_table);
     info.internal = true;
     info.on_conflict = OnCreateConflict::IGNORE_ON_CONFLICT;
     vector<string> coerced;
@@ -321,12 +330,13 @@ public:
     lance_close_dataset(dataset);
 
     if (dataset_uri.empty()) {
-      dataset_uri = JoinNamespacePath(ns->root, GetDatasetDirName(entry_name));
+      dataset_uri =
+          JoinNamespacePath(ns->root, GetDatasetDirName(physical_table));
     }
     LanceNamespaceTableConfig cfg;
     cfg.kind = LanceNamespaceKind::Directory;
     cfg.root = ns->root;
-    cfg.table_id = entry_name;
+    cfg.table_id = physical_table;
     cfg.option_keys = ns->option_keys;
     cfg.option_values = ns->option_values;
     cfg.display_uri = std::move(dataset_uri);
@@ -830,13 +840,14 @@ public:
       BuildStorageOptionPointerArrays(option_keys, option_values, key_ptrs,
                                       value_ptrs);
 
+      const auto &physical_table = lance_entry->NamespaceConfig().table_id;
       auto rc = lance_dir_namespace_drop_table(
-          root.c_str(), info.name.c_str(),
+          root.c_str(), physical_table.c_str(),
           key_ptrs.empty() ? nullptr : key_ptrs.data(),
           value_ptrs.empty() ? nullptr : value_ptrs.data(), option_keys.size());
       if (rc != 0) {
         throw IOException("Failed to drop Lance dataset: " + root + "/" +
-                          GetDatasetDirName(info.name) +
+                          GetDatasetDirName(physical_table) +
                           LanceFormatErrorSuffix());
       }
     }

--- a/src/lance_storage.cpp
+++ b/src/lance_storage.cpp
@@ -596,6 +596,12 @@ static string GetDatasetDirName(const string &table_name) {
   return table_name + ".lance";
 }
 
+class LanceSchemaEntry;
+
+static void EvictLanceTableCatalogEntry(LanceSchemaEntry &schema,
+                                        CatalogTransaction transaction,
+                                        const string &table_name);
+
 static bool IsSafeDatasetTableName(const string &name) {
   if (name.empty()) {
     return false;
@@ -885,6 +891,7 @@ public:
     string dataset_path;
     vector<string> option_keys;
     vector<string> option_values;
+    bool refresh_directory_entry = false;
 
     if (rest_ns) {
       unordered_map<string, Value> overrides;
@@ -1012,6 +1019,9 @@ public:
           exists) {
         throw IOException("Lance dataset already exists: " + dataset_path);
       }
+      refresh_directory_entry =
+          exists &&
+          create_info.on_conflict == OnCreateConflict::REPLACE_ON_CONFLICT;
 
       option_keys = directory_ns->option_keys;
       option_values = directory_ns->option_values;
@@ -1058,6 +1068,13 @@ public:
                         LanceFormatErrorSuffix());
     }
 
+    if (refresh_directory_entry) {
+      auto cache_key = LanceBuildResolvedPathDatasetCacheKey(
+          dataset_path, option_keys, option_values);
+      LanceInvalidateDatasetCache(context, cache_key);
+      EvictLanceTableCatalogEntry(*this, transaction, create_info.table);
+    }
+
     // Best-effort persistence of DuckDB column defaults in Lance field
     // metadata. Lance itself does not currently expose defaults through
     // DuckDB's catalog, but we can still use the metadata during UPDATE
@@ -1101,6 +1118,30 @@ private:
   shared_ptr<LanceRestNamespaceConfig> rest_ns;
   DefaultGenerator *table_default_generator = nullptr;
 };
+
+static void EvictLanceTableCatalogEntry(LanceSchemaEntry &schema,
+                                        CatalogTransaction transaction,
+                                        const string &table_name) {
+  auto &set = schema.GetCatalogSet(CatalogType::TABLE_ENTRY);
+  auto existing_entry = set.GetEntry(transaction, table_name);
+  if (!existing_entry) {
+    return;
+  }
+  auto existing_type = existing_entry->type;
+  if (existing_type != CatalogType::TABLE_ENTRY &&
+      existing_type != CatalogType::VIEW_ENTRY) {
+    throw InternalException(
+        "Unexpected catalog entry type for Lance table '%s': %s", table_name,
+        CatalogTypeToString(existing_type));
+  }
+  auto system_transaction =
+      CatalogTransaction::GetSystemTransaction(schema.catalog.GetDatabase());
+  if (!set.DropEntry(system_transaction, table_name, false, true)) {
+    throw InternalException("Could not drop catalog entry for Lance table '%s'",
+                            table_name);
+  }
+  set.CleanupEntry(*existing_entry);
+}
 
 class LanceDuckCatalog final : public DuckCatalog {
 public:

--- a/test/sql/dml_drop_table.test
+++ b/test/sql/dml_drop_table.test
@@ -46,4 +46,20 @@ SELECT count(*) FROM 'test/.tmp/unsafe.lance';
 1
 
 statement ok
+CREATE TABLE ns.main."DropCase" (id BIGINT);
+
+statement ok
+DROP TABLE ns.main.dropcase;
+
+statement error
+SELECT count(*) FROM 'test/.tmp/nsroot/DropCase.lance';
+----
+IO Error: Failed to open Lance dataset: test/.tmp/nsroot/DropCase.lance (Lance error: dataset open 'test/.tmp/nsroot/DropCase.lance':
+
+statement error
+SELECT count(*) FROM ns.main.dropcase;
+----
+Catalog Error: Table with name dropcase does not exist
+
+statement ok
 DETACH ns;

--- a/test/sql/namespace_replace_schema.test
+++ b/test/sql/namespace_replace_schema.test
@@ -1,0 +1,97 @@
+# name: test/sql/namespace_replace_schema.test
+# description: CREATE OR REPLACE TABLE replaces schema after INSERT (directory namespace)
+# group: [sql]
+
+require lance
+
+statement ok
+ATTACH 'test/.tmp/nsroot_replace_schema_126' AS ns (TYPE LANCE);
+
+statement ok
+CREATE OR REPLACE TABLE ns.main.replace_schema_t (id BIGINT);
+
+statement ok
+INSERT INTO ns.main.replace_schema_t VALUES (42);
+
+statement ok
+CREATE OR REPLACE TABLE ns.main.untouched_t (id BIGINT);
+
+statement ok
+INSERT INTO ns.main.untouched_t VALUES (7);
+
+query I
+SELECT count(*) FROM ns.main.replace_schema_t
+----
+1
+
+query II
+EXPLAIN (FORMAT JSON) SELECT * FROM ns.main.replace_schema_t;
+----
+physical_plan	<REGEX>:[\s\S]*"Lance Dataset Cache Hit": "true"[\s\S]*
+
+query II
+EXPLAIN (FORMAT JSON) SELECT * FROM ns.main.untouched_t;
+----
+physical_plan	<REGEX>:[\s\S]*"Lance Dataset Cache Hit": "false"[\s\S]*
+
+query II
+EXPLAIN (FORMAT JSON) SELECT * FROM ns.main.untouched_t;
+----
+physical_plan	<REGEX>:[\s\S]*"Lance Dataset Cache Hit": "true"[\s\S]*
+
+statement error
+CREATE OR REPLACE TABLE ns.main.replace_schema_t (id BIGINT, label VARCHAR)
+  WITH (data_storage_version = 'bad_version');
+----
+IO Error: Failed to open Lance writer:
+
+query I
+SELECT count(*) FROM ns.main.replace_schema_t
+----
+1
+
+query TT
+SELECT column_name, data_type FROM duckdb_columns()
+WHERE database_name = 'ns' AND schema_name = 'main' AND table_name = 'replace_schema_t'
+ORDER BY column_index
+----
+id	BIGINT
+
+statement ok
+CREATE OR REPLACE TABLE ns.main.replace_schema_t (id BIGINT, label VARCHAR);
+
+query II
+EXPLAIN (FORMAT JSON) SELECT * FROM ns.main.replace_schema_t;
+----
+physical_plan	<REGEX>:[\s\S]*"Lance Dataset Cache Hit": "false"[\s\S]*
+
+query I
+SELECT count(*) FROM ns.main.replace_schema_t
+----
+0
+
+query I
+SELECT count(label) FROM ns.main.replace_schema_t
+----
+0
+
+query II
+EXPLAIN (FORMAT JSON) SELECT * FROM ns.main.replace_schema_t;
+----
+physical_plan	<REGEX>:[\s\S]*"Lance Dataset Cache Hit": "true"[\s\S]*
+
+query II
+EXPLAIN (FORMAT JSON) SELECT * FROM ns.main.untouched_t;
+----
+physical_plan	<REGEX>:[\s\S]*"Lance Dataset Cache Hit": "true"[\s\S]*
+
+query TT
+SELECT column_name, data_type FROM duckdb_columns()
+WHERE database_name = 'ns' AND schema_name = 'main' AND table_name = 'replace_schema_t'
+ORDER BY column_index
+----
+id	BIGINT
+label	VARCHAR
+
+statement ok
+DETACH ns;

--- a/test/sql/namespace_replace_schema_case.test
+++ b/test/sql/namespace_replace_schema_case.test
@@ -1,0 +1,30 @@
+# name: test/sql/namespace_replace_schema_case.test
+# description: Case-variant replacements preserve the discovered physical table identifier
+# group: [sql]
+
+require lance
+
+statement ok
+ATTACH '__TEST_DIR__/nsroot_replace_schema_case' AS ns (TYPE LANCE);
+
+statement ok
+CREATE OR REPLACE TABLE ns.main."Foo" (id BIGINT);
+
+statement ok
+INSERT INTO ns.main."Foo" VALUES (7);
+
+statement ok
+CREATE OR REPLACE TABLE ns.main.foo (id BIGINT, label VARCHAR);
+
+query I
+SELECT count(*) FROM '__TEST_DIR__/nsroot_replace_schema_case/Foo.lance'
+----
+0
+
+statement error
+SELECT count(*) FROM '__TEST_DIR__/nsroot_replace_schema_case/foo.lance';
+----
+IO Error: Failed to open Lance dataset:
+
+statement ok
+DETACH ns;

--- a/test/sql/namespace_replace_schema_case.test
+++ b/test/sql/namespace_replace_schema_case.test
@@ -17,9 +17,32 @@ statement ok
 CREATE OR REPLACE TABLE ns.main.foo (id BIGINT, label VARCHAR);
 
 query I
+SELECT count(label) FROM ns.main.foo;
+----
+0
+
+query I
 SELECT count(*) FROM '__TEST_DIR__/nsroot_replace_schema_case/Foo.lance'
 ----
 0
+
+statement error
+SELECT count(*) FROM '__TEST_DIR__/nsroot_replace_schema_case/foo.lance';
+----
+IO Error: Failed to open Lance dataset:
+
+statement ok
+CREATE OR REPLACE TABLE ns.main.foo AS SELECT 11::BIGINT AS id, 'ctas'::VARCHAR AS label;
+
+query IT
+SELECT id, label FROM ns.main.foo;
+----
+11	ctas
+
+query I
+SELECT count(*) FROM '__TEST_DIR__/nsroot_replace_schema_case/Foo.lance'
+----
+1
 
 statement error
 SELECT count(*) FROM '__TEST_DIR__/nsroot_replace_schema_case/foo.lance';


### PR DESCRIPTION
Preserve Lance's zero-row overwrite commit semantics for schema-only CREATE OR REPLACE TABLE operations.

After a successful overwrite, invalidate only the replaced directory dataset cache entry and evict its stale attached-catalog entry so lazy discovery reloads the committed schema. Leave cached handles and catalog state unchanged when the writer fails, and preserve cross-query reuse for untouched datasets.

Add regression coverage for schema refresh, failed replacements, precise cache invalidation, and untouched cache reuse.