### PR TITLE
fix(delete): correct predicate translation and identifier quoting

### DIFF
--- a/rust/ffi/dataset.rs
+++ b/rust/ffi/dataset.rs
@@ -9,7 +9,8 @@ use arrow_array::types::UInt64Type;
 use datafusion::logical_expr::Expr;
 use datafusion::physical_plan::SendableRecordBatchStream;
 use datafusion::scalar::ScalarValue;
-use datafusion_sql::unparser::expr_to_sql;
+use datafusion_sql::unparser::dialect::CustomDialectBuilder;
+use datafusion_sql::unparser::Unparser;
 use futures::TryStreamExt;
 use lance::dataset::builder::DatasetBuilder;
 use lance::dataset::statistics::DatasetStatisticsExt;
@@ -27,6 +28,28 @@ use super::util::{
     cstr_to_str, optional_session_handle, parse_optional_filter_ir, slice_from_ptr, FfiError,
     FfiResult,
 };
+
+/// Convert an optional filter expression into a predicate SQL string for
+/// Lance's string-based `delete` API. Identifiers are always backtick-quoted so
+/// column names that collide with SQL keywords (e.g. `name`, `value`, `key`,
+/// `desc`) survive the unparse/re-parse round-trip. Lance's filter parser uses
+/// backtick identifier quoting; double quotes would be treated as string
+/// literals.
+fn delete_filter_expr_to_sql(filter: Option<Expr>) -> FfiResult<String> {
+    match filter {
+        Some(expr) => {
+            let dialect = CustomDialectBuilder::new()
+                .with_identifier_quote_style('`')
+                .build();
+            let unparser = Unparser::new(&dialect);
+            let sql = unparser.expr_to_sql(&expr).map_err(|err| {
+                FfiError::new(ErrorCode::DatasetDelete, format!("predicate sql: {err}"))
+            })?;
+            Ok(sql.to_string())
+        }
+        None => Ok("true".to_string()),
+    }
+}
 
 #[repr(C)]
 #[derive(Clone, Copy, Debug)]
@@ -699,14 +722,7 @@ fn delete_transaction_with_storage_options_inner(
             "delete filter_ir",
         )?
     };
-    let predicate = match filter {
-        Some(expr) => expr_to_sql(&expr)
-            .map_err(|err| {
-                FfiError::new(ErrorCode::DatasetDelete, format!("predicate sql: {err}"))
-            })?
-            .to_string(),
-        None => "true".to_string(),
-    };
+    let predicate = delete_filter_expr_to_sql(filter)?;
     let session = unsafe { optional_session_handle(session)? };
 
     let (maybe_txn, deleted_rows) = match runtime::block_on(async {
@@ -854,14 +870,7 @@ fn dataset_delete_inner(
             "delete filter_ir",
         )?
     };
-    let predicate = match filter {
-        Some(expr) => expr_to_sql(&expr)
-            .map_err(|err| {
-                FfiError::new(ErrorCode::DatasetDelete, format!("predicate sql: {err}"))
-            })?
-            .to_string(),
-        None => "true".to_string(),
-    };
+    let predicate = delete_filter_expr_to_sql(filter)?;
 
     let mut ds = (*handle.dataset).clone();
 

--- a/src/lance_delete.cpp
+++ b/src/lance_delete.cpp
@@ -99,13 +99,12 @@ static bool TryBuildLanceDeleteFilterIR(LogicalDelete &op,
 
   vector<string> parts;
 
-  vector<ColumnIndex> column_indexes = get->GetColumnIds();
-  TableFunctionInitInput init_input(get->bind_data.get(),
-                                    std::move(column_indexes),
-                                    get->projection_ids, &get->table_filters);
-  auto table_filters =
-      BuildLanceTableFilterIRParts(names, types, init_input, false);
-  parts = std::move(table_filters.parts);
+  if (!TryBuildLanceTableFilterIRParts(names, types, get->table_filters,
+                                       parts)) {
+    out_error = "unsupported DELETE predicate for Lance: pushed-down table "
+                "filter could not be translated to Lance filter IR";
+    return false;
+  }
 
   vector<const Expression *> predicates;
   if (!TryCollectDeleteFilterPredicates(*op.children[0], predicates,

--- a/src/lance_filter_ir.cpp
+++ b/src/lance_filter_ir.cpp
@@ -1084,6 +1084,14 @@ bool TryBuildLanceTableFilterIRParts(const vector<string> &names,
     if (!filter) {
       continue;
     }
+    // OPTIONAL_FILTER / DYNAMIC_FILTER are pruning hints that are not required
+    // for correctness: DuckDB pushes them as PUSHED_DOWN_PARTIALLY and keeps
+    // the exact predicate as a residual LogicalFilter (collected separately for
+    // DELETE). Skip them here rather than failing translation.
+    if (filter->filter_type == TableFilterType::OPTIONAL_FILTER ||
+        filter->filter_type == TableFilterType::DYNAMIC_FILTER) {
+      continue;
+    }
     if (col_id == COLUMN_IDENTIFIER_ROW_ID ||
         col_id == COLUMN_IDENTIFIER_EMPTY) {
       return false;

--- a/test/sql/dml_delete_keyword_column.test
+++ b/test/sql/dml_delete_keyword_column.test
@@ -1,0 +1,24 @@
+# name: test/sql/dml_delete_keyword_column.test
+# description: DELETE predicates on columns whose names are SQL keywords still match rows
+# group: [sql]
+
+require lance
+
+statement ok
+COPY (
+  SELECT 'x'::VARCHAR AS name, 1::BIGINT AS id
+  UNION ALL
+  SELECT 'y'::VARCHAR AS name, 2::BIGINT AS id
+) TO 'test/.tmp/lance_delete_keyword.lance' (FORMAT lance, mode 'overwrite');
+
+statement ok
+ATTACH 'test/.tmp' AS del_kw_ns (TYPE LANCE);
+
+# 'name' is a SQL keyword; the predicate must still match and delete the row.
+statement ok
+DELETE FROM del_kw_ns.main.lance_delete_keyword WHERE name = 'x';
+
+query TI
+SELECT name, id FROM del_kw_ns.main.lance_delete_keyword ORDER BY id;
+----
+y	2

--- a/test/sql/dml_delete_non_first_column_filter.test
+++ b/test/sql/dml_delete_non_first_column_filter.test
@@ -1,0 +1,29 @@
+# name: test/sql/dml_delete_non_first_column_filter.test
+# description: DELETE with a predicate on a non-first column deletes only matching rows
+# group: [sql]
+
+require lance
+
+statement ok
+COPY (
+  SELECT 1::BIGINT AS id, 'a'::VARCHAR AS s, 0::BIGINT AS flag
+  UNION ALL
+  SELECT 2::BIGINT AS id, 'b'::VARCHAR AS s, 1::BIGINT AS flag
+  UNION ALL
+  SELECT 3::BIGINT AS id, 'c'::VARCHAR AS s, 0::BIGINT AS flag
+  UNION ALL
+  SELECT 4::BIGINT AS id, 'd'::VARCHAR AS s, 1::BIGINT AS flag
+) TO 'test/.tmp/lance_delete_non_first.lance' (FORMAT lance, mode 'overwrite');
+
+statement ok
+ATTACH 'test/.tmp' AS del_col_ns (TYPE LANCE);
+
+# Predicate on the non-first column: only the flag=1 rows may be removed.
+statement ok
+DELETE FROM del_col_ns.main.lance_delete_non_first WHERE flag = 1;
+
+query IT
+SELECT id, s FROM del_col_ns.main.lance_delete_non_first ORDER BY id;
+----
+1	a
+3	c


### PR DESCRIPTION
Two bugs in DELETE predicate handling, both verified on main. Either one can
silently delete the wrong data (or none at all).

**1. Pushed-down table filters were translated against the wrong column**

DELETE built its Lance filter IR from `get->table_filters` via
`BuildLanceTableFilterIRParts`, which treats the filter key as a
scan-projection index and remaps it through `column_ids`. During DELETE the
keys are already physical column ids, so a predicate on any column other
than the first was translated against the wrong column:

```sql
ATTACH 'repro' AS ns (TYPE LANCE);
CREATE TABLE ns.main.t(id INT, name VARCHAR, flag INT);
INSERT INTO ns.main.t VALUES (1,'a',0),(2,'b',1),(3,'c',0),(4,'d',1);
DELETE FROM ns.main.t WHERE flag = 1;
SELECT * FROM ns.main.t ORDER BY id;
-- expected: ids 1, 3
-- actual: empty table, all four rows deleted
```

Fix: wire DELETE to TryBuildLanceTableFilterIRParts, which consumes
table_filters keyed by physical column id directly. Also skip
OPTIONAL_FILTER / DYNAMIC_FILTER entries: they are pruning hints pushed
as PUSHED_DOWN_PARTIALLY while the exact predicate remains in the plan as
a residual LogicalFilter (collected separately), so translating them into
hard delete predicates is unnecessary and breaks cases like string IN
lists.

**2. Unquoted identifiers broke predicates on SQL-keyword column names**

The delete FFI turns the filter IR into SQL via expr_to_sql and passes it
to Lance's string-based delete API. The default unparser dialect never
quotes identifiers, so a column whose name is a SQL keyword (name,
value, key, desc, ...) is emitted bare and the re-parsed predicate
matches nothing — the DELETE succeeds but removes zero rows:

```sql
ATTACH 'repro' AS ns (TYPE LANCE);
CREATE TABLE ns.main.k(name VARCHAR, id INT);
INSERT INTO ns.main.k VALUES ('x',1),('y',2);
DELETE FROM ns.main.k WHERE name = 'x';
SELECT * FROM ns.main.k ORDER BY id;
-- expected: only ('y', 2)
-- actual: both rows still present
```

Fix: unparse with a CustomDialect that always backtick-quotes identifiers.
Lance's filter parser uses backticks for identifier quoting; double quotes
would be read as string literals. Applied to both delete FFI entry points.
